### PR TITLE
add RISC-V support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,8 @@ current_os = build_machine.system()
 current_arch = build_machine.cpu_family()
 cflags = []
 
-# Add x86_64 optimization where appropriate (not for ARM)
-if current_arch != 'aarch64'
+# Add x86_64 optimization where appropriate (not for ARM, not for riscv)
+if current_arch != 'aarch64' and current_arch != 'riscv64'
     cflags += ['-msse','-msse2','-mfpmath=sse']
 endif
 


### PR DESCRIPTION
I try build this package on riscv,but it has a error:
```
cc: error: unrecognized command-line option `-msse`
cc: error: unrecognized command-line option `-msse2`
```
RISC-V does not support the `-msse` option, so I fix build. And the can build for riscv.