### PR TITLE
French fix.

### DIFF
--- a/nrepel.ttl.in
+++ b/nrepel.ttl.in
@@ -168,5 +168,5 @@
   ];
   rdfs:comment "Instructions: Select a section of noise only in your track and loop it. Turn on noise capture for one second or two to learn the noise profile and then turn it off. Then you can now adjust the reduction.",
    "Instrucciones: Seleccionar una seccion de la pista que solo contenga ruido y reproducirla ciclicamente. Encender la captura del perfil de ruido por unos segundos para capturar el perfil de ruido y luego apagarlo. Luego se puede ajustar la reduccion."@es ,
-   "Instructions : Sélectionnez une portion de bruit seul dans votre piste et bouclez-la. Activez la capture de l'empreinte pendant une seconde ou deux pour apprendre le profil du bruit, puis désactivez-la. Vous pouvez alors ajuster la réduction."@fr ;
+   "Instructions : sélectionnez une portion de bruit seul dans votre piste et bouclez-la. Activez la capture de l'empreinte pendant une seconde ou deux pour apprendre le profil du bruit, puis désactivez-la. Vous pouvez alors ajuster la réduction."@fr ;
 .


### PR DESCRIPTION
No capital letter after ":" in French.
(unless it starts a quote which is not  the case here)