### PR TITLE
Apply makeup on the processed signal, not the dry one

### DIFF
--- a/spectral_processing.c
+++ b/spectral_processing.c
@@ -118,9 +118,9 @@ void gain_application(float amount_of_reduction,
 
   //Applying make up gain
   for (k = 0; k <= fft_size_2; k++) {
-    output_fft_buffer[k] *= from_dB(makeup_gain);
+    final_fft_buffer[k] *= from_dB(makeup_gain);
     if(k < fft_size_2)
-      output_fft_buffer[fft_size-k] *= from_dB(makeup_gain);
+      final_fft_buffer[fft_size-k] *= from_dB(makeup_gain);
   }
 
   //Smooth bypass


### PR DESCRIPTION
Currently, the makeup gain is applied on the dry signal, which is
supposed to be passed as-is when the plugin is bypassed. That doesn't
make it transparent when (soft) bypass is enabled, and in the normal usage case where the full wet signal is used (99.9% of the time), the makeup gain control is ineffective because the wet signal is not amplified.

Apply the makeup gain on the wet signal as intended.