### PR TITLE
feat: Psychoacoustic Redesign and Parameter Cleanup

### DIFF
--- a/lv2ttl/nrepellent#stereo.ttl.in
+++ b/lv2ttl/nrepellent#stereo.ttl.in
@@ -184,7 +184,7 @@
     rdfs:comment "Balances between noise reduction and transient preservation. High transparency preserves attacks and delicate details but can leave more noise. Standard is 'Natural' (50%)." ;
     lv2:minimum 0.0 ;
     lv2:maximum 100.0 ;
-    lv2:default 50.0 ;
+    lv2:default 100.0 ;
     units:unit units:pc ;
   ], [
     a lv2:ControlPort,

--- a/lv2ttl/nrepellent-2d#stereo.ttl.in
+++ b/lv2ttl/nrepellent-2d#stereo.ttl.in
@@ -181,7 +181,7 @@
     rdfs:comment "Balances transient preservation vs. noise floor silence. 0%: Maximum reduction, 50%: Natural sweet spot (recommended), 100%: Pure transparency." ;
     lv2:minimum 0.0 ;
     lv2:maximum 100.0 ;
-    lv2:default 0.0 ;
+    lv2:default 100.0 ;
     units:unit units:pc ;
   ], [
     a lv2:ControlPort,

--- a/lv2ttl/nrepellent-2d.ttl.in
+++ b/lv2ttl/nrepellent-2d.ttl.in
@@ -181,7 +181,7 @@
     rdfs:comment "Balances transient preservation vs. noise floor silence. 0%: Maximum reduction, 50%: Natural sweet spot (recommended), 100%: Pure transparency." ;
     lv2:minimum 0.0 ;
     lv2:maximum 100.0 ;
-    lv2:default 0.0 ;
+    lv2:default 100.0 ;
     units:unit units:pc ;
   ], [
     a lv2:ControlPort,

--- a/lv2ttl/nrepellent.ttl.in
+++ b/lv2ttl/nrepellent.ttl.in
@@ -181,7 +181,7 @@
     rdfs:comment "Balances between noise reduction and transient preservation. High transparency preserves attacks and delicate details but can leave more noise. Standard is 'Natural' (50%)." ;
     lv2:minimum 0.0 ;
     lv2:maximum 100.0 ;
-    lv2:default 50.0 ;
+    lv2:default 100.0 ;
     units:unit units:pc ;
   ], [
     a lv2:ControlPort,

--- a/plugins/nrepellent-2d.c
+++ b/plugins/nrepellent-2d.c
@@ -505,7 +505,6 @@ static void run(LV2_Handle instance, uint32_t number_of_samples) {
       .adaptive_noise = self->adaptive_noise ? (int)*self->adaptive_noise : 0,
       .noise_estimation_method = self->adaptive_method ? (int)*self->adaptive_method : 2,
       .nlm_masking_protection = self->masking_transparency ? (1.0f - powf(1.0f - (*self->masking_transparency / 100.0f), 3.0f)) : 0.5f,
-      .masking_elasticity = self->masking_transparency ? (0.2f * (1.0f - (*self->masking_transparency / 100.0f))) : 0.1f,
       .suppression_strength = self->suppression_strength ? *self->suppression_strength : 20.0F,
       .aggressiveness = self->aggressiveness ? *self->aggressiveness / 100.0f : 0.0f,
       .tonal_reduction = self->tonal_reduction ? *self->tonal_reduction : 0.0f,

--- a/plugins/nrepellent.c
+++ b/plugins/nrepellent.c
@@ -493,7 +493,6 @@ static void run(LV2_Handle instance, uint32_t number_of_samples) {
       .adaptive_noise = self->adaptive_noise ? (int)*self->adaptive_noise : 0,
       .noise_estimation_method = self->adaptive_method ? (int)*self->adaptive_method : 0,
       .masking_depth = self->masking_transparency ? (1.0f - powf(1.0f - (*self->masking_transparency / 100.0f), 3.0f)) : 0.5f,
-      .masking_elasticity = self->masking_transparency ? (0.2f * (1.0f - (*self->masking_transparency / 100.0f))) : 0.1f,
       .suppression_strength = self->suppression_strength ? *self->suppression_strength : 20.0f,
       .tonal_reduction = self->tonal_reduction ? *self->tonal_reduction : 0.0f,
       .aggressiveness = self->aggressiveness ? *self->aggressiveness / 100.0f : 0.0f,

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 63142cd536bdf891bbc9008ee175729a5c03b352
+revision = 65da3cc7014b3fa370f3eb010d8bc45ba6d99ecb

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 657e1c1ea843dc23207bb0296e520aa01eb2d5d5
+revision = 63142cd536bdf891bbc9008ee175729a5c03b352

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 65da3cc7014b3fa370f3eb010d8bc45ba6d99ecb
+revision = 2f83af84c4877bb0241c1f8c13a50136f56d53ef


### PR DESCRIPTION
This PR aligns the noise-repellent plugins with the latest libspecbleach changes, featuring a purely NMR-based masking veto and removal of the obsolete masking elasticity control. Linked to libspecbleach PR #89.