### PR TITLE
Fix cross building and archs other than x86_64/aarch64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,13 +20,13 @@ add_global_arguments('-ffast-math','-fomit-frame-pointer','-fno-finite-math-only
 #install folder
 install_folder = join_paths(get_option('libdir'), 'lv2', meson.project_name())
 
-#get the build operating system and configure install path and shared object extension
-current_os = build_machine.system()
-current_arch = build_machine.cpu_family()
+#get the host operating system and configure install path and shared object extension
+current_os = host_machine.system()
+current_arch = host_machine.cpu_family()
 cflags = []
 
-# Add x86_64 optimization where appropriate (not for ARM)
-if current_arch != 'aarch64'
+# Add x86_64 optimization
+if current_arch == 'x86_64'
     cflags += ['-msse','-msse2','-mfpmath=sse']
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ lv2_dep = dependency('lv2', required : true)
 nr_dep = [m_dep,fftw_dep,lv2_dep]
 
 #compiler default flags
-add_global_arguments('-ffast-math','-fomit-frame-pointer','-fno-finite-math-only','-Wno-unused-function',language : 'c')
+add_global_arguments('-fomit-frame-pointer','-fno-finite-math-only','-Wno-unused-function',language : 'c')
 
 #install folder
 install_folder = join_paths(get_option('libdir'), 'lv2', meson.project_name())
@@ -27,7 +27,7 @@ cflags = []
 
 # Add x86_64 optimization
 if current_arch == 'x86_64'
-    cflags += ['-msse','-msse2','-mfpmath=sse']
+    cflags += ['-ffast-math','-msse','-msse2','-mfpmath=sse']
 endif
 
 # Add osx multiarch flags when appropriate


### PR DESCRIPTION
- for defining compilation flags and any other information, it's the
  host machine (where the resulting binary will run) that matters, not
  the build machine
- x86_64 optimizations should be enabled only for x86_64; there are many
  archs other than x86_64 and aarch64