### PR TITLE
ci: Enable AVX optimizations for bundled libspecbleach

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build noise-repellent
         shell: bash
         run: |
-          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true -Dlibspecbleach:enable_avx=true
+          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true
           meson compile -v -C build
           meson install -C build --skip-subprojects
           mv /tmp/lv2/nrepellent.lv2 ./nrepellent.lv2
@@ -176,7 +176,7 @@ jobs:
         run: |
           pushd PawPaw && source local.env win64 && popd
           wineboot -u
-          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dlv2dir=/tmp/lv2 --cross-file $PWD/setup/win64.ini -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true -Dlibspecbleach:enable_avx=true
+          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dlv2dir=/tmp/lv2 --cross-file $PWD/setup/win64.ini -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true
           meson compile -v -C build
           meson install -C build --skip-subprojects
           mv /tmp/lv2/nrepellent.lv2 ./nrepellent.lv2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build noise-repellent
         shell: bash
         run: |
-          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true
+          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true -Dlibspecbleach:enable_avx=true
           meson compile -v -C build
           meson install -C build --skip-subprojects
           mv /tmp/lv2/nrepellent.lv2 ./nrepellent.lv2
@@ -176,7 +176,7 @@ jobs:
         run: |
           pushd PawPaw && source local.env win64 && popd
           wineboot -u
-          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dlv2dir=/tmp/lv2 --cross-file $PWD/setup/win64.ini -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true
+          meson setup build --buildtype release --prefix /tmp --libdir /tmp -Dlv2dir=/tmp/lv2 --cross-file $PWD/setup/win64.ini -Dstatic_libspecbleach=true -Dforce_bundled_libspecbleach=true -Dlibspecbleach:enable_avx=true
           meson compile -v -C build
           meson install -C build --skip-subprojects
           mv /tmp/lv2/nrepellent.lv2 ./nrepellent.lv2

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 02028ae33ffce1b6570b4c571a7026a4521c1198
+revision = cbc4e4d049fa02daad132dab01729bb7d0b6333f

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 33c745315de719fd5153526df37057c8e10c429e
+revision = 02028ae33ffce1b6570b4c571a7026a4521c1198

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 2f83af84c4877bb0241c1f8c13a50136f56d53ef
+revision = b747843f9703ac303bac8d709c2059d041829d82

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = b747843f9703ac303bac8d709c2059d041829d82
+revision = 33c745315de719fd5153526df37057c8e10c429e


### PR DESCRIPTION
Enabling AVX optimizations to ensure SIMD instructions are correctly compiled for AMD64 architectures during CI builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a pinned external library dependency to a newer revision.
  * No other configuration or surface changes were made; this is a low-risk maintenance update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->