### PR TITLE
chore: update libspecbleach subproject revision

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# CodeRabbit Configuration File
+version: "2"
+language: "en-US"
+reviews:
+  profile: "chill"
+  auto_review:
+    enabled: false
+    drafts: false
+  auto_approve: true
+  path_instructions:
+    - path: "plugins/**/*"
+      instructions: |
+        Pay attention to LV2 real-time plugin safety:
+        - Strict hardRTCapable compliance (no blocking operations in run()).
+        - Ensure manifest files (.ttl.in) match any parameter or port changes in C code.
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,6 @@ reviews:
   auto_review:
     enabled: false
     drafts: false
-  review_status: false
   auto_approve: true
   path_instructions:
     - path: "plugins/**/*"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,7 @@ reviews:
   auto_review:
     enabled: false
     drafts: false
+  review_status: false
   auto_approve: true
   path_instructions:
     - path: "plugins/**/*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,4 @@ This file contains foundational mandates and architectural context for Gemini CL
   `self->parameters.masking_depth = 1.0f - powf(1.0f - (*self->masking_transparency / 100.0f), 3.0f);`
 - **Latency**: Latency is reported to the host in `activate()` and through a dedicated output control port.
 
----
-
-## CodeRabbit PR Review Workflow
-- **Manual Review Trigger**: `auto_review.enabled` is set to `false` in `.coderabbit.yaml` to conserve the daily free quota.
-- **Trigger Command**: Post `@coderabbitai review` as a comment on the PR when ready for review.
-- **Auto-Approval**: CodeRabbit will review on demand and automatically approve if checks pass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,11 @@ This file contains foundational mandates and architectural context for Gemini CL
 - **Mapping**: Note the non-linear mapping for `masking_depth` in `run()`:
   `self->parameters.masking_depth = 1.0f - powf(1.0f - (*self->masking_transparency / 100.0f), 3.0f);`
 - **Latency**: Latency is reported to the host in `activate()` and through a dedicated output control port.
+
+---
+
+## CodeRabbit PR Review Workflow
+- **Manual Review Trigger**: `auto_review.enabled` is set to `false` in `.coderabbit.yaml` to conserve the daily free quota.
+- **Trigger Command**: Post `@coderabbitai review` as a comment on the PR when ready for review.
+- **Auto-Approval**: CodeRabbit will review on demand and automatically approve if checks pass.
+

--- a/subprojects/libspecbleach.wrap
+++ b/subprojects/libspecbleach.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/lucianodato/libspecbleach.git
-revision = 020948a70fb2e478ce71d1eda7a86dba5f289cee0
+revision = 091f971c674617966024e7dae00abc6fc6d2475f


### PR DESCRIPTION
Updates libspecbleach subproject wrap revision to 091f971c674617966024e7dae00abc6fc6d2475f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “CodeRabbit PR Review Workflow” section with instructions for triggering reviews manually and describing when auto-approval happens.

* **Chores**
  * Updated automated review configuration to conserve review quota while still auto-approving when checks pass.
  * Added clearer guidance for hard real-time safety expectations and keeping plugin manifest files in sync with parameter/port changes.
  * Enabled automatic chat replies in the review assistant.

* **Dependencies**
  * Bumped the pinned `libspecbleach` revision used by the project’s vendored library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->