### PR TITLE
Fix lv2 meta-data (samples/frames)

### DIFF
--- a/lv2ttl/nrepel.ttl.in
+++ b/lv2ttl/nrepel.ttl.in
@@ -165,7 +165,7 @@
     lv2:minimum 0 ;
     lv2:maximum 8192 ;
     lv2:portProperty lv2:reportsLatency, lv2:integer, pprop:notOnGUI ;
-    units:unit units:samples ;
+    units:unit units:frame ;
   ], [
     a lv2:AudioPort,
       lv2:InputPort ;


### PR DESCRIPTION
LV2 sematics uses "frame" for "audio samples" as unit: http://lv2plug.in/ns/extensions/units/#frame