### PR TITLE
Fix symbol visibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ if meson.get_compiler('c').get_id() == 'clang'
   add_global_arguments('-mrecip', language : 'c')
 endif
 cflags = ['-msse','-msse2','-mfpmath=sse','-ffast-math','-fomit-frame-pointer','-fno-finite-math-only']
+cflags += ['-Wno-unused-function']
 
 #install folder
 install_folder = 'nrepel.lv2'

--- a/src/denoise_gain.c
+++ b/src/denoise_gain.c
@@ -37,7 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/
 * /param spectrum is the power spectum array
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void wiener_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
+static void
+wiener_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
 {
 	int k;
 
@@ -75,7 +76,8 @@ void wiener_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds
 * \param noise_thresholds is the threshold for each corresponding power spectum value
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void power_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
+static void
+power_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
 {
 	int k;
 
@@ -113,7 +115,8 @@ void power_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds,
 * \param noise_thresholds is the threshold for each corresponding power spectum value
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void magnitude_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
+static void
+magnitude_subtraction(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
 {
 	int k;
 
@@ -151,7 +154,8 @@ void magnitude_subtraction(int fft_size_2, float *spectrum, float *noise_thresho
 * \param noise_thresholds is the threshold for each corresponding power spectum value
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void spectral_gating(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
+static void
+spectral_gating(int fft_size_2, float *spectrum, float *noise_thresholds, float *Gk)
 {
 	int k;
 
@@ -194,7 +198,8 @@ void spectral_gating(int fft_size_2, float *spectrum, float *noise_thresholds, f
 * \param noise_thresholds is the threshold for each corresponding power spectum value
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void denoise_gain_gss(int fft_size_2, float *alpha, float *beta, float *spectrum,
+static void
+denoise_gain_gss(int fft_size_2, float *alpha, float *beta, float *spectrum,
 					  float *noise_thresholds, float *Gk)
 {
 	int k;

--- a/src/estimate_noise_spectrum.c
+++ b/src/estimate_noise_spectrum.c
@@ -51,8 +51,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/
 * \param fft_size_2 is half of the fft size
 * \param samp_rate current sample rate of the host
 */
-void compute_auto_thresholds(float *auto_thresholds, float fft_size, float fft_size_2,
-                             float samp_rate)
+static void
+compute_auto_thresholds(float *auto_thresholds, float fft_size, float fft_size_2,
+                        float samp_rate)
 {
   //This was experimentally obteined in louizou paper
   int LF = freq_to_bin(CROSSOVER_POINT1, samp_rate, fft_size); //1kHz
@@ -152,8 +153,9 @@ estimate_noise_loizou(float *thresh, int fft_size_2, float *p2, float *s_pow_spe
 * \param speech_p_p speech presence probability spectrum
 * \param prev_speech_p_p speech presence probability spectrum of previous frame
 */
-void adapt_noise(float *p2, int fft_size_2, float *noise_thresholds_p2, float *thresh,
-                 float *prev_noise_thresholds, float *s_pow_spec, float *prev_s_pow_spec, float *p_min, float *prev_p_min, float *speech_p_p, float *prev_speech_p_p)
+static void
+adapt_noise(float *p2, int fft_size_2, float *noise_thresholds_p2, float *thresh,
+            float *prev_noise_thresholds, float *s_pow_spec, float *prev_s_pow_spec, float *p_min, float *prev_p_min, float *speech_p_p, float *prev_speech_p_p)
 {
   estimate_noise_loizou(thresh, fft_size_2, p2, s_pow_spec, prev_s_pow_spec,
                         noise_thresholds_p2, prev_noise_thresholds, p_min, prev_p_min, speech_p_p, prev_speech_p_p);
@@ -172,8 +174,9 @@ void adapt_noise(float *p2, int fft_size_2, float *noise_thresholds_p2, float *t
 * \param noise_thresholds_p2 the noise thresholds for each bin estimated
 * \param window_count is the frame counter for the rolling mean estimation
 */
-void get_noise_statistics(float *fft_p2, int fft_size_2, float *noise_thresholds_p2,
-                          float window_count)
+static void
+get_noise_statistics(float *fft_p2, int fft_size_2, float *noise_thresholds_p2,
+                     float window_count)
 {
   int k;
 

--- a/src/extra_functions.c
+++ b/src/extra_functions.c
@@ -61,7 +61,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/
 * Method to force already-denormal float value to zero.
 * \param value to sanitize
 */
-float sanitize_denormal(float value)
+static float
+sanitize_denormal(float value)
 {
   if (isnan(value))
   {
@@ -74,13 +75,15 @@ float sanitize_denormal(float value)
 }
 
 ///sign function.
-int sign(float x)
+static int
+sign(float x)
 {
   return (x >= 0.f ? 1.f : -1.f);
 }
 
 ///gets the next power of two of a number x.
-int next_pow_two(int x)
+static int
+next_pow_two(int x)
 {
   int power = 2;
   while (x >>= 1)
@@ -89,7 +92,8 @@ int next_pow_two(int x)
 }
 
 ///gets the nearest odd number of a number x.
-int nearest_odd(int x)
+static int
+nearest_odd(int x)
 {
   if (x % 2 == 0)
     return x + 1;
@@ -98,7 +102,8 @@ int nearest_odd(int x)
 }
 
 ///gets the nearest even number of a number x.
-int nearest_even(int x)
+static int
+nearest_even(int x)
 {
   if (x % 2 == 0)
     return x;
@@ -107,13 +112,15 @@ int nearest_even(int x)
 }
 
 ///converts a db value to linear scale.
-float from_dB(float gdb)
+static float
+from_dB(float gdb)
 {
   return (expf(gdb / 10.f * logf(10.f)));
 }
 
 ///converts a linear value to db scale.
-float to_dB(float g)
+static float
+to_dB(float g)
 {
   return (10.f * log10f(g));
 }
@@ -123,7 +130,8 @@ float to_dB(float g)
 * \param samp_rate current sample rate of the host
 * \param N size of the fft
 */
-float bin_to_freq(int i, float samp_rate, int N)
+static float
+bin_to_freq(int i, float samp_rate, int N)
 {
   return (float)i * (samp_rate / N / 2.f);
 }
@@ -133,7 +141,8 @@ float bin_to_freq(int i, float samp_rate, int N)
 * \param samp_rate current sample rate of the host
 * \param N size of the fft
 */
-int freq_to_bin(float freq, float samp_rate, int N)
+static int
+freq_to_bin(float freq, float samp_rate, int N)
 {
   return (int)(freq / (samp_rate / N / 2.f));
 }
@@ -159,8 +168,9 @@ typedef struct
 * \param result_val interpolation value result
 * \param result_val interpolation bin result
 */
-void parabolic_interpolation(float left_val, float middle_val, float right_val,
-                             int current_bin, float *result_val, int *result_bin)
+static void
+parabolic_interpolation(float left_val, float middle_val, float right_val,
+                        int current_bin, float *result_val, int *result_bin)
 {
   float delta_x = 0.5 * ((left_val - right_val) / (left_val - 2.f * middle_val + right_val));
   *result_bin = current_bin + (int)delta_x;
@@ -173,7 +183,8 @@ void parabolic_interpolation(float left_val, float middle_val, float right_val,
 * \param value the value to copy to every position in the array
 * \param size the size of the array
 */
-void initialize_array(float *array, float value, int size)
+static void
+initialize_array(float *array, float value, int size)
 {
   for (int k = 0; k < size; k++)
   {
@@ -186,7 +197,8 @@ void initialize_array(float *array, float value, int size)
 * \param spectrum the array to check
 * \param N the size of the array (half the fft size plus 1)
 */
-bool is_empty(float *spectrum, int N)
+static bool
+is_empty(float *spectrum, int N)
 {
   int k;
   for (k = 0; k <= N; k++)
@@ -204,7 +216,8 @@ bool is_empty(float *spectrum, int N)
 * \param spectrum the array to check
 * \param N the size of the array (half the fft size plus 1)
 */
-float max_spectral_value(float *spectrum, int N)
+static float
+max_spectral_value(float *spectrum, int N)
 {
   int k;
   float max = spectrum[0];
@@ -220,7 +233,8 @@ float max_spectral_value(float *spectrum, int N)
 * \param spectrum the array to check
 * \param N the size of the array (half the fft size plus 1)
 */
-float min_spectral_value(float *spectrum, int N)
+static float
+min_spectral_value(float *spectrum, int N)
 {
   int k;
   float min = spectrum[0];
@@ -236,7 +250,8 @@ float min_spectral_value(float *spectrum, int N)
 * \param a the array to check
 * \param m the size of the array (half the fft size plus 1)
 */
-float spectral_mean(float *a, int m)
+static float
+spectral_mean(float *a, int m)
 {
   float sum = 0.f;
   for (int i = 0; i <= m; i++)
@@ -249,7 +264,8 @@ float spectral_mean(float *a, int m)
 * \param a the array to sum
 * \param m the size of the array (half the fft size plus 1)
 */
-float spectral_addition(float *a, int m)
+static float
+spectral_addition(float *a, int m)
 {
   float sum = 0.f;
   for (int i = 0; i <= m; i++)
@@ -262,7 +278,8 @@ float spectral_addition(float *a, int m)
 * \param x the array to check
 * \param n the size of the array (half the fft size plus 1)
 */
-float spectral_median(float *x, int n)
+static float
+spectral_median(float *x, int n)
 {
   float temp;
   int i, j;
@@ -300,7 +317,8 @@ float spectral_median(float *x, int n)
 * \param x the array to check
 * \param n the size of the array (half the fft size plus 1)
 */
-float spectral_moda(float *x, int n)
+static float
+spectral_moda(float *x, int n)
 {
   float temp[n];
   int i, j, pos_max;
@@ -338,7 +356,8 @@ float spectral_moda(float *x, int n)
 * \param spectrum the spectrum to normalize
 * \param N the size of the spectrum (half the fft size plus 1)
 */
-void get_normalized_spectum(float *spectrum, int N)
+static void
+get_normalized_spectum(float *spectrum, int N)
 {
   int k;
   float max_value = max_spectral_value(spectrum, N);
@@ -357,7 +376,8 @@ void get_normalized_spectum(float *spectrum, int N)
 * \param spectrum_prev the previous power spectrum
 * \param N the size of the spectrum (half the fft size plus 1)
 */
-float spectral_flux(float *spectrum, float *spectrum_prev, float N)
+static float
+spectral_flux(float *spectrum, float *spectrum_prev, float N)
 {
   int i;
   float spectral_flux = 0.f;
@@ -376,7 +396,8 @@ float spectral_flux(float *spectrum, float *spectrum_prev, float N)
 * \param spectrum the current power spectrum
 * \param N the size of the spectrum (half the fft size plus 1)
 */
-float high_frequency_content(float *spectrum, float N)
+static float
+high_frequency_content(float *spectrum, float N)
 {
   int i;
   float sum = 0.f;
@@ -396,7 +417,8 @@ float high_frequency_content(float *spectrum, float N)
 * \param samp_rate current sample rate of the host
 * \param spectral_envelope_values array that holds the spectral envelope values
 */
-void spectral_envelope(int fft_size_2, float *fft_p2, int samp_rate, float *spectral_envelope_values)
+static void
+spectral_envelope(int fft_size_2, float *fft_p2, int samp_rate, float *spectral_envelope_values)
 {
   int k;
 
@@ -450,8 +472,9 @@ void spectral_envelope(int fft_size_2, float *fft_p2, int samp_rate, float *spec
 * \param peaks_count counter of peaks founded
 * \param samp_rate current sample rate of the host
 */
-void spectral_peaks(int fft_size_2, float *fft_p2, FFTPeak *spectral_peaks, int *peak_pos,
-                    int *peaks_count, int samp_rate)
+static void
+spectral_peaks(int fft_size_2, float *fft_p2, FFTPeak *spectral_peaks, int *peak_pos,
+               int *peaks_count, int samp_rate)
 {
   int k;
   float fft_magnitude_db[fft_size_2 + 1];
@@ -582,7 +605,8 @@ void spectral_peaks(int fft_size_2, float *fft_p2, FFTPeak *spectral_peaks, int 
 * \param N the size of the array
 * \param p the norm number
 */
-float spectrum_p_norm(float *spectrum, float N, float p)
+static float
+spectrum_p_norm(float *spectrum, float N, float p)
 {
   float sum = 0.f;
 
@@ -608,8 +632,9 @@ float spectrum_p_norm(float *spectrum, float N, float p)
 * \param max_spectrum array of temporal maximums of the residual signal
 * \param max_decay_rate amount of ms of decay for temporal maximums
 */
-void spectral_whitening(float *spectrum, float b, int N, float *max_spectrum,
-                        float *whitening_window_count, float max_decay_rate)
+static void
+spectral_whitening(float *spectrum, float b, int N, float *max_spectrum,
+                   float *whitening_window_count, float max_decay_rate)
 {
   float whitened_spectrum[N];
 
@@ -652,8 +677,9 @@ void spectral_whitening(float *spectrum, float b, int N, float *max_spectrum,
 * \param prev_beta beta corresponded to previos frame
 * \param coeff reference smoothing value
 */
-void spectrum_adaptive_time_smoothing(int fft_size_2, float *spectrum_prev, float *spectrum,
-                                      float *noise_thresholds, float *prev_beta, float coeff)
+static void
+spectrum_adaptive_time_smoothing(int fft_size_2, float *spectrum_prev, float *spectrum,
+                                 float *noise_thresholds, float *prev_beta, float coeff)
 {
   int k;
   float discrepancy, numerator = 0.f, denominator = 0.f;
@@ -702,7 +728,8 @@ void spectrum_adaptive_time_smoothing(int fft_size_2, float *spectrum_prev, floa
 * \param N half of the fft size
 * \param release_coeff release coefficient
 */
-void apply_time_envelope(float *spectrum, float *spectrum_prev, float N, float release_coeff)
+static void
+apply_time_envelope(float *spectrum, float *spectrum_prev, float N, float release_coeff)
 {
   int k;
 
@@ -731,8 +758,9 @@ void apply_time_envelope(float *spectrum, float *spectrum_prev, float N, float r
 * \param tp_r_mean rolling mean value
 * \param transient_protection the manual scaling of the mean thresholding setted by the user
 */
-bool transient_detection(float *fft_p2, float *transient_preserv_prev, float fft_size_2,
-                         float *tp_window_count, float *tp_r_mean, float transient_protection)
+static bool
+transient_detection(float *fft_p2, float *transient_preserv_prev, float fft_size_2,
+                    float *tp_window_count, float *tp_r_mean, float transient_protection)
 {
   float adapted_threshold, reduction_function;
 
@@ -772,7 +800,8 @@ bool transient_detection(float *fft_p2, float *transient_preserv_prev, float fft
 * \param k bin number
 * \param N fft size
 */
-float blackman(int k, int N)
+static float
+blackman(int k, int N)
 {
   float p = ((float)(k)) / ((float)(N));
   return 0.42 - 0.5 * cosf(2.f * M_PI * p) + 0.08 * cosf(4.f * M_PI * p);
@@ -783,7 +812,8 @@ float blackman(int k, int N)
 * \param k bin number
 * \param N fft size
 */
-float hanning(int k, int N)
+static float
+hanning(int k, int N)
 {
   float p = ((float)(k)) / ((float)(N));
   return 0.5 - 0.5 * cosf(2.f * M_PI * p);
@@ -794,7 +824,8 @@ float hanning(int k, int N)
 * \param k bin number
 * \param N fft size
 */
-float hamming(int k, int N)
+static float
+hamming(int k, int N)
 {
   float p = ((float)(k)) / ((float)(N));
   return 0.54 - 0.46 * cosf(2.f * M_PI * p);
@@ -807,7 +838,8 @@ float hamming(int k, int N)
 * \param k bin number
 * \param N fft size
 */
-float vorbis(int k, int N)
+static float
+vorbis(int k, int N)
 {
   float p = ((float)(k)) / ((float)(N));
   return sinf(M_PI / 2.f * powf(sinf(M_PI * p), 2.f));
@@ -819,7 +851,8 @@ float vorbis(int k, int N)
 * \param N fft size
 * \param window_type type of window
 */
-void fft_window(float *window, int N, int window_type)
+static void
+fft_window(float *window, int N, int window_type)
 {
   int k;
   for (k = 0; k < N; k++)
@@ -848,7 +881,8 @@ void fft_window(float *window, int N, int window_type)
 * \param output_window array of the output window values
 * \param frame_size size of the window arrays
 */
-float get_window_scale_factor(float *input_window, float *output_window, int frame_size)
+static float
+get_window_scale_factor(float *input_window, float *output_window, int frame_size)
 {
   float sum = 0.f;
   for (int i = 0; i < frame_size; i++)
@@ -865,9 +899,10 @@ float get_window_scale_factor(float *input_window, float *output_window, int fra
 * \param window_option_output output window option
 * \param overlap_scale_factor scaling factor for the OLA for configured window options
 */
-void fft_pre_and_post_window(float *input_window, float *output_window, int frame_size,
-                             int window_option_input, int window_option_output,
-                             float *overlap_scale_factor)
+static void
+fft_pre_and_post_window(float *input_window, float *output_window, int frame_size,
+                        int window_option_input, int window_option_output,
+                        float *overlap_scale_factor)
 {
   //Input window
   switch (window_option_input)
@@ -919,8 +954,9 @@ void fft_pre_and_post_window(float *input_window, float *output_window, int fram
 * \param fft_size size of the fft
 * \param fft_buffer buffer with the complex spectrum of the fft transform
 */
-void get_info_from_bins(float *fft_p2, float *fft_magnitude, float *fft_phase,
-                        int fft_size_2, int fft_size, float *fft_buffer)
+static void
+get_info_from_bins(float *fft_p2, float *fft_magnitude, float *fft_phase,
+                   int fft_size_2, int fft_size, float *fft_buffer)
 {
   int k;
   float real_p, imag_n, mag, p2, phase;

--- a/src/masking.c
+++ b/src/masking.c
@@ -45,7 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/
 #define ARRAYACCESS(a, i, j) ((a)[(i)*N_BARK_BANDS + (j)]) //This is for SSF Matrix recall
 
 //Proposed by Sinha and Tewfik and explained by Virag
-const float relative_thresholds[N_BARK_BANDS] = {-16.f, -17.f, -18.f, -19.f, -20.f, -21.f, -22.f, -23.f, -24.f, -25.f, -25.f, -25.f, -25.f, -25.f, -25.f, -24.f, -23.f, -22.f, -19.f, -18.f, -18.f, -18.f, -18.f, -18.f, -18.f};
+static const float
+relative_thresholds[N_BARK_BANDS] = {-16.f, -17.f, -18.f, -19.f, -20.f, -21.f, -22.f, -23.f, -24.f, -25.f, -25.f, -25.f, -25.f, -25.f, -25.f, -24.f, -23.f, -22.f, -19.f, -18.f, -18.f, -18.f, -18.f, -18.f, -18.f};
 
 /**
 * Fft to bark bilinear scale transform. This computes the corresponding bark band for
@@ -55,7 +56,8 @@ const float relative_thresholds[N_BARK_BANDS] = {-16.f, -17.f, -18.f, -19.f, -20
 * \param fft_size_2 is half of the fft size
 * \param srate current sample rate of the host
 */
-void compute_bark_mapping(float *bark_z, int fft_size_2, int srate)
+static void
+compute_bark_mapping(float *bark_z, int fft_size_2, int srate)
 {
   int k;
   float freq;
@@ -74,7 +76,8 @@ void compute_bark_mapping(float *bark_z, int fft_size_2, int srate)
 * assessment of coded audio'.
 * \param SSF defines the spreading function matrix
 */
-void compute_SSF(float *SSF)
+static void
+compute_SSF(float *SSF)
 {
   int i, j;
   float y;
@@ -99,7 +102,8 @@ void compute_SSF(float *SSF)
 * \param bark_spectrum the bark spectrum values of current power spectrum
 * \param spreaded_spectrum result of the convolution bewtween SSF and the bark spectrum
 */
-void convolve_with_SSF(float *SSF, float *bark_spectrum, float *spreaded_spectrum)
+static void
+convolve_with_SSF(float *SSF, float *bark_spectrum, float *spreaded_spectrum)
 {
   int i, j;
   for (i = 0; i < N_BARK_BANDS; i++)
@@ -121,8 +125,9 @@ void convolve_with_SSF(float *SSF, float *bark_spectrum, float *spreaded_spectru
 * \param intermediate_band_bins holds the bin numbers that are limits of each band
 * \param n_bins_per_band holds the the number of bins in each band
 */
-void compute_bark_spectrum(float *bark_z, float *bark_spectrum, float *spectrum,
-                           float *intermediate_band_bins, float *n_bins_per_band)
+static void
+compute_bark_spectrum(float *bark_z, float *bark_spectrum, float *spectrum,
+                      float *intermediate_band_bins, float *n_bins_per_band)
 {
   int j;
   int last_position = 0;
@@ -163,9 +168,10 @@ void compute_bark_spectrum(float *bark_z, float *bark_spectrum, float *spectrum,
 * \param output_fft_buffer_at output buffer for the reference sinewave fft transform
 * \param forward_at fftw plan for the reference sinewave fft transform
 */
-void spl_reference(float *spl_reference_values, int fft_size_2, int srate,
-                   float *input_fft_buffer_at, float *output_fft_buffer_at,
-                   fftwf_plan *forward_at)
+static void
+spl_reference(float *spl_reference_values, int fft_size_2, int srate,
+              float *input_fft_buffer_at, float *output_fft_buffer_at,
+              fftwf_plan *forward_at)
 {
   int k;
   float sinewave[2 * fft_size_2];
@@ -211,7 +217,8 @@ void spl_reference(float *spl_reference_values, int fft_size_2, int srate,
 * \param masking_thresholds the masking thresholds obtained in db scale
 * \param fft_size_2 is half of the fft size
 */
-void convert_to_dbspl(float *spl_reference_values, float *masking_thresholds, int fft_size_2)
+static void
+convert_to_dbspl(float *spl_reference_values, float *masking_thresholds, int fft_size_2)
 {
   for (int k = 0; k <= fft_size_2; k++)
   {
@@ -227,7 +234,8 @@ void convert_to_dbspl(float *spl_reference_values, float *masking_thresholds, in
 * \param fft_size_2 is half of the fft size
 * \param srate current sample rate of the host
 */
-void compute_absolute_thresholds(float *absolute_thresholds, int fft_size_2, int srate)
+static void
+compute_absolute_thresholds(float *absolute_thresholds, int fft_size_2, int srate)
 {
   int k;
   float freq;
@@ -249,8 +257,9 @@ void compute_absolute_thresholds(float *absolute_thresholds, int fft_size_2, int
 * \param n_bins_per_band holds the the number of bins in each band
 * \param band the bark band given
 */
-float compute_tonality_factor(float *spectrum, float *intermediate_band_bins,
-                              float *n_bins_per_band, int band)
+static float
+compute_tonality_factor(float *spectrum, float *intermediate_band_bins,
+                        float *n_bins_per_band, int band)
 {
   int k;
   float SFM, tonality_factor;
@@ -300,10 +309,11 @@ float compute_tonality_factor(float *spectrum, float *intermediate_band_bins,
 * \param spreaded_unity_gain_bark_spectrum correction to be applied to SSF convolution
 * \param spl_reference_values defines the reference values for each bin to convert from db to db SPL
 */
-void compute_masking_thresholds(float *bark_z, float *absolute_thresholds, float *SSF,
-                                float *spectrum, int fft_size_2, float *masking_thresholds,
-                                float *spreaded_unity_gain_bark_spectrum,
-                                float *spl_reference_values)
+static void
+compute_masking_thresholds(float *bark_z, float *absolute_thresholds, float *SSF,
+                           float *spectrum, int fft_size_2, float *masking_thresholds,
+                           float *spreaded_unity_gain_bark_spectrum,
+                           float *spl_reference_values)
 {
   int k, j, start_pos, end_pos;
   float intermediate_band_bins[N_BARK_BANDS];
@@ -396,12 +406,13 @@ void compute_masking_thresholds(float *bark_z, float *absolute_thresholds, float
 * \param masking_value is the limit max oversubtraction to be computed
 * \param reduction_value is the limit max the spectral flooring to be computed
 */
-void compute_alpha_and_beta(float *fft_p2, float *noise_thresholds_p2, int fft_size_2,
-                            float *alpha_masking, float *beta_masking, float *bark_z,
-                            float *absolute_thresholds, float *SSF,
-                            float *spreaded_unity_gain_bark_spectrum,
-                            float *spl_reference_values, float masking_value,
-                            float reduction_value)
+static void
+compute_alpha_and_beta(float *fft_p2, float *noise_thresholds_p2, int fft_size_2,
+                       float *alpha_masking, float *beta_masking, float *bark_z,
+                       float *absolute_thresholds, float *SSF,
+                       float *spreaded_unity_gain_bark_spectrum,
+                       float *spl_reference_values, float masking_value,
+                       float reduction_value)
 {
   int k;
   float masking_thresholds[fft_size_2 + 1];

--- a/src/spectral_processing.c
+++ b/src/spectral_processing.c
@@ -59,16 +59,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/
 * \param transient_present indicates if current frame is an onset or not (contains a transient)
 * \param transient_protection is the flag that indicates whether transient protection is active or not
 */
-void preprocessing(float noise_thresholds_offset, float *fft_p2,
-				   float *noise_thresholds_p2,
-				   float *noise_thresholds_scaled, float *smoothed_spectrum,
-				   float *smoothed_spectrum_prev, int fft_size_2,
-				   float *bark_z, float *absolute_thresholds, float *SSF,
-				   float release_coeff, float *spreaded_unity_gain_bark_spectrum,
-				   float *spl_reference_values, float *alpha_masking, float *beta_masking,
-				   float masking_value, float adaptive_state, float reduction_value,
-				   float *transient_preserv_prev, float *tp_window_count, float *tp_r_mean,
-				   bool *transient_present, float transient_protection)
+static void
+preprocessing(float noise_thresholds_offset, float *fft_p2,
+              float *noise_thresholds_p2,
+              float *noise_thresholds_scaled, float *smoothed_spectrum,
+              float *smoothed_spectrum_prev, int fft_size_2,
+              float *bark_z, float *absolute_thresholds, float *SSF,
+              float release_coeff, float *spreaded_unity_gain_bark_spectrum,
+              float *spl_reference_values, float *alpha_masking, float *beta_masking,
+              float masking_value, float adaptive_state, float reduction_value,
+              float *transient_preserv_prev, float *tp_window_count, float *tp_r_mean,
+              bool *transient_present, float transient_protection)
 {
 	int k;
 
@@ -136,9 +137,10 @@ void preprocessing(float noise_thresholds_offset, float *fft_p2,
 * \param transient_protection is the flag that indicates whether transient protection is active or not
 * \param transient_present indicates if current frame is an onset or not (contains a transient)
 */
-void spectral_gain(float *fft_p2, float *noise_thresholds_p2, float *noise_thresholds_scaled,
-				   float *smoothed_spectrum, int fft_size_2, float adaptive, float *Gk,
-				   float transient_protection, bool transient_present)
+static void
+spectral_gain(float *fft_p2, float *noise_thresholds_p2, float *noise_thresholds_scaled,
+              float *smoothed_spectrum, int fft_size_2, float adaptive, float *Gk,
+              float transient_protection, bool transient_present)
 {
 	//------REDUCTION GAINS------
 
@@ -168,8 +170,9 @@ void spectral_gain(float *fft_p2, float *noise_thresholds_p2, float *noise_thres
 * \param denoised_spectrum the spectrum of the cleaned signal
 * \param Gk is the filter computed by the supression rule for each bin of the spectrum
 */
-void denoised_calulation(int fft_size, float *output_fft_buffer,
-						 float *denoised_spectrum, float *Gk)
+static void
+denoised_calulation(int fft_size, float *output_fft_buffer,
+                    float *denoised_spectrum, float *Gk)
 {
 	int k;
 
@@ -190,10 +193,11 @@ void denoised_calulation(int fft_size, float *output_fft_buffer,
 * \param whitening_window_count counts frames to distinguish the first from the others
 * \param max_decay_rate coefficient that sets the memory for each temporal maximun
 */
-void residual_calulation(int fft_size, float *output_fft_buffer,
-						 float *residual_spectrum, float *denoised_spectrum,
-						 float whitening_factor, float *residual_max_spectrum,
-						 float *whitening_window_count, float max_decay_rate)
+static void
+residual_calulation(int fft_size, float *output_fft_buffer,
+                    float *residual_spectrum, float *denoised_spectrum,
+                    float whitening_factor, float *residual_max_spectrum,
+                    float *whitening_window_count, float max_decay_rate)
 {
 
 	int k;
@@ -224,9 +228,10 @@ void residual_calulation(int fft_size, float *output_fft_buffer,
 * \param reduction_amount the amount of dB power to reduce setted by the user
 * \param noise_listen control variable that decides whether to output the mixed noise reduced signal or the residual only
 */
-void final_spectrum_ensemble(int fft_size, float *final_spectrum,
-							 float *residual_spectrum, float *denoised_spectrum,
-							 float reduction_amount, float noise_listen)
+static void
+final_spectrum_ensemble(int fft_size, float *final_spectrum,
+                        float *residual_spectrum, float *denoised_spectrum,
+                        float reduction_amount, float noise_listen)
 {
 	int k;
 
@@ -256,8 +261,9 @@ void final_spectrum_ensemble(int fft_size, float *final_spectrum,
 * \param wet_dry mixing coefficient
 * \param fft_size size of the fft
 */
-void soft_bypass(float *final_spectrum, float *output_fft_buffer, float wet_dry,
-				 int fft_size)
+static void
+soft_bypass(float *final_spectrum, float *output_fft_buffer, float wet_dry,
+            int fft_size)
 {
 	int k;
 


### PR DESCRIPTION
This should fix #63 

Previously the shared object exposed all local methods into the global namespace (for others to use) and likewise also used already existing methods. Compare to frame `#0 hanning () at /usr/lib/x86_64-linux-gnu/libcodec2.so.0.8.1`  the backtrace shown in #63 
