### PR TITLE
refactor: update processor parameters to include non-automatable metadata and add bypass parameter getter

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -109,6 +109,65 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
   return {params.begin(), params.end()};
 }
 
+static bool loadProfile1DSafe(SpectralBleachHandle h, const float* data,
+                              uint32_t size, uint32_t blockCount, int mode) {
+  if (!h || !data || size == 0)
+    return false;
+  uint32_t targetSize = specbleach_get_noise_profile_size(h);
+  if (targetSize == 0)
+    return false;
+
+  if (size == targetSize) {
+    return specbleach_load_noise_profile_for_mode(h, data, size, blockCount,
+                                                  mode);
+  } else {
+    std::vector<float> resampled(targetSize);
+    float maxSrcIdx = static_cast<float>(size - 1);
+    float maxTargetIdx = static_cast<float>(targetSize - 1);
+    for (uint32_t i = 0; i < targetSize; ++i) {
+      float normPos = static_cast<float>(i) / maxTargetIdx;
+      float exactIdx = normPos * maxSrcIdx;
+      uint32_t idx0 =
+          std::clamp(static_cast<uint32_t>(exactIdx), 0u, size - 1);
+      uint32_t idx1 = std::min(idx0 + 1, size - 1);
+      float frac = exactIdx - static_cast<float>(idx0);
+      resampled[i] = (1.0f - frac) * data[idx0] + frac * data[idx1];
+    }
+    return specbleach_load_noise_profile_for_mode(
+        h, resampled.data(), targetSize, blockCount, mode);
+  }
+}
+
+static bool loadProfile2DSafe(SpectralBleachHandle h,
+                              const float* data, uint32_t size,
+                              uint32_t blockCount, int mode) {
+  if (!h || !data || size == 0)
+    return false;
+  uint32_t targetSize = specbleach_2d_get_noise_profile_size(h);
+  if (targetSize == 0)
+    return false;
+
+  if (size == targetSize) {
+    return specbleach_2d_load_noise_profile_for_mode(h, data, size,
+                                                     blockCount, mode);
+  } else {
+    std::vector<float> resampled(targetSize);
+    float maxSrcIdx = static_cast<float>(size - 1);
+    float maxTargetIdx = static_cast<float>(targetSize - 1);
+    for (uint32_t i = 0; i < targetSize; ++i) {
+      float normPos = static_cast<float>(i) / maxTargetIdx;
+      float exactIdx = normPos * maxSrcIdx;
+      uint32_t idx0 =
+          std::clamp(static_cast<uint32_t>(exactIdx), 0u, size - 1);
+      uint32_t idx1 = std::min(idx0 + 1, size - 1);
+      float frac = exactIdx - static_cast<float>(idx0);
+      resampled[i] = (1.0f - frac) * data[idx0] + frac * data[idx1];
+    }
+    return specbleach_2d_load_noise_profile_for_mode(
+        h, resampled.data(), targetSize, blockCount, mode);
+  }
+}
+
 void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   bool needNewEngines = (specbleach1D_L == nullptr ||
                          std::abs(currentSampleRate - sampleRate) > 0.001);
@@ -117,6 +176,7 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
     return;
 
   struct SavedProfileData {
+    int channel; // 0 = Left, 1 = Right
     int mode;
     uint32_t size;
     uint32_t blockCount;
@@ -126,37 +186,37 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   std::vector<SavedProfileData> profiles1D;
   std::vector<SavedProfileData> profiles2D;
 
-  // Backup 1D profiles if handles exist
-  if (specbleach1D_L) {
+  auto backup1D = [&](SpectralBleachHandle h, int channel) {
+    if (!h) return;
     for (int mode = 1; mode <= 4; ++mode) {
-      if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode)) {
-        float* p = specbleach_get_noise_profile_for_mode(specbleach1D_L, mode);
-        uint32_t sz = specbleach_get_noise_profile_size(specbleach1D_L);
-        uint32_t bc = specbleach_get_noise_profile_block_count_for_mode(
-            specbleach1D_L, mode);
+      if (specbleach_noise_profile_available_for_mode(h, mode)) {
+        float* p = specbleach_get_noise_profile_for_mode(h, mode);
+        uint32_t sz = specbleach_get_noise_profile_size(h);
+        uint32_t bc = specbleach_get_noise_profile_block_count_for_mode(h, mode);
         if (p && sz > 0) {
-          profiles1D.push_back({mode, sz, bc, std::vector<float>(p, p + sz)});
+          profiles1D.push_back({channel, mode, sz, bc, std::vector<float>(p, p + sz)});
         }
       }
     }
-  }
+  };
+  backup1D(specbleach1D_L, 0);
+  backup1D(specbleach1D_R, 1);
 
-  // Backup 2D profiles if handles exist
-  if (specbleach2D_L) {
+  auto backup2D = [&](auto h, int channel) {
+    if (!h) return;
     for (int mode = 1; mode <= 4; ++mode) {
-      if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L,
-                                                         mode)) {
-        float* p =
-            specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, mode);
-        uint32_t sz = specbleach_2d_get_noise_profile_size(specbleach2D_L);
-        uint32_t bc = specbleach_2d_get_noise_profile_block_count_for_mode(
-            specbleach2D_L, mode);
+      if (specbleach_2d_noise_profile_available_for_mode(h, mode)) {
+        float* p = specbleach_2d_get_noise_profile_for_mode(h, mode);
+        uint32_t sz = specbleach_2d_get_noise_profile_size(h);
+        uint32_t bc = specbleach_2d_get_noise_profile_block_count_for_mode(h, mode);
         if (p && sz > 0) {
-          profiles2D.push_back({mode, sz, bc, std::vector<float>(p, p + sz)});
+          profiles2D.push_back({channel, mode, sz, bc, std::vector<float>(p, p + sz)});
         }
       }
     }
-  }
+  };
+  backup2D(specbleach2D_L, 0);
+  backup2D(specbleach2D_R, 1);
 
   // Free existing handles
   if (specbleach1D_L)
@@ -182,26 +242,47 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
 
   // Restore saved profiles into new handles
   for (const auto& item : profiles1D) {
-    if (specbleach1D_L)
-      specbleach_load_noise_profile_for_mode(specbleach1D_L, item.data.data(),
-                                             item.size, item.blockCount,
-                                             item.mode);
-    if (specbleach1D_R)
-      specbleach_load_noise_profile_for_mode(specbleach1D_R, item.data.data(),
-                                             item.size, item.blockCount,
-                                             item.mode);
+    auto h = (item.channel == 1) ? specbleach1D_R : specbleach1D_L;
+    if (h)
+      loadProfile1DSafe(h, item.data.data(), item.size, item.blockCount,
+                        item.mode);
   }
 
   for (const auto& item : profiles2D) {
-    if (specbleach2D_L)
-      specbleach_2d_load_noise_profile_for_mode(specbleach2D_L,
-                                                item.data.data(), item.size,
-                                                item.blockCount, item.mode);
-    if (specbleach2D_R)
-      specbleach_2d_load_noise_profile_for_mode(specbleach2D_R,
-                                                item.data.data(), item.size,
-                                                item.blockCount, item.mode);
+    auto h = (item.channel == 1) ? specbleach2D_R : specbleach2D_L;
+    if (h)
+      loadProfile2DSafe(h, item.data.data(), item.size, item.blockCount,
+                        item.mode);
   }
+
+  // Restore state pending profiles if loaded before prepareToPlay
+  bool hasCh1 = false;
+  for (const auto& item : pendingProfiles) {
+    if (item.channel == 1) hasCh1 = true;
+    auto h1D = (item.channel == 1) ? specbleach1D_R : specbleach1D_L;
+    auto h2D = (item.channel == 1) ? specbleach2D_R : specbleach2D_L;
+    if (h1D)
+      loadProfile1DSafe(h1D, item.data.data(), item.size, item.blockCount,
+                        item.mode);
+    if (h2D)
+      loadProfile2DSafe(h2D, item.data.data(), item.size, item.blockCount,
+                        item.mode);
+  }
+
+  // If no channel 1 profile, fallback channel 0 to channel 1
+  if (!hasCh1) {
+    for (const auto& item : pendingProfiles) {
+      if (item.channel == 0) {
+        if (specbleach1D_R)
+          loadProfile1DSafe(specbleach1D_R, item.data.data(), item.size,
+                            item.blockCount, item.mode);
+        if (specbleach2D_R)
+          loadProfile2DSafe(specbleach2D_R, item.data.data(), item.size,
+                            item.blockCount, item.mode);
+      }
+    }
+  }
+  pendingProfiles.clear();
 
   // Synchronize loaded profiles between engines
   syncNoiseProfiles(0);
@@ -306,7 +387,8 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   dryWetMixer.setMixingRule(juce::dsp::DryWetMixingRule::linear);
   dryWetMixer.setWetLatency(static_cast<float>(latency));
 
-  // Prepare buffer and state for engine crossfading
+  // Pre-allocate persistent buffers to prevent audio-thread allocations
+  dryInputL.resize(static_cast<size_t>(samplesPerBlock), 0.0f);
   crossfadeBuffer.setSize(getTotalNumOutputChannels(), samplesPerBlock, false,
                           false, true);
   crossfadeProgress = 1.0f;
@@ -336,6 +418,9 @@ void NoiseRepellentAudioProcessor::processBlock(
   juce::ScopedNoDenormals noDenormals;
   const int numSamples = buffer.getNumSamples();
   const int numChannels = buffer.getNumChannels();
+
+  if (numSamples == 0 || numChannels == 0)
+    return;
 
   const bool isBypassed =
       parameters.getRawParameterValue("bypass")->load() > 0.5f;
@@ -408,9 +493,9 @@ void NoiseRepellentAudioProcessor::processBlock(
   }
 
   // Save dry input copy for FFT visualization before processing
-  std::vector<float> dryInputL(static_cast<size_t>(numSamples));
-  if (numChannels >= 1)
-    std::copy_n(buffer.getReadPointer(0), numSamples, dryInputL.begin());
+  const size_t copySamples = std::min(static_cast<size_t>(numSamples), dryInputL.size());
+  if (numChannels >= 1 && copySamples > 0)
+    std::copy_n(buffer.getReadPointer(0), copySamples, dryInputL.begin());
 
   // Push dry samples into JUCE DryWetMixer before in-place DSP processing
   juce::dsp::AudioBlock<float> audioBlock(buffer);
@@ -445,25 +530,24 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   if (crossfadeProgress < 1.0f) {
     // Smooth crossfade mode: run both engines and blend sample-by-sample
-    if (crossfadeBuffer.getNumChannels() < numChannels ||
-        crossfadeBuffer.getNumSamples() < numSamples)
-      crossfadeBuffer.setSize(numChannels, numSamples, false, false, true);
+    const int maxSamples = std::min(numSamples, crossfadeBuffer.getNumSamples());
+    const int maxChannels = std::min(numChannels, crossfadeBuffer.getNumChannels());
 
-    for (int ch = 0; ch < numChannels; ++ch)
-      std::copy_n(buffer.getReadPointer(ch), numSamples,
+    for (int ch = 0; ch < maxChannels; ++ch)
+      std::copy_n(buffer.getReadPointer(ch), maxSamples,
                   crossfadeBuffer.getWritePointer(ch));
 
     // Process 1D on buffer
     if (specbleach1D_L) {
       specbleach_load_parameters(specbleach1D_L, p);
       float* ch0 = buffer.getWritePointer(0);
-      specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0,
+      specbleach_process(specbleach1D_L, static_cast<uint32_t>(maxSamples), ch0,
                          ch0);
     }
     if (numChannels >= 2 && specbleach1D_R) {
       specbleach_load_parameters(specbleach1D_R, p);
       float* ch1 = buffer.getWritePointer(1);
-      specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1,
+      specbleach_process(specbleach1D_R, static_cast<uint32_t>(maxSamples), ch1,
                          ch1);
     }
 
@@ -471,23 +555,23 @@ void NoiseRepellentAudioProcessor::processBlock(
     if (specbleach2D_L) {
       specbleach_2d_load_parameters(specbleach2D_L, p2);
       float* ch0 = crossfadeBuffer.getWritePointer(0);
-      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples),
+      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(maxSamples),
                             ch0, ch0);
     }
-    if (numChannels >= 2 && specbleach2D_R) {
+    if (numChannels >= 2 && specbleach2D_R && maxChannels >= 2) {
       specbleach_2d_load_parameters(specbleach2D_R, p2);
       float* ch1 = crossfadeBuffer.getWritePointer(1);
-      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples),
+      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(maxSamples),
                             ch1, ch1);
     }
 
     // Equal-power crossfade blend into buffer
-    for (int ch = 0; ch < numChannels; ++ch) {
+    for (int ch = 0; ch < maxChannels; ++ch) {
       float* out1D = buffer.getWritePointer(ch);
       const float* out2D = crossfadeBuffer.getReadPointer(ch);
 
       float currentP = crossfadeProgress;
-      for (int s = 0; s < numSamples; ++s) {
+      for (int s = 0; s < maxSamples; ++s) {
         float pVal = std::min(1.0f, currentP);
         float rad = pVal * juce::MathConstants<float>::halfPi;
         float w1D = (targetAlgoMode == 1) ? std::cos(rad) : std::sin(rad);
@@ -497,7 +581,7 @@ void NoiseRepellentAudioProcessor::processBlock(
         currentP += crossfadeStep;
       }
     }
-    crossfadeProgress += numSamples * crossfadeStep;
+    crossfadeProgress += maxSamples * crossfadeStep;
     if (crossfadeProgress > 1.0f)
       crossfadeProgress = 1.0f;
   } else if (algoMode == 0) {
@@ -586,22 +670,48 @@ void NoiseRepellentAudioProcessor::processBlock(
         bool profileAvailable = false;
 
         bool isAdaptive = adaptiveNoise;
+        bool profileHasAnyMode = false;
 
-        if (algoMode == 0 && specbleach1D_L &&
-            (isAdaptive ||
-             specbleach_noise_profile_available_for_mode(specbleach1D_L, 1))) {
-          actualNoiseProfile =
-              specbleach_get_active_noise_profile(specbleach1D_L);
-          profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
-          profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
-        } else if (algoMode == 1 && specbleach2D_L &&
-                   (isAdaptive ||
-                    specbleach_2d_noise_profile_available_for_mode(
-                        specbleach2D_L, 1))) {
-          actualNoiseProfile =
-              specbleach_2d_get_active_noise_profile(specbleach2D_L);
-          profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
-          profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+        if (algoMode == 0 && specbleach1D_L) {
+          for (int m = 1; m <= 4; ++m) {
+            if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
+              profileHasAnyMode = true;
+              break;
+            }
+          }
+          if (isAdaptive || profileHasAnyMode) {
+            actualNoiseProfile = specbleach_get_active_noise_profile(specbleach1D_L);
+            profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
+            if (!actualNoiseProfile && profileHasAnyMode) {
+              for (int m = 1; m <= 4; ++m) {
+                if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
+                  actualNoiseProfile = specbleach_get_noise_profile_for_mode(specbleach1D_L, m);
+                  break;
+                }
+              }
+            }
+            profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+          }
+        } else if (algoMode == 1 && specbleach2D_L) {
+          for (int m = 1; m <= 4; ++m) {
+            if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
+              profileHasAnyMode = true;
+              break;
+            }
+          }
+          if (isAdaptive || profileHasAnyMode) {
+            actualNoiseProfile = specbleach_2d_get_active_noise_profile(specbleach2D_L);
+            profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
+            if (!actualNoiseProfile && profileHasAnyMode) {
+              for (int m = 1; m <= 4; ++m) {
+                if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
+                  actualNoiseProfile = specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, m);
+                  break;
+                }
+              }
+            }
+            profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+          }
         }
 
         frame.hasNoiseProfile = profileAvailable;
@@ -610,10 +720,7 @@ void NoiseRepellentAudioProcessor::processBlock(
         frame.tonalPeaksHz.clear();
 
         if (profileAvailable && actualNoiseProfile) {
-          // In 2D mode, noise_profile_size is
-          // SB_PROCESSOR_CORE_FULL_FFT_SPECTRUM (e.g. 3008 bins). The real
-          // unique spectrum from DC (0 Hz) to Nyquist (Fs/2) is the first
-          // (profileSize / 2) + 1 bins.
+          // profileSize represents the unique spectrum from DC (0 Hz) to Nyquist (Fs/2)
           size_t realProfileBins = profileSize;
 
           const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
@@ -712,27 +819,16 @@ void NoiseRepellentAudioProcessor::resetNoiseProfile() {
     specbleach_2d_reset_noise_profile(specbleach2D_L);
   if (specbleach2D_R)
     specbleach_2d_reset_noise_profile(specbleach2D_R);
+  pendingProfiles.clear();
 }
 
 bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {
-  auto* paramAlgo = parameters.getRawParameterValue("algorithm_mode");
-  if (!paramAlgo)
-    return false;
-
-  int algoMode = static_cast<int>(paramAlgo->load());
-
-  if (algoMode == 0 && specbleach1D_L) {
-    for (int mode = 1; mode <= 4; ++mode) {
-      if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode))
-        return true;
-    }
-  } else if (algoMode == 1 && specbleach2D_L) {
-    for (int mode = 1; mode <= 4; ++mode) {
-      if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, mode))
-        return true;
-    }
+  for (int mode = 1; mode <= 4; ++mode) {
+    if (specbleach1D_L && specbleach_noise_profile_available_for_mode(specbleach1D_L, mode))
+      return true;
+    if (specbleach2D_L && specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, mode))
+      return true;
   }
-
   return false;
 }
 
@@ -742,44 +838,44 @@ juce::AudioProcessorEditor* NoiseRepellentAudioProcessor::createEditor() {
 
 void NoiseRepellentAudioProcessor::getStateInformation(
     juce::MemoryBlock& destData) {
+  // Sync profiles across engines before state serialization
+  syncNoiseProfiles(currentAlgoMode);
+
   auto state = parameters.copyState();
 
   juce::ValueTree profilesTree("LEARNED_PROFILES");
 
-  auto saveProfiles = [&](SpectralBleachHandle instance, const char* tagName,
-                          auto getProfileFn, auto getSizeFn,
-                          auto getBlockCountFn, auto isAvailableFn) {
-    // Modes 1-4: ROLLING_MEAN=1, MEDIAN=2, MAX=3, MINIMUM=4
-    for (int mode = 1; mode <= 4; ++mode) {
-      if (instance && isAvailableFn(instance, mode)) {
-        float* profile = getProfileFn(instance, mode);
-        uint32_t profileSize = getSizeFn(instance);
-        uint32_t blockCount = getBlockCountFn(instance, mode);
+  for (int channel = 0; channel < 2; ++channel) {
+    auto h1D = (channel == 0) ? specbleach1D_L : specbleach1D_R;
+    auto h2D = (channel == 0) ? specbleach2D_L : specbleach2D_R;
 
-        if (profile && profileSize > 0) {
-          juce::MemoryBlock mb(profile, profileSize * sizeof(float));
-          juce::ValueTree node(tagName);
-          node.setProperty("mode", mode, nullptr);
-          node.setProperty("size", static_cast<int>(profileSize), nullptr);
-          node.setProperty("blockCount", static_cast<int>(blockCount), nullptr);
-          node.setProperty("data", mb.toBase64Encoding(), nullptr);
-          profilesTree.appendChild(node, nullptr);
-        }
+    for (int mode = 1; mode <= 4; ++mode) {
+      const float* profile = nullptr;
+      uint32_t profileSize = 0;
+      uint32_t blockCount = 0;
+
+      if (h1D && specbleach_noise_profile_available_for_mode(h1D, mode)) {
+        profile = specbleach_get_noise_profile_for_mode(h1D, mode);
+        profileSize = specbleach_get_noise_profile_size(h1D);
+        blockCount = specbleach_get_noise_profile_block_count_for_mode(h1D, mode);
+      } else if (h2D && specbleach_2d_noise_profile_available_for_mode(h2D, mode)) {
+        profile = specbleach_2d_get_noise_profile_for_mode(h2D, mode);
+        profileSize = specbleach_2d_get_noise_profile_size(h2D);
+        blockCount = specbleach_2d_get_noise_profile_block_count_for_mode(h2D, mode);
+      }
+
+      if (profile && profileSize > 0) {
+        juce::MemoryBlock mb(profile, profileSize * sizeof(float));
+        juce::ValueTree node("CHANNEL_PROFILE");
+        node.setProperty("channel", channel, nullptr);
+        node.setProperty("mode", mode, nullptr);
+        node.setProperty("size", static_cast<int>(profileSize), nullptr);
+        node.setProperty("blockCount", static_cast<int>(blockCount), nullptr);
+        node.setProperty("data", mb.toBase64Encoding(), nullptr);
+        profilesTree.appendChild(node, nullptr);
       }
     }
-  };
-
-  saveProfiles(specbleach1D_L, "PROFILE_1D",
-               specbleach_get_noise_profile_for_mode,
-               specbleach_get_noise_profile_size,
-               specbleach_get_noise_profile_block_count_for_mode,
-               specbleach_noise_profile_available_for_mode);
-
-  saveProfiles(specbleach2D_L, "PROFILE_2D",
-               specbleach_2d_get_noise_profile_for_mode,
-               specbleach_2d_get_noise_profile_size,
-               specbleach_2d_get_noise_profile_block_count_for_mode,
-               specbleach_2d_noise_profile_available_for_mode);
+  }
 
   state.appendChild(profilesTree, nullptr);
 
@@ -789,16 +885,44 @@ void NoiseRepellentAudioProcessor::getStateInformation(
 
 void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
                                                        int sizeInBytes) {
+  pendingProfiles.clear();
+
   std::unique_ptr<juce::XmlElement> xmlState(
       getXmlFromBinary(data, sizeInBytes));
-  if (xmlState != nullptr && xmlState->hasTagName(parameters.state.getType())) {
-    juce::ValueTree state = juce::ValueTree::fromXml(*xmlState);
-    parameters.replaceState(state);
+  if (xmlState == nullptr && data != nullptr && sizeInBytes > 0) {
+    juce::String xmlString = juce::String::createStringFromData(data, sizeInBytes);
+    if (xmlString.trim().startsWith("<")) {
+      xmlState = juce::XmlDocument::parse(xmlString);
+    }
+  }
 
-    juce::ValueTree profilesTree = state.getChildWithName("LEARNED_PROFILES");
+  if (xmlState != nullptr) {
+    juce::ValueTree state = juce::ValueTree::fromXml(*xmlState);
+    
+    // Extract LEARNED_PROFILES before replaceState modifies state
+    juce::ValueTree profilesTree;
+    if (state.isValid()) {
+      profilesTree = state.getChildWithName("LEARNED_PROFILES");
+    }
+
+    if (!profilesTree.isValid()) {
+      juce::XmlElement* xmlProfiles = xmlState->getChildByName("LEARNED_PROFILES");
+      if (xmlProfiles != nullptr) {
+        profilesTree = juce::ValueTree::fromXml(*xmlProfiles);
+      }
+    }
+
+    if (state.isValid()) {
+      parameters.replaceState(state);
+    }
+
     if (profilesTree.isValid()) {
+      bool hasCh1 = false;
       for (int i = 0; i < profilesTree.getNumChildren(); ++i) {
         juce::ValueTree node = profilesTree.getChild(i);
+        int channel = node.getProperty("channel", 0);
+        if (channel == 1) hasCh1 = true;
+
         int mode = node.getProperty("mode", 0);
         uint32_t size = static_cast<uint32_t>(
             static_cast<int>(node.getProperty("size", 0)));
@@ -812,21 +936,34 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
               mb.getSize() >= size * sizeof(float)) {
             const float* floatArray =
                 reinterpret_cast<const float*>(mb.getData());
-            if (node.hasType("PROFILE_1D")) {
-              if (specbleach1D_L)
-                specbleach_load_noise_profile_for_mode(
-                    specbleach1D_L, floatArray, size, blockCount, mode);
-              if (specbleach1D_R)
-                specbleach_load_noise_profile_for_mode(
-                    specbleach1D_R, floatArray, size, blockCount, mode);
-            } else if (node.hasType("PROFILE_2D")) {
-              if (specbleach2D_L)
-                specbleach_2d_load_noise_profile_for_mode(
-                    specbleach2D_L, floatArray, size, blockCount, mode);
-              if (specbleach2D_R)
-                specbleach_2d_load_noise_profile_for_mode(
-                    specbleach2D_R, floatArray, size, blockCount, mode);
-            }
+
+            PendingProfile pp;
+            pp.channel = channel;
+            pp.mode = mode;
+            pp.size = size;
+            pp.blockCount = blockCount;
+            pp.data.assign(floatArray, floatArray + size);
+            pendingProfiles.push_back(pp);
+
+            auto h1D = (channel == 1) ? specbleach1D_R : specbleach1D_L;
+            auto h2D = (channel == 1) ? specbleach2D_R : specbleach2D_L;
+
+            if (h1D)
+              loadProfile1DSafe(h1D, floatArray, size, blockCount, mode);
+            if (h2D)
+              loadProfile2DSafe(h2D, floatArray, size, blockCount, mode);
+          }
+        }
+      }
+
+      // If legacy profile had no Channel 1 profile, copy Channel 0 to Channel 1 handles
+      if (!hasCh1) {
+        for (const auto& pp : pendingProfiles) {
+          if (pp.channel == 0) {
+            if (specbleach1D_R)
+              loadProfile1DSafe(specbleach1D_R, pp.data.data(), pp.size, pp.blockCount, pp.mode);
+            if (specbleach2D_R)
+              loadProfile2DSafe(specbleach2D_R, pp.data.data(), pp.size, pp.blockCount, pp.mode);
           }
         }
       }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -23,752 +23,821 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cstring>
 
 NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
-    : AudioProcessor(BusesProperties()
-                     .withInput("Input", juce::AudioChannelSet::stereo(), true)
-                     .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
-      parameters(*this, nullptr, "PARAMETERS", createParameterLayout())
-{
+    : AudioProcessor(
+          BusesProperties()
+              .withInput("Input", juce::AudioChannelSet::stereo(), true)
+              .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+      parameters(*this, nullptr, "PARAMETERS", createParameterLayout()),
+      dryWetMixer(16384) {
+  bypassParameter = dynamic_cast<juce::AudioParameterBool*>(
+      parameters.getParameter("bypass"));
 }
 
-NoiseRepellentAudioProcessor::~NoiseRepellentAudioProcessor()
-{
-    releaseResources();
+NoiseRepellentAudioProcessor::~NoiseRepellentAudioProcessor() {
+  releaseResources();
 }
 
-juce::AudioProcessorValueTreeState::ParameterLayout NoiseRepellentAudioProcessor::createParameterLayout()
-{
-    std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
-
-    params.push_back(std::make_unique<juce::AudioParameterChoice>(
-        "algorithm_mode", "Algorithm", juce::StringArray{ "1D Spectral", "2D NLM Patch HQ" }, 1));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "learn_noise", "Learn Noise", false));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "adaptive_noise", "Adaptive Noise", false));
-
-    params.push_back(std::make_unique<juce::AudioParameterChoice>(
-        "adaptive_method", "Estimation Method",
-        juce::StringArray{ "SPP-MMSE (Unbiased)", "Brandt (Trimmed Mean)", "Martin (Min Statistics)" }, 2));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "aggressiveness", "Aggressiveness", juce::NormalisableRange<float>(-1.0f, 1.0f, 0.1f), 0.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "link_reduction", "Link Reduction", true));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "reduction_amount", "Master Reduction", juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "tonal_reduction", "Tonal Reduction", juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "smoothing_factor", "Smoothing", juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 0.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "nlm_smoothing", "NLM Smoothing", juce::NormalisableRange<float>(0.1f, 10.0f, 0.1f), 5.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "masking_depth", "Masking Protect", juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 100.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "whitening_factor", "Whitening", juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 0.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        "suppression_strength", "Suppression", juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 50.0f));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "residual_listen", "Residual Listen", false));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "bypass", "Bypass", false));
-
-    params.push_back(std::make_unique<juce::AudioParameterBool>(
-        "show_advanced", "Show Advanced Controls", false));
-
-    return { params.begin(), params.end() };
+juce::AudioProcessorParameter*
+NoiseRepellentAudioProcessor::getBypassParameter() const {
+  return bypassParameter;
 }
 
-void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate)
-{
-    bool needNewEngines = (specbleach1D_L == nullptr || std::abs(currentSampleRate - sampleRate) > 0.001);
+juce::AudioProcessorValueTreeState::ParameterLayout
+NoiseRepellentAudioProcessor::createParameterLayout() {
+  std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
 
-    if (!needNewEngines)
-        return;
+  params.push_back(std::make_unique<juce::AudioParameterChoice>(
+      "algorithm_mode", "Algorithm",
+      juce::StringArray{"1D Spectral", "2D NLM Patch HQ"}, 1));
 
-    struct SavedProfileData {
-        int mode;
-        uint32_t size;
-        uint32_t blockCount;
-        std::vector<float> data;
-    };
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "learn_noise", "Learn Noise", false));
 
-    std::vector<SavedProfileData> profiles1D;
-    std::vector<SavedProfileData> profiles2D;
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "adaptive_noise", "Adaptive Noise", false));
 
-    // Backup 1D profiles if handles exist
+  params.push_back(std::make_unique<juce::AudioParameterChoice>(
+      "adaptive_method", "Estimation Method",
+      juce::StringArray{"SPP-MMSE (Unbiased)", "Brandt (Trimmed Mean)",
+                        "Martin (Min Statistics)"},
+      2));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "aggressiveness", "Aggressiveness",
+      juce::NormalisableRange<float>(-1.0f, 1.0f, 0.1f), 0.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "link_reduction", "Link Reduction", true,
+      juce::AudioParameterBoolAttributes().withAutomatable(false).withMeta(
+          true)));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "reduction_amount", "Master Reduction",
+      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "tonal_reduction", "Tonal Reduction",
+      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "smoothing_factor", "Smoothing",
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 0.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "masking_depth", "Masking Protect",
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 100.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "whitening_factor", "Whitening",
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 0.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "suppression_strength", "Suppression",
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 50.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "residual_listen", "Residual Listen", false));
+
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "bypass", "Internal Bypass", false));
+
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "show_advanced", "Show Advanced Controls", false,
+      juce::AudioParameterBoolAttributes().withAutomatable(false).withMeta(
+          true)));
+
+  return {params.begin(), params.end()};
+}
+
+void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
+  bool needNewEngines = (specbleach1D_L == nullptr ||
+                         std::abs(currentSampleRate - sampleRate) > 0.001);
+
+  if (!needNewEngines)
+    return;
+
+  struct SavedProfileData {
+    int mode;
+    uint32_t size;
+    uint32_t blockCount;
+    std::vector<float> data;
+  };
+
+  std::vector<SavedProfileData> profiles1D;
+  std::vector<SavedProfileData> profiles2D;
+
+  // Backup 1D profiles if handles exist
+  if (specbleach1D_L) {
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode)) {
+        float* p = specbleach_get_noise_profile_for_mode(specbleach1D_L, mode);
+        uint32_t sz = specbleach_get_noise_profile_size(specbleach1D_L);
+        uint32_t bc = specbleach_get_noise_profile_block_count_for_mode(
+            specbleach1D_L, mode);
+        if (p && sz > 0) {
+          profiles1D.push_back({mode, sz, bc, std::vector<float>(p, p + sz)});
+        }
+      }
+    }
+  }
+
+  // Backup 2D profiles if handles exist
+  if (specbleach2D_L) {
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L,
+                                                         mode)) {
+        float* p =
+            specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, mode);
+        uint32_t sz = specbleach_2d_get_noise_profile_size(specbleach2D_L);
+        uint32_t bc = specbleach_2d_get_noise_profile_block_count_for_mode(
+            specbleach2D_L, mode);
+        if (p && sz > 0) {
+          profiles2D.push_back({mode, sz, bc, std::vector<float>(p, p + sz)});
+        }
+      }
+    }
+  }
+
+  // Free existing handles
+  if (specbleach1D_L)
+    specbleach_free(specbleach1D_L);
+  if (specbleach1D_R)
+    specbleach_free(specbleach1D_R);
+  if (specbleach2D_L)
+    specbleach_2d_free(specbleach2D_L);
+  if (specbleach2D_R)
+    specbleach_2d_free(specbleach2D_R);
+
+  // Initialize per-channel instances
+  specbleach1D_L =
+      specbleach_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
+  specbleach1D_R =
+      specbleach_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
+  specbleach2D_L =
+      specbleach_2d_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
+  specbleach2D_R =
+      specbleach_2d_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
+
+  currentSampleRate = sampleRate;
+
+  // Restore saved profiles into new handles
+  for (const auto& item : profiles1D) {
     if (specbleach1D_L)
-    {
-        for (int mode = 1; mode <= 4; ++mode)
-        {
-            if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode))
-            {
-                float* p = specbleach_get_noise_profile_for_mode(specbleach1D_L, mode);
-                uint32_t sz = specbleach_get_noise_profile_size(specbleach1D_L);
-                uint32_t bc = specbleach_get_noise_profile_block_count_for_mode(specbleach1D_L, mode);
-                if (p && sz > 0)
-                {
-                    profiles1D.push_back({ mode, sz, bc, std::vector<float>(p, p + sz) });
-                }
-            }
-        }
-    }
+      specbleach_load_noise_profile_for_mode(specbleach1D_L, item.data.data(),
+                                             item.size, item.blockCount,
+                                             item.mode);
+    if (specbleach1D_R)
+      specbleach_load_noise_profile_for_mode(specbleach1D_R, item.data.data(),
+                                             item.size, item.blockCount,
+                                             item.mode);
+  }
 
-    // Backup 2D profiles if handles exist
+  for (const auto& item : profiles2D) {
     if (specbleach2D_L)
-    {
-        for (int mode = 1; mode <= 4; ++mode)
-        {
-            if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, mode))
-            {
-                float* p = specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, mode);
-                uint32_t sz = specbleach_2d_get_noise_profile_size(specbleach2D_L);
-                uint32_t bc = specbleach_2d_get_noise_profile_block_count_for_mode(specbleach2D_L, mode);
-                if (p && sz > 0)
-                {
-                    profiles2D.push_back({ mode, sz, bc, std::vector<float>(p, p + sz) });
-                }
-            }
-        }
-    }
+      specbleach_2d_load_noise_profile_for_mode(specbleach2D_L,
+                                                item.data.data(), item.size,
+                                                item.blockCount, item.mode);
+    if (specbleach2D_R)
+      specbleach_2d_load_noise_profile_for_mode(specbleach2D_R,
+                                                item.data.data(), item.size,
+                                                item.blockCount, item.mode);
+  }
 
-    // Free existing handles
-    if (specbleach1D_L) specbleach_free(specbleach1D_L);
-    if (specbleach1D_R) specbleach_free(specbleach1D_R);
-    if (specbleach2D_L) specbleach_2d_free(specbleach2D_L);
-    if (specbleach2D_R) specbleach_2d_free(specbleach2D_R);
-
-    // Initialize per-channel instances
-    specbleach1D_L = specbleach_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
-    specbleach1D_R = specbleach_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
-    specbleach2D_L = specbleach_2d_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
-    specbleach2D_R = specbleach_2d_initialize(static_cast<uint32_t>(sampleRate), 50.0f);
-
-    currentSampleRate = sampleRate;
-
-    // Restore saved profiles into new handles
-    for (const auto& item : profiles1D)
-    {
-        if (specbleach1D_L)
-            specbleach_load_noise_profile_for_mode(specbleach1D_L, item.data.data(), item.size, item.blockCount, item.mode);
-        if (specbleach1D_R)
-            specbleach_load_noise_profile_for_mode(specbleach1D_R, item.data.data(), item.size, item.blockCount, item.mode);
-    }
-
-    for (const auto& item : profiles2D)
-    {
-        if (specbleach2D_L)
-            specbleach_2d_load_noise_profile_for_mode(specbleach2D_L, item.data.data(), item.size, item.blockCount, item.mode);
-        if (specbleach2D_R)
-            specbleach_2d_load_noise_profile_for_mode(specbleach2D_R, item.data.data(), item.size, item.blockCount, item.mode);
-    }
-
-    // Synchronize loaded profiles between engines
-    syncNoiseProfiles(0);
-    syncNoiseProfiles(1);
+  // Synchronize loaded profiles between engines
+  syncNoiseProfiles(0);
+  syncNoiseProfiles(1);
 }
 
-void NoiseRepellentAudioProcessor::syncNoiseProfiles(int sourceAlgoMode)
-{
-    auto syncHandle = [](auto getProfileFn, auto getSizeFn, auto getBlockCountFn, auto isAvailableFn,
-                         auto loadFn, auto targetHandle, auto sourceHandle) {
-        if (!sourceHandle || !targetHandle) return;
+void NoiseRepellentAudioProcessor::syncNoiseProfiles(int sourceAlgoMode) {
+  auto syncHandle = [](auto getProfileFn, auto getSizeFn, auto getBlockCountFn,
+                       auto isAvailableFn, auto loadFn, auto targetHandle,
+                       auto sourceHandle) {
+    if (!sourceHandle || !targetHandle)
+      return;
 
-        uint32_t sz = getSizeFn(sourceHandle);
-        if (sz == 0) return;
+    uint32_t sz = getSizeFn(sourceHandle);
+    if (sz == 0)
+      return;
 
-        // Find a fallback profile (first available mode in source handle)
-        float* fallbackP = nullptr;
-        uint32_t fallbackBc = 0;
+    // Find a fallback profile (first available mode in source handle)
+    float* fallbackP = nullptr;
+    uint32_t fallbackBc = 0;
 
-        for (int m = 1; m <= 4; ++m) {
-            if (isAvailableFn(sourceHandle, m)) {
-                fallbackP = getProfileFn(sourceHandle, m);
-                fallbackBc = getBlockCountFn(sourceHandle, m);
-                break;
-            }
-        }
-
-        if (!fallbackP) return; // No profile learned in source handle yet
-
-        // Load available mode profiles or use fallback so no target mode is left empty
-        for (int mode = 1; mode <= 4; ++mode) {
-            if (isAvailableFn(sourceHandle, mode)) {
-                float* p = getProfileFn(sourceHandle, mode);
-                uint32_t bc = getBlockCountFn(sourceHandle, mode);
-                if (p) {
-                    loadFn(targetHandle, p, sz, bc, mode);
-                }
-            } else {
-                loadFn(targetHandle, fallbackP, sz, fallbackBc, mode);
-            }
-        }
-    };
-
-    if (sourceAlgoMode == 0)
-    {
-        // Sync 1D -> 2D
-        syncHandle(specbleach_get_noise_profile_for_mode,
-                   specbleach_get_noise_profile_size,
-                   specbleach_get_noise_profile_block_count_for_mode,
-                   specbleach_noise_profile_available_for_mode,
-                   specbleach_2d_load_noise_profile_for_mode,
-                   specbleach2D_L, specbleach1D_L);
-
-        syncHandle(specbleach_get_noise_profile_for_mode,
-                   specbleach_get_noise_profile_size,
-                   specbleach_get_noise_profile_block_count_for_mode,
-                   specbleach_noise_profile_available_for_mode,
-                   specbleach_2d_load_noise_profile_for_mode,
-                   specbleach2D_R, specbleach1D_R);
+    for (int m = 1; m <= 4; ++m) {
+      if (isAvailableFn(sourceHandle, m)) {
+        fallbackP = getProfileFn(sourceHandle, m);
+        fallbackBc = getBlockCountFn(sourceHandle, m);
+        break;
+      }
     }
-    else if (sourceAlgoMode == 1)
-    {
-        // Sync 2D -> 1D
-        syncHandle(specbleach_2d_get_noise_profile_for_mode,
-                   specbleach_2d_get_noise_profile_size,
-                   specbleach_2d_get_noise_profile_block_count_for_mode,
-                   specbleach_2d_noise_profile_available_for_mode,
-                   specbleach_load_noise_profile_for_mode,
-                   specbleach1D_L, specbleach2D_L);
 
-        syncHandle(specbleach_2d_get_noise_profile_for_mode,
-                   specbleach_2d_get_noise_profile_size,
-                   specbleach_2d_get_noise_profile_block_count_for_mode,
-                   specbleach_2d_noise_profile_available_for_mode,
-                   specbleach_load_noise_profile_for_mode,
-                   specbleach1D_R, specbleach2D_R);
+    if (!fallbackP)
+      return; // No profile learned in source handle yet
+
+    // Load available mode profiles or use fallback so no target mode is left
+    // empty
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (isAvailableFn(sourceHandle, mode)) {
+        float* p = getProfileFn(sourceHandle, mode);
+        uint32_t bc = getBlockCountFn(sourceHandle, mode);
+        if (p) {
+          loadFn(targetHandle, p, sz, bc, mode);
+        }
+      } else {
+        loadFn(targetHandle, fallbackP, sz, fallbackBc, mode);
+      }
     }
+  };
+
+  if (sourceAlgoMode == 0) {
+    // Sync 1D -> 2D
+    syncHandle(specbleach_get_noise_profile_for_mode,
+               specbleach_get_noise_profile_size,
+               specbleach_get_noise_profile_block_count_for_mode,
+               specbleach_noise_profile_available_for_mode,
+               specbleach_2d_load_noise_profile_for_mode, specbleach2D_L,
+               specbleach1D_L);
+
+    syncHandle(specbleach_get_noise_profile_for_mode,
+               specbleach_get_noise_profile_size,
+               specbleach_get_noise_profile_block_count_for_mode,
+               specbleach_noise_profile_available_for_mode,
+               specbleach_2d_load_noise_profile_for_mode, specbleach2D_R,
+               specbleach1D_R);
+  } else if (sourceAlgoMode == 1) {
+    // Sync 2D -> 1D
+    syncHandle(specbleach_2d_get_noise_profile_for_mode,
+               specbleach_2d_get_noise_profile_size,
+               specbleach_2d_get_noise_profile_block_count_for_mode,
+               specbleach_2d_noise_profile_available_for_mode,
+               specbleach_load_noise_profile_for_mode, specbleach1D_L,
+               specbleach2D_L);
+
+    syncHandle(specbleach_2d_get_noise_profile_for_mode,
+               specbleach_2d_get_noise_profile_size,
+               specbleach_2d_get_noise_profile_block_count_for_mode,
+               specbleach_2d_noise_profile_available_for_mode,
+               specbleach_load_noise_profile_for_mode, specbleach1D_R,
+               specbleach2D_R);
+  }
 }
 
-void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
-{
-    ensureEnginesInitialized(sampleRate);
+void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
+                                                 int samplesPerBlock) {
+  ensureEnginesInitialized(sampleRate);
 
-    // Set initial latency based on current algorithm mode
-    currentAlgoMode = static_cast<int>(parameters.getRawParameterValue("algorithm_mode")->load());
+  // Set initial latency based on current algorithm mode
+  currentAlgoMode = static_cast<int>(
+      parameters.getRawParameterValue("algorithm_mode")->load());
+  uint32_t latency = 0;
+  if (currentAlgoMode == 0 && specbleach1D_L) {
+    latency = specbleach_get_latency(specbleach1D_L);
+  } else if (currentAlgoMode == 1 && specbleach2D_L) {
+    latency = specbleach_2d_get_latency(specbleach2D_L);
+  }
+  setLatencySamples(static_cast<int>(latency));
+
+  juce::dsp::ProcessSpec spec;
+  spec.sampleRate = sampleRate;
+  spec.maximumBlockSize = static_cast<juce::uint32>(samplesPerBlock);
+  spec.numChannels = static_cast<juce::uint32>(getTotalNumOutputChannels());
+
+  dryWetMixer.prepare(spec);
+  dryWetMixer.setMixingRule(juce::dsp::DryWetMixingRule::linear);
+  dryWetMixer.setWetLatency(static_cast<float>(latency));
+
+  // Prepare buffer and state for engine crossfading
+  crossfadeBuffer.setSize(getTotalNumOutputChannels(), samplesPerBlock, false,
+                          false, true);
+  crossfadeProgress = 1.0f;
+  targetAlgoMode = currentAlgoMode;
+
+  // Reset FFT accumulation
+  fftAccumInput.fill(0.0f);
+  fftAccumOutput.fill(0.0f);
+  fftAccumCount = 0;
+}
+
+void NoiseRepellentAudioProcessor::releaseResources() {
+  dryWetMixer.reset();
+}
+
+bool NoiseRepellentAudioProcessor::isBusesLayoutSupported(
+    const BusesLayout& layouts) const {
+  if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono() &&
+      layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+    return false;
+
+  return layouts.getMainOutputChannelSet() == layouts.getMainInputChannelSet();
+}
+
+void NoiseRepellentAudioProcessor::processBlock(
+    juce::AudioBuffer<float>& buffer, juce::MidiBuffer&) {
+  juce::ScopedNoDenormals noDenormals;
+  const int numSamples = buffer.getNumSamples();
+  const int numChannels = buffer.getNumChannels();
+
+  const bool isBypassed =
+      parameters.getRawParameterValue("bypass")->load() > 0.5f;
+  const int algoMode = static_cast<int>(
+      parameters.getRawParameterValue("algorithm_mode")->load());
+  const bool learnNoise =
+      parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
+  const bool adaptiveNoise =
+      parameters.getRawParameterValue("adaptive_noise")->load() > 0.5f;
+  const int adaptiveMethod = static_cast<int>(
+      parameters.getRawParameterValue("adaptive_method")->load());
+  const float aggressiveness =
+      parameters.getRawParameterValue("aggressiveness")->load();
+
+  const bool linkReduction =
+      parameters.getRawParameterValue("link_reduction")->load() > 0.5f;
+  const float masterRed =
+      parameters.getRawParameterValue("reduction_amount")->load();
+  const float tonalRed =
+      linkReduction
+          ? masterRed
+          : parameters.getRawParameterValue("tonal_reduction")->load();
+
+  const float smoothing =
+      parameters.getRawParameterValue("smoothing_factor")->load();
+
+  // Masking: apply cubic curve mapping (matches original LV2 behavior)
+  const float maskingRaw =
+      parameters.getRawParameterValue("masking_depth")->load() / 100.0f;
+  const float masking = 1.0f - std::pow(1.0f - maskingRaw, 3.0f);
+
+  const float whitening =
+      parameters.getRawParameterValue("whitening_factor")->load();
+
+  // Suppression: pass raw 0-100 value — libspecbleach divides by 100 internally
+  const float suppression =
+      parameters.getRawParameterValue("suppression_strength")->load();
+
+  const bool residualListen =
+      parameters.getRawParameterValue("residual_listen")->load() > 0.5f;
+
+  // Sync profiles if manual noise learning was just turned off
+  if (wasLearning && !learnNoise) {
+    syncNoiseProfiles(currentAlgoMode);
+  }
+  wasLearning = learnNoise;
+
+  // Update latency dynamically, sync profiles, and start smooth crossfade when
+  // algorithm mode changes
+  if (algoMode != currentAlgoMode) {
+    syncNoiseProfiles(currentAlgoMode);
+    targetAlgoMode = algoMode;
+    currentAlgoMode = algoMode;
+
+    // Initiate 30 ms smooth crossfade transition to prevent clicks/pops
+    int crossfadeSamples = static_cast<int>(currentSampleRate * 0.030);
+    if (crossfadeSamples < 1)
+      crossfadeSamples = 1;
+    crossfadeProgress = 0.0f;
+    crossfadeStep = 1.0f / static_cast<float>(crossfadeSamples);
+
     uint32_t latency = 0;
-    if (currentAlgoMode == 0 && specbleach1D_L) {
-        latency = specbleach_get_latency(specbleach1D_L);
-    } else if (currentAlgoMode == 1 && specbleach2D_L) {
-        latency = specbleach_2d_get_latency(specbleach2D_L);
+    if (algoMode == 0 && specbleach1D_L) {
+      latency = specbleach_get_latency(specbleach1D_L);
+    } else if (algoMode == 1 && specbleach2D_L) {
+      latency = specbleach_2d_get_latency(specbleach2D_L);
     }
     setLatencySamples(static_cast<int>(latency));
-
-    juce::dsp::ProcessSpec spec;
-    spec.sampleRate = sampleRate;
-    spec.maximumBlockSize = static_cast<juce::uint32>(samplesPerBlock);
-    spec.numChannels = static_cast<juce::uint32>(getTotalNumOutputChannels());
-
-    dryWetMixer.prepare(spec);
-    dryWetMixer.setMixingRule(juce::dsp::DryWetMixingRule::linear);
     dryWetMixer.setWetLatency(static_cast<float>(latency));
+  }
 
-    // Prepare buffer and state for engine crossfading
-    crossfadeBuffer.setSize(getTotalNumOutputChannels(), samplesPerBlock, false, false, true);
-    crossfadeProgress = 1.0f;
-    targetAlgoMode = currentAlgoMode;
+  // Save dry input copy for FFT visualization before processing
+  std::vector<float> dryInputL(static_cast<size_t>(numSamples));
+  if (numChannels >= 1)
+    std::copy_n(buffer.getReadPointer(0), numSamples, dryInputL.begin());
 
-    // Reset FFT accumulation
-    fftAccumInput.fill(0.0f);
-    fftAccumOutput.fill(0.0f);
-    fftAccumCount = 0;
+  // Push dry samples into JUCE DryWetMixer before in-place DSP processing
+  juce::dsp::AudioBlock<float> audioBlock(buffer);
+  dryWetMixer.pushDrySamples(audioBlock);
+
+  // Prepare parameters for DSP engines
+  SpectralBleachDenoiserParameters p;
+  p.learn_noise = learnNoise ? 1 : 0;
+  p.residual_listen = residualListen;
+  p.reduction_amount = masterRed;
+  p.smoothing_factor = smoothing;
+  p.whitening_factor = whitening;
+  p.adaptive_noise = adaptiveNoise ? 1 : 0;
+  p.noise_estimation_method = adaptiveMethod;
+  p.masking_depth = masking;
+  p.suppression_strength = suppression;
+  p.aggressiveness = aggressiveness;
+  p.tonal_reduction = tonalRed;
+
+  SpectralBleach2DDenoiserParameters p2;
+  p2.learn_noise = learnNoise ? 1 : 0;
+  p2.residual_listen = residualListen;
+  p2.reduction_amount = masterRed;
+  p2.smoothing_factor = smoothing;
+  p2.whitening_factor = whitening;
+  p2.adaptive_noise = adaptiveNoise ? 1 : 0;
+  p2.noise_estimation_method = adaptiveMethod;
+  p2.nlm_masking_protection = masking;
+  p2.suppression_strength = suppression;
+  p2.aggressiveness = aggressiveness;
+  p2.tonal_reduction = tonalRed;
+
+  if (crossfadeProgress < 1.0f) {
+    // Smooth crossfade mode: run both engines and blend sample-by-sample
+    if (crossfadeBuffer.getNumChannels() < numChannels ||
+        crossfadeBuffer.getNumSamples() < numSamples)
+      crossfadeBuffer.setSize(numChannels, numSamples, false, false, true);
+
+    for (int ch = 0; ch < numChannels; ++ch)
+      std::copy_n(buffer.getReadPointer(ch), numSamples,
+                  crossfadeBuffer.getWritePointer(ch));
+
+    // Process 1D on buffer
+    if (specbleach1D_L) {
+      specbleach_load_parameters(specbleach1D_L, p);
+      float* ch0 = buffer.getWritePointer(0);
+      specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0,
+                         ch0);
+    }
+    if (numChannels >= 2 && specbleach1D_R) {
+      specbleach_load_parameters(specbleach1D_R, p);
+      float* ch1 = buffer.getWritePointer(1);
+      specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1,
+                         ch1);
+    }
+
+    // Process 2D on crossfadeBuffer
+    if (specbleach2D_L) {
+      specbleach_2d_load_parameters(specbleach2D_L, p2);
+      float* ch0 = crossfadeBuffer.getWritePointer(0);
+      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples),
+                            ch0, ch0);
+    }
+    if (numChannels >= 2 && specbleach2D_R) {
+      specbleach_2d_load_parameters(specbleach2D_R, p2);
+      float* ch1 = crossfadeBuffer.getWritePointer(1);
+      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples),
+                            ch1, ch1);
+    }
+
+    // Equal-power crossfade blend into buffer
+    for (int ch = 0; ch < numChannels; ++ch) {
+      float* out1D = buffer.getWritePointer(ch);
+      const float* out2D = crossfadeBuffer.getReadPointer(ch);
+
+      float currentP = crossfadeProgress;
+      for (int s = 0; s < numSamples; ++s) {
+        float pVal = std::min(1.0f, currentP);
+        float rad = pVal * juce::MathConstants<float>::halfPi;
+        float w1D = (targetAlgoMode == 1) ? std::cos(rad) : std::sin(rad);
+        float w2D = (targetAlgoMode == 1) ? std::sin(rad) : std::cos(rad);
+
+        out1D[s] = w1D * out1D[s] + w2D * out2D[s];
+        currentP += crossfadeStep;
+      }
+    }
+    crossfadeProgress += numSamples * crossfadeStep;
+    if (crossfadeProgress > 1.0f)
+      crossfadeProgress = 1.0f;
+  } else if (algoMode == 0) {
+    // Steady-state 1D mode
+    if (specbleach1D_L) {
+      specbleach_load_parameters(specbleach1D_L, p);
+      float* ch0 = buffer.getWritePointer(0);
+      specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0,
+                         ch0);
+    }
+    if (numChannels >= 2 && specbleach1D_R) {
+      specbleach_load_parameters(specbleach1D_R, p);
+      float* ch1 = buffer.getWritePointer(1);
+      specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1,
+                         ch1);
+    }
+  } else if (algoMode == 1) {
+    // Steady-state 2D mode
+    if (specbleach2D_L) {
+      specbleach_2d_load_parameters(specbleach2D_L, p2);
+      float* ch0 = buffer.getWritePointer(0);
+      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples),
+                            ch0, ch0);
+    }
+    if (numChannels >= 2 && specbleach2D_R) {
+      specbleach_2d_load_parameters(specbleach2D_R, p2);
+      float* ch1 = buffer.getWritePointer(1);
+      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples),
+                            ch1, ch1);
+    }
+  }
+
+  // Apply Soft Crossfade Bypass using JUCE DryWetMixer (with dry latency
+  // compensation)
+  dryWetMixer.setWetMixProportion(isBypassed ? 0.0f : 1.0f);
+  dryWetMixer.mixWetSamples(audioBlock);
+
+  // ── FFT-based spectral frame for GUI visualization ──
+  // Accumulate samples until we have a full FFT window (kFftSize samples)
+  const float* inputSrc = dryInputL.data();
+  const float* outputSrc =
+      (numChannels >= 1) ? buffer.getReadPointer(0) : nullptr;
+
+  for (int s = 0; s < numSamples; ++s) {
+    if (fftAccumCount < kFftSize) {
+      fftAccumInput[fftAccumCount] = inputSrc[s];
+      fftAccumOutput[fftAccumCount] = outputSrc ? outputSrc[s] : 0.0f;
+      fftAccumCount++;
+    }
+
+    if (fftAccumCount >= kFftSize) {
+      // We have a full FFT frame — compute and push to ring buffer
+      int start1, size1, start2, size2;
+      spectralFifo.prepareToWrite(1, start1, size1, start2, size2);
+
+      if (size1 > 0) {
+        SpectralFrame& frame = spectralBuffer[static_cast<size_t>(start1)];
+
+        // ── Input FFT ──
+        std::memcpy(fftInputWork.data(), fftAccumInput.data(),
+                    kFftSize * sizeof(float));
+        std::fill(fftInputWork.begin() + kFftSize, fftInputWork.end(), 0.0f);
+        fftWindow.multiplyWithWindowingTable(fftInputWork.data(), kFftSize);
+        fftAnalyzer.performFrequencyOnlyForwardTransform(fftInputWork.data());
+
+        for (size_t i = 0; i < kFftBins; ++i) {
+          float mag = fftInputWork[i] / static_cast<float>(kFftBins);
+          frame.inputMagnitudeDB[i] = 20.0f * std::log10(std::max(mag, 1e-7f));
+        }
+
+        // ── Output FFT ──
+        std::memcpy(fftOutputWork.data(), fftAccumOutput.data(),
+                    kFftSize * sizeof(float));
+        std::fill(fftOutputWork.begin() + kFftSize, fftOutputWork.end(), 0.0f);
+        fftWindow.multiplyWithWindowingTable(fftOutputWork.data(), kFftSize);
+        fftAnalyzer.performFrequencyOnlyForwardTransform(fftOutputWork.data());
+
+        for (size_t i = 0; i < kFftBins; ++i) {
+          float mag = fftOutputWork[i] / static_cast<float>(kFftBins);
+          frame.outputMagnitudeDB[i] = 20.0f * std::log10(std::max(mag, 1e-7f));
+        }
+
+        // ── Noise profile from libspecbleach (stationary or live adaptive) ──
+        const float* actualNoiseProfile = nullptr;
+        uint32_t profileSize = 0;
+        bool profileAvailable = false;
+
+        bool isAdaptive = adaptiveNoise;
+
+        if (algoMode == 0 && specbleach1D_L &&
+            (isAdaptive ||
+             specbleach_noise_profile_available_for_mode(specbleach1D_L, 1))) {
+          actualNoiseProfile =
+              specbleach_get_active_noise_profile(specbleach1D_L);
+          profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
+          profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+        } else if (algoMode == 1 && specbleach2D_L &&
+                   (isAdaptive ||
+                    specbleach_2d_noise_profile_available_for_mode(
+                        specbleach2D_L, 1))) {
+          actualNoiseProfile =
+              specbleach_2d_get_active_noise_profile(specbleach2D_L);
+          profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
+          profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+        }
+
+        frame.hasNoiseProfile = profileAvailable;
+        frame.isLinked =
+            (parameters.getRawParameterValue("link_reduction")->load() > 0.5f);
+        frame.tonalPeaksHz.clear();
+
+        if (profileAvailable && actualNoiseProfile) {
+          // In 2D mode, noise_profile_size is
+          // SB_PROCESSOR_CORE_FULL_FFT_SPECTRUM (e.g. 3008 bins). The real
+          // unique spectrum from DC (0 Hz) to Nyquist (Fs/2) is the first
+          // (profileSize / 2) + 1 bins.
+          size_t realProfileBins = profileSize;
+
+          const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
+          const float maxFftIdx = static_cast<float>(kFftBins - 1);
+          // FFTW unnormalized power scaling offset: 20 * log10(N/2)
+          const float dbOffset = (maxProfileIdx > 0.0f)
+                                     ? (20.0f * std::log10(maxProfileIdx))
+                                     : 0.0f;
+
+          for (size_t i = 0; i < kFftBins; ++i) {
+            float normPos = static_cast<float>(i) / maxFftIdx;
+            float exactP = normPos * maxProfileIdx;
+
+            size_t p0 = std::clamp(static_cast<size_t>(exactP),
+                                   static_cast<size_t>(0), realProfileBins - 1);
+            size_t p1 = std::min(p0 + 1, realProfileBins - 1);
+            float frac = exactP - static_cast<float>(p0);
+
+            float val0 = actualNoiseProfile[p0];
+            float val1 = actualNoiseProfile[p1];
+            float interpVal = (1.0f - frac) * val0 + frac * val1;
+
+            float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
+            frame.noiseFloorDB[i] = rawDb - dbOffset;
+          }
+
+          // Query libspecbleach directly for reported tonal peak frequencies
+          // computed on this real noise profile
+          std::array<float, 16> peakBuf{};
+          uint32_t numPeaks = 0;
+          if (algoMode == 0 && specbleach1D_L) {
+            numPeaks = specbleach_get_tonal_peaks_for_profile(
+                specbleach1D_L, actualNoiseProfile,
+                static_cast<uint32_t>(realProfileBins), peakBuf.data(),
+                static_cast<uint32_t>(peakBuf.size()));
+          } else if (algoMode == 1 && specbleach2D_L) {
+            numPeaks = specbleach_2d_get_tonal_peaks_for_profile(
+                specbleach2D_L, actualNoiseProfile,
+                static_cast<uint32_t>(realProfileBins), peakBuf.data(),
+                static_cast<uint32_t>(peakBuf.size()));
+          }
+
+          for (uint32_t i = 0; i < numPeaks; ++i) {
+            frame.tonalPeaksHz.push_back(peakBuf[i]);
+          }
+        } else {
+          frame.noiseFloorDB.fill(-120.0f);
+        }
+
+        spectralFifo.finishedWrite(1);
+      }
+
+      // Shift: keep last quarter for overlap (hop = 75%)
+      constexpr size_t kHop = kFftSize / 4;
+      std::memmove(fftAccumInput.data(), fftAccumInput.data() + kHop,
+                   (kFftSize - kHop) * sizeof(float));
+      std::memmove(fftAccumOutput.data(), fftAccumOutput.data() + kHop,
+                   (kFftSize - kHop) * sizeof(float));
+      fftAccumCount = kFftSize - kHop;
+    }
+  }
 }
 
-void NoiseRepellentAudioProcessor::releaseResources()
-{
-    dryWetMixer.reset();
+void NoiseRepellentAudioProcessor::processBlockBypassed(
+    juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*midiMessages*/) {
+  const int numSamples = buffer.getNumSamples();
+  const int numChannels = buffer.getNumChannels();
+
+  if (numSamples == 0 || numChannels == 0)
+    return;
+
+  juce::dsp::AudioBlock<float> audioBlock(buffer);
+  dryWetMixer.pushDrySamples(audioBlock);
+  dryWetMixer.setWetMixProportion(0.0f);
+  dryWetMixer.mixWetSamples(audioBlock);
 }
 
-bool NoiseRepellentAudioProcessor::isBusesLayoutSupported(const BusesLayout& layouts) const
-{
-    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
-        && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
-        return false;
+bool NoiseRepellentAudioProcessor::getNextSpectralFrame(SpectralFrame& frame) {
+  int start1, size1, start2, size2;
+  spectralFifo.prepareToRead(1, start1, size1, start2, size2);
 
-    return layouts.getMainOutputChannelSet() == layouts.getMainInputChannelSet();
+  if (size1 > 0) {
+    frame = spectralBuffer[static_cast<size_t>(start1)];
+    spectralFifo.finishedRead(1);
+    return true;
+  }
+  return false;
 }
 
-void NoiseRepellentAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer&)
-{
-    juce::ScopedNoDenormals noDenormals;
-    const int numSamples = buffer.getNumSamples();
-    const int numChannels = buffer.getNumChannels();
-
-    const bool isBypassed = parameters.getRawParameterValue("bypass")->load() > 0.5f;
-    const int algoMode = static_cast<int>(parameters.getRawParameterValue("algorithm_mode")->load());
-    const bool learnNoise = parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
-    const bool adaptiveNoise = parameters.getRawParameterValue("adaptive_noise")->load() > 0.5f;
-    const int adaptiveMethod = static_cast<int>(parameters.getRawParameterValue("adaptive_method")->load());
-    const float aggressiveness = parameters.getRawParameterValue("aggressiveness")->load();
-
-    const bool linkReduction = parameters.getRawParameterValue("link_reduction")->load() > 0.5f;
-    const float masterRed = parameters.getRawParameterValue("reduction_amount")->load();
-    const float tonalRed = linkReduction ? masterRed : parameters.getRawParameterValue("tonal_reduction")->load();
-
-    const float smoothing = parameters.getRawParameterValue("smoothing_factor")->load();
-    const float nlmSmoothing = parameters.getRawParameterValue("nlm_smoothing")->load();
-
-    // Masking: apply cubic curve mapping (matches original LV2 behavior)
-    const float maskingRaw = parameters.getRawParameterValue("masking_depth")->load() / 100.0f;
-    const float masking = 1.0f - std::pow(1.0f - maskingRaw, 3.0f);
-
-    const float whitening = parameters.getRawParameterValue("whitening_factor")->load();
-
-    // Suppression: pass raw 0-100 value — libspecbleach divides by 100 internally
-    const float suppression = parameters.getRawParameterValue("suppression_strength")->load();
-
-    const bool residualListen = parameters.getRawParameterValue("residual_listen")->load() > 0.5f;
-
-    // Sync profiles if manual noise learning was just turned off
-    if (wasLearning && !learnNoise) {
-        syncNoiseProfiles(currentAlgoMode);
-    }
-    wasLearning = learnNoise;
-
-    // Update latency dynamically, sync profiles, and start smooth crossfade when algorithm mode changes
-    if (algoMode != currentAlgoMode) {
-        syncNoiseProfiles(currentAlgoMode);
-        targetAlgoMode = algoMode;
-        currentAlgoMode = algoMode;
-
-        // Initiate 30 ms smooth crossfade transition to prevent clicks/pops
-        int crossfadeSamples = static_cast<int>(currentSampleRate * 0.030);
-        if (crossfadeSamples < 1) crossfadeSamples = 1;
-        crossfadeProgress = 0.0f;
-        crossfadeStep = 1.0f / static_cast<float>(crossfadeSamples);
-
-        uint32_t latency = 0;
-        if (algoMode == 0 && specbleach1D_L) {
-            latency = specbleach_get_latency(specbleach1D_L);
-        } else if (algoMode == 1 && specbleach2D_L) {
-            latency = specbleach_2d_get_latency(specbleach2D_L);
-        }
-        setLatencySamples(static_cast<int>(latency));
-        dryWetMixer.setWetLatency(static_cast<float>(latency));
-    }
-
-    // Save dry input copy for FFT visualization before processing
-    std::vector<float> dryInputL(static_cast<size_t>(numSamples));
-    if (numChannels >= 1)
-        std::copy_n(buffer.getReadPointer(0), numSamples, dryInputL.begin());
-
-    // Push dry samples into JUCE DryWetMixer before in-place DSP processing
-    juce::dsp::AudioBlock<float> audioBlock(buffer);
-    dryWetMixer.pushDrySamples(audioBlock);
-
-    // Prepare parameters for DSP engines
-    SpectralBleachDenoiserParameters p;
-    p.learn_noise = learnNoise ? 1 : 0;
-    p.residual_listen = residualListen;
-    p.reduction_amount = masterRed;
-    p.smoothing_factor = smoothing;
-    p.whitening_factor = whitening;
-    p.adaptive_noise = adaptiveNoise ? 1 : 0;
-    p.noise_estimation_method = adaptiveMethod;
-    p.masking_depth = masking;
-    p.suppression_strength = suppression;
-    p.aggressiveness = aggressiveness;
-    p.tonal_reduction = tonalRed;
-
-    SpectralBleach2DDenoiserParameters p2;
-    p2.learn_noise = learnNoise ? 1 : 0;
-    p2.residual_listen = residualListen;
-    p2.reduction_amount = masterRed;
-    p2.smoothing_factor = nlmSmoothing;
-    p2.whitening_factor = whitening;
-    p2.adaptive_noise = adaptiveNoise ? 1 : 0;
-    p2.noise_estimation_method = adaptiveMethod;
-    p2.nlm_masking_protection = masking;
-    p2.suppression_strength = suppression;
-    p2.aggressiveness = aggressiveness;
-    p2.tonal_reduction = tonalRed;
-
-    if (crossfadeProgress < 1.0f)
-    {
-        // Smooth crossfade mode: run both engines and blend sample-by-sample
-        if (crossfadeBuffer.getNumChannels() < numChannels || crossfadeBuffer.getNumSamples() < numSamples)
-            crossfadeBuffer.setSize(numChannels, numSamples, false, false, true);
-
-        for (int ch = 0; ch < numChannels; ++ch)
-            std::copy_n(buffer.getReadPointer(ch), numSamples, crossfadeBuffer.getWritePointer(ch));
-
-        // Process 1D on buffer
-        if (specbleach1D_L) {
-            specbleach_load_parameters(specbleach1D_L, p);
-            float* ch0 = buffer.getWritePointer(0);
-            specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0, ch0);
-        }
-        if (numChannels >= 2 && specbleach1D_R) {
-            specbleach_load_parameters(specbleach1D_R, p);
-            float* ch1 = buffer.getWritePointer(1);
-            specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1, ch1);
-        }
-
-        // Process 2D on crossfadeBuffer
-        if (specbleach2D_L) {
-            specbleach_2d_load_parameters(specbleach2D_L, p2);
-            float* ch0 = crossfadeBuffer.getWritePointer(0);
-            specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples), ch0, ch0);
-        }
-        if (numChannels >= 2 && specbleach2D_R) {
-            specbleach_2d_load_parameters(specbleach2D_R, p2);
-            float* ch1 = crossfadeBuffer.getWritePointer(1);
-            specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples), ch1, ch1);
-        }
-
-        // Equal-power crossfade blend into buffer
-        for (int ch = 0; ch < numChannels; ++ch) {
-            float* out1D = buffer.getWritePointer(ch);
-            const float* out2D = crossfadeBuffer.getReadPointer(ch);
-
-            float currentP = crossfadeProgress;
-            for (int s = 0; s < numSamples; ++s) {
-                float pVal = std::min(1.0f, currentP);
-                float rad = pVal * juce::MathConstants<float>::halfPi;
-                float w1D = (targetAlgoMode == 1) ? std::cos(rad) : std::sin(rad);
-                float w2D = (targetAlgoMode == 1) ? std::sin(rad) : std::cos(rad);
-
-                out1D[s] = w1D * out1D[s] + w2D * out2D[s];
-                currentP += crossfadeStep;
-            }
-        }
-        crossfadeProgress += numSamples * crossfadeStep;
-        if (crossfadeProgress > 1.0f) crossfadeProgress = 1.0f;
-    }
-    else if (algoMode == 0)
-    {
-        // Steady-state 1D mode
-        if (specbleach1D_L) {
-            specbleach_load_parameters(specbleach1D_L, p);
-            float* ch0 = buffer.getWritePointer(0);
-            specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0, ch0);
-        }
-        if (numChannels >= 2 && specbleach1D_R) {
-            specbleach_load_parameters(specbleach1D_R, p);
-            float* ch1 = buffer.getWritePointer(1);
-            specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1, ch1);
-        }
-    }
-    else if (algoMode == 1)
-    {
-        // Steady-state 2D mode
-        if (specbleach2D_L) {
-            specbleach_2d_load_parameters(specbleach2D_L, p2);
-            float* ch0 = buffer.getWritePointer(0);
-            specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples), ch0, ch0);
-        }
-        if (numChannels >= 2 && specbleach2D_R) {
-            specbleach_2d_load_parameters(specbleach2D_R, p2);
-            float* ch1 = buffer.getWritePointer(1);
-            specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples), ch1, ch1);
-        }
-    }
-
-    // Apply Soft Crossfade Bypass using JUCE DryWetMixer (with dry latency compensation)
-    dryWetMixer.setWetMixProportion(isBypassed ? 0.0f : 1.0f);
-    dryWetMixer.mixWetSamples(audioBlock);
-
-    // ── FFT-based spectral frame for GUI visualization ──
-    // Accumulate samples until we have a full FFT window (kFftSize samples)
-    const float* inputSrc = dryInputL.data();
-    const float* outputSrc = (numChannels >= 1) ? buffer.getReadPointer(0) : nullptr;
-
-    for (int s = 0; s < numSamples; ++s)
-    {
-        if (fftAccumCount < kFftSize) {
-            fftAccumInput[fftAccumCount] = inputSrc[s];
-            fftAccumOutput[fftAccumCount] = outputSrc ? outputSrc[s] : 0.0f;
-            fftAccumCount++;
-        }
-
-        if (fftAccumCount >= kFftSize)
-        {
-            // We have a full FFT frame — compute and push to ring buffer
-            int start1, size1, start2, size2;
-            spectralFifo.prepareToWrite(1, start1, size1, start2, size2);
-
-            if (size1 > 0)
-            {
-                SpectralFrame& frame = spectralBuffer[static_cast<size_t>(start1)];
-
-                // ── Input FFT ──
-                std::memcpy(fftInputWork.data(), fftAccumInput.data(), kFftSize * sizeof(float));
-                std::fill(fftInputWork.begin() + kFftSize, fftInputWork.end(), 0.0f);
-                fftWindow.multiplyWithWindowingTable(fftInputWork.data(), kFftSize);
-                fftAnalyzer.performFrequencyOnlyForwardTransform(fftInputWork.data());
-
-                for (size_t i = 0; i < kFftBins; ++i) {
-                    float mag = fftInputWork[i] / static_cast<float>(kFftBins);
-                    frame.inputMagnitudeDB[i] = 20.0f * std::log10(std::max(mag, 1e-7f));
-                }
-
-                // ── Output FFT ──
-                std::memcpy(fftOutputWork.data(), fftAccumOutput.data(), kFftSize * sizeof(float));
-                std::fill(fftOutputWork.begin() + kFftSize, fftOutputWork.end(), 0.0f);
-                fftWindow.multiplyWithWindowingTable(fftOutputWork.data(), kFftSize);
-                fftAnalyzer.performFrequencyOnlyForwardTransform(fftOutputWork.data());
-
-                for (size_t i = 0; i < kFftBins; ++i) {
-                    float mag = fftOutputWork[i] / static_cast<float>(kFftBins);
-                    frame.outputMagnitudeDB[i] = 20.0f * std::log10(std::max(mag, 1e-7f));
-                }
-
-                // ── Noise profile from libspecbleach (stationary or live adaptive) ──
-                const float* actualNoiseProfile = nullptr;
-                uint32_t profileSize = 0;
-                bool profileAvailable = false;
-
-                bool isAdaptive = adaptiveNoise;
-
-                if (algoMode == 0 && specbleach1D_L &&
-                    (isAdaptive || specbleach_noise_profile_available_for_mode(specbleach1D_L, 1))) {
-                    actualNoiseProfile = specbleach_get_active_noise_profile(specbleach1D_L);
-                    profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
-                    profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
-                } else if (algoMode == 1 && specbleach2D_L &&
-                           (isAdaptive || specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, 1))) {
-                    actualNoiseProfile = specbleach_2d_get_active_noise_profile(specbleach2D_L);
-                    profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
-                    profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
-                }
-
-                frame.hasNoiseProfile = profileAvailable;
-                frame.isLinked = (parameters.getRawParameterValue("link_reduction")->load() > 0.5f);
-                frame.tonalPeaksHz.clear();
-
-                if (profileAvailable && actualNoiseProfile) {
-                    // In 2D mode, noise_profile_size is SB_PROCESSOR_CORE_FULL_FFT_SPECTRUM (e.g. 3008 bins).
-                    // The real unique spectrum from DC (0 Hz) to Nyquist (Fs/2) is the first (profileSize / 2) + 1 bins.
-                    size_t realProfileBins = profileSize;
-
-                    const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
-                    const float maxFftIdx = static_cast<float>(kFftBins - 1);
-                    // FFTW unnormalized power scaling offset: 20 * log10(N/2)
-                    const float dbOffset = (maxProfileIdx > 0.0f) ? (20.0f * std::log10(maxProfileIdx)) : 0.0f;
-
-                    for (size_t i = 0; i < kFftBins; ++i) {
-                        float normPos = static_cast<float>(i) / maxFftIdx;
-                        float exactP = normPos * maxProfileIdx;
-
-                        size_t p0 = std::clamp(static_cast<size_t>(exactP), static_cast<size_t>(0), realProfileBins - 1);
-                        size_t p1 = std::min(p0 + 1, realProfileBins - 1);
-                        float frac = exactP - static_cast<float>(p0);
-
-                        float val0 = actualNoiseProfile[p0];
-                        float val1 = actualNoiseProfile[p1];
-                        float interpVal = (1.0f - frac) * val0 + frac * val1;
-
-                        float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
-                        frame.noiseFloorDB[i] = rawDb - dbOffset;
-                    }
-
-                    // Query libspecbleach directly for reported tonal peak frequencies computed on this real noise profile
-                    std::array<float, 16> peakBuf{};
-                    uint32_t numPeaks = 0;
-                    if (algoMode == 0 && specbleach1D_L) {
-                        numPeaks = specbleach_get_tonal_peaks_for_profile(specbleach1D_L, actualNoiseProfile, static_cast<uint32_t>(realProfileBins), peakBuf.data(), static_cast<uint32_t>(peakBuf.size()));
-                    } else if (algoMode == 1 && specbleach2D_L) {
-                        numPeaks = specbleach_2d_get_tonal_peaks_for_profile(specbleach2D_L, actualNoiseProfile, static_cast<uint32_t>(realProfileBins), peakBuf.data(), static_cast<uint32_t>(peakBuf.size()));
-                    }
-
-                    for (uint32_t i = 0; i < numPeaks; ++i) {
-                        frame.tonalPeaksHz.push_back(peakBuf[i]);
-                    }
-                } else {
-                    frame.noiseFloorDB.fill(-120.0f);
-                }
-
-                spectralFifo.finishedWrite(1);
-            }
-
-            // Shift: keep last quarter for overlap (hop = 75%)
-            constexpr size_t kHop = kFftSize / 4;
-            std::memmove(fftAccumInput.data(), fftAccumInput.data() + kHop, (kFftSize - kHop) * sizeof(float));
-            std::memmove(fftAccumOutput.data(), fftAccumOutput.data() + kHop, (kFftSize - kHop) * sizeof(float));
-            fftAccumCount = kFftSize - kHop;
-        }
-    }
+void NoiseRepellentAudioProcessor::resetNoiseProfile() {
+  if (specbleach1D_L)
+    specbleach_reset_noise_profile(specbleach1D_L);
+  if (specbleach1D_R)
+    specbleach_reset_noise_profile(specbleach1D_R);
+  if (specbleach2D_L)
+    specbleach_2d_reset_noise_profile(specbleach2D_L);
+  if (specbleach2D_R)
+    specbleach_2d_reset_noise_profile(specbleach2D_R);
 }
 
-void NoiseRepellentAudioProcessor::processBlockBypassed(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*midiMessages*/)
-{
-    const int numSamples = buffer.getNumSamples();
-    const int numChannels = buffer.getNumChannels();
+bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {
+  auto* paramAlgo = parameters.getRawParameterValue("algorithm_mode");
+  if (!paramAlgo)
+    return false;
 
-    if (numSamples == 0 || numChannels == 0)
-        return;
+  int algoMode = static_cast<int>(paramAlgo->load());
 
-    juce::dsp::AudioBlock<float> audioBlock(buffer);
-    dryWetMixer.pushDrySamples(audioBlock);
-    dryWetMixer.setWetMixProportion(0.0f);
-    dryWetMixer.mixWetSamples(audioBlock);
-}
-
-bool NoiseRepellentAudioProcessor::getNextSpectralFrame(SpectralFrame& frame)
-{
-    int start1, size1, start2, size2;
-    spectralFifo.prepareToRead(1, start1, size1, start2, size2);
-
-    if (size1 > 0)
-    {
-        frame = spectralBuffer[static_cast<size_t>(start1)];
-        spectralFifo.finishedRead(1);
+  if (algoMode == 0 && specbleach1D_L) {
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode))
         return true;
     }
-    return false;
-}
-
-void NoiseRepellentAudioProcessor::resetNoiseProfile()
-{
-    if (specbleach1D_L) specbleach_reset_noise_profile(specbleach1D_L);
-    if (specbleach1D_R) specbleach_reset_noise_profile(specbleach1D_R);
-    if (specbleach2D_L) specbleach_2d_reset_noise_profile(specbleach2D_L);
-    if (specbleach2D_R) specbleach_2d_reset_noise_profile(specbleach2D_R);
-}
-
-bool NoiseRepellentAudioProcessor::hasNoiseProfile() const
-{
-    auto* paramAlgo = parameters.getRawParameterValue("algorithm_mode");
-    if (!paramAlgo)
-        return false;
-
-    int algoMode = static_cast<int>(paramAlgo->load());
-
-    if (algoMode == 0 && specbleach1D_L)
-    {
-        for (int mode = 1; mode <= 4; ++mode)
-        {
-            if (specbleach_noise_profile_available_for_mode(specbleach1D_L, mode))
-                return true;
-        }
+  } else if (algoMode == 1 && specbleach2D_L) {
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, mode))
+        return true;
     }
-    else if (algoMode == 1 && specbleach2D_L)
-    {
-        for (int mode = 1; mode <= 4; ++mode)
-        {
-            if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, mode))
-                return true;
+  }
+
+  return false;
+}
+
+juce::AudioProcessorEditor* NoiseRepellentAudioProcessor::createEditor() {
+  return new NoiseRepellentAudioProcessorEditor(*this);
+}
+
+void NoiseRepellentAudioProcessor::getStateInformation(
+    juce::MemoryBlock& destData) {
+  auto state = parameters.copyState();
+
+  juce::ValueTree profilesTree("LEARNED_PROFILES");
+
+  auto saveProfiles = [&](SpectralBleachHandle instance, const char* tagName,
+                          auto getProfileFn, auto getSizeFn,
+                          auto getBlockCountFn, auto isAvailableFn) {
+    // Modes 1-4: ROLLING_MEAN=1, MEDIAN=2, MAX=3, MINIMUM=4
+    for (int mode = 1; mode <= 4; ++mode) {
+      if (instance && isAvailableFn(instance, mode)) {
+        float* profile = getProfileFn(instance, mode);
+        uint32_t profileSize = getSizeFn(instance);
+        uint32_t blockCount = getBlockCountFn(instance, mode);
+
+        if (profile && profileSize > 0) {
+          juce::MemoryBlock mb(profile, profileSize * sizeof(float));
+          juce::ValueTree node(tagName);
+          node.setProperty("mode", mode, nullptr);
+          node.setProperty("size", static_cast<int>(profileSize), nullptr);
+          node.setProperty("blockCount", static_cast<int>(blockCount), nullptr);
+          node.setProperty("data", mb.toBase64Encoding(), nullptr);
+          profilesTree.appendChild(node, nullptr);
         }
+      }
     }
+  };
 
-    return false;
+  saveProfiles(specbleach1D_L, "PROFILE_1D",
+               specbleach_get_noise_profile_for_mode,
+               specbleach_get_noise_profile_size,
+               specbleach_get_noise_profile_block_count_for_mode,
+               specbleach_noise_profile_available_for_mode);
+
+  saveProfiles(specbleach2D_L, "PROFILE_2D",
+               specbleach_2d_get_noise_profile_for_mode,
+               specbleach_2d_get_noise_profile_size,
+               specbleach_2d_get_noise_profile_block_count_for_mode,
+               specbleach_2d_noise_profile_available_for_mode);
+
+  state.appendChild(profilesTree, nullptr);
+
+  std::unique_ptr<juce::XmlElement> xml(state.createXml());
+  copyXmlToBinary(*xml, destData);
 }
 
-juce::AudioProcessorEditor* NoiseRepellentAudioProcessor::createEditor()
-{
-    return new NoiseRepellentAudioProcessorEditor(*this);
-}
+void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
+                                                       int sizeInBytes) {
+  std::unique_ptr<juce::XmlElement> xmlState(
+      getXmlFromBinary(data, sizeInBytes));
+  if (xmlState != nullptr && xmlState->hasTagName(parameters.state.getType())) {
+    juce::ValueTree state = juce::ValueTree::fromXml(*xmlState);
+    parameters.replaceState(state);
 
-void NoiseRepellentAudioProcessor::getStateInformation(juce::MemoryBlock& destData)
-{
-    auto state = parameters.copyState();
+    juce::ValueTree profilesTree = state.getChildWithName("LEARNED_PROFILES");
+    if (profilesTree.isValid()) {
+      for (int i = 0; i < profilesTree.getNumChildren(); ++i) {
+        juce::ValueTree node = profilesTree.getChild(i);
+        int mode = node.getProperty("mode", 0);
+        uint32_t size = static_cast<uint32_t>(
+            static_cast<int>(node.getProperty("size", 0)));
+        uint32_t blockCount = static_cast<uint32_t>(
+            static_cast<int>(node.getProperty("blockCount", 0)));
+        juce::String base64Data = node.getProperty("data", "");
 
-    juce::ValueTree profilesTree("LEARNED_PROFILES");
-
-    auto saveProfiles = [&](SpectralBleachHandle instance, const char* tagName,
-                            auto getProfileFn, auto getSizeFn, auto getBlockCountFn, auto isAvailableFn) {
-        // Modes 1-4: ROLLING_MEAN=1, MEDIAN=2, MAX=3, MINIMUM=4
-        for (int mode = 1; mode <= 4; ++mode) {
-            if (instance && isAvailableFn(instance, mode)) {
-                float* profile = getProfileFn(instance, mode);
-                uint32_t profileSize = getSizeFn(instance);
-                uint32_t blockCount = getBlockCountFn(instance, mode);
-
-                if (profile && profileSize > 0) {
-                    juce::MemoryBlock mb(profile, profileSize * sizeof(float));
-                    juce::ValueTree node(tagName);
-                    node.setProperty("mode", mode, nullptr);
-                    node.setProperty("size", static_cast<int>(profileSize), nullptr);
-                    node.setProperty("blockCount", static_cast<int>(blockCount), nullptr);
-                    node.setProperty("data", mb.toBase64Encoding(), nullptr);
-                    profilesTree.appendChild(node, nullptr);
-                }
+        if (size > 0 && base64Data.isNotEmpty() && mode >= 1 && mode <= 4) {
+          juce::MemoryBlock mb;
+          if (mb.fromBase64Encoding(base64Data) &&
+              mb.getSize() >= size * sizeof(float)) {
+            const float* floatArray =
+                reinterpret_cast<const float*>(mb.getData());
+            if (node.hasType("PROFILE_1D")) {
+              if (specbleach1D_L)
+                specbleach_load_noise_profile_for_mode(
+                    specbleach1D_L, floatArray, size, blockCount, mode);
+              if (specbleach1D_R)
+                specbleach_load_noise_profile_for_mode(
+                    specbleach1D_R, floatArray, size, blockCount, mode);
+            } else if (node.hasType("PROFILE_2D")) {
+              if (specbleach2D_L)
+                specbleach_2d_load_noise_profile_for_mode(
+                    specbleach2D_L, floatArray, size, blockCount, mode);
+              if (specbleach2D_R)
+                specbleach_2d_load_noise_profile_for_mode(
+                    specbleach2D_R, floatArray, size, blockCount, mode);
             }
+          }
         }
-    };
+      }
 
-    saveProfiles(specbleach1D_L, "PROFILE_1D",
-                 specbleach_get_noise_profile_for_mode,
-                 specbleach_get_noise_profile_size,
-                 specbleach_get_noise_profile_block_count_for_mode,
-                 specbleach_noise_profile_available_for_mode);
-
-    saveProfiles(specbleach2D_L, "PROFILE_2D",
-                 specbleach_2d_get_noise_profile_for_mode,
-                 specbleach_2d_get_noise_profile_size,
-                 specbleach_2d_get_noise_profile_block_count_for_mode,
-                 specbleach_2d_noise_profile_available_for_mode);
-
-    state.appendChild(profilesTree, nullptr);
-
-    std::unique_ptr<juce::XmlElement> xml(state.createXml());
-    copyXmlToBinary(*xml, destData);
-}
-
-void NoiseRepellentAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
-{
-    std::unique_ptr<juce::XmlElement> xmlState(getXmlFromBinary(data, sizeInBytes));
-    if (xmlState != nullptr && xmlState->hasTagName(parameters.state.getType()))
-    {
-        juce::ValueTree state = juce::ValueTree::fromXml(*xmlState);
-        parameters.replaceState(state);
-
-        juce::ValueTree profilesTree = state.getChildWithName("LEARNED_PROFILES");
-        if (profilesTree.isValid())
-        {
-            for (int i = 0; i < profilesTree.getNumChildren(); ++i)
-            {
-                juce::ValueTree node = profilesTree.getChild(i);
-                int mode = node.getProperty("mode", 0);
-                uint32_t size = static_cast<uint32_t>(static_cast<int>(node.getProperty("size", 0)));
-                uint32_t blockCount = static_cast<uint32_t>(static_cast<int>(node.getProperty("blockCount", 0)));
-                juce::String base64Data = node.getProperty("data", "");
-
-                if (size > 0 && base64Data.isNotEmpty() && mode >= 1 && mode <= 4)
-                {
-                    juce::MemoryBlock mb;
-                    if (mb.fromBase64Encoding(base64Data) && mb.getSize() >= size * sizeof(float))
-                    {
-                        const float* floatArray = reinterpret_cast<const float*>(mb.getData());
-                        if (node.hasType("PROFILE_1D"))
-                        {
-                            if (specbleach1D_L)
-                                specbleach_load_noise_profile_for_mode(specbleach1D_L, floatArray, size, blockCount, mode);
-                            if (specbleach1D_R)
-                                specbleach_load_noise_profile_for_mode(specbleach1D_R, floatArray, size, blockCount, mode);
-                        }
-                        else if (node.hasType("PROFILE_2D"))
-                        {
-                            if (specbleach2D_L)
-                                specbleach_2d_load_noise_profile_for_mode(specbleach2D_L, floatArray, size, blockCount, mode);
-                            if (specbleach2D_R)
-                                specbleach_2d_load_noise_profile_for_mode(specbleach2D_R, floatArray, size, blockCount, mode);
-                        }
-                    }
-                }
-            }
-
-            // Sync loaded profiles to ensure both engines are fully populated
-            syncNoiseProfiles(0);
-            syncNoiseProfiles(1);
-        }
+      // Sync loaded profiles to ensure both engines are fully populated
+      syncNoiseProfiles(0);
+      syncNoiseProfiles(1);
     }
+  }
 }
 
-juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
-{
-    return new NoiseRepellentAudioProcessor();
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter() {
+  return new NoiseRepellentAudioProcessor();
 }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -109,17 +109,22 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
   return {params.begin(), params.end()};
 }
 
-static bool loadProfile1DSafe(SpectralBleachHandle h, const float* data,
-                              uint32_t size, uint32_t blockCount, int mode) {
+template <typename SizeQueryFn, typename LoadProfileFn>
+static bool loadProfileSafeHelper(SpectralBleachHandle h, const float* data,
+                                  uint32_t size, uint32_t blockCount, int mode,
+                                  SizeQueryFn sizeQueryFn,
+                                  LoadProfileFn loadProfileFn) {
   if (!h || !data || size == 0)
     return false;
-  uint32_t targetSize = specbleach_get_noise_profile_size(h);
+  uint32_t targetSize = sizeQueryFn(h);
   if (targetSize == 0)
     return false;
 
   if (size == targetSize) {
-    return specbleach_load_noise_profile_for_mode(h, data, size, blockCount,
-                                                  mode);
+    return loadProfileFn(h, data, size, blockCount, mode);
+  } else if (targetSize == 1) {
+    float resampledSample = data[0];
+    return loadProfileFn(h, &resampledSample, 1, blockCount, mode);
   } else {
     std::vector<float> resampled(targetSize);
     float maxSrcIdx = static_cast<float>(size - 1);
@@ -133,39 +138,22 @@ static bool loadProfile1DSafe(SpectralBleachHandle h, const float* data,
       float frac = exactIdx - static_cast<float>(idx0);
       resampled[i] = (1.0f - frac) * data[idx0] + frac * data[idx1];
     }
-    return specbleach_load_noise_profile_for_mode(
-        h, resampled.data(), targetSize, blockCount, mode);
+    return loadProfileFn(h, resampled.data(), targetSize, blockCount, mode);
   }
 }
 
-static bool loadProfile2DSafe(SpectralBleachHandle h,
-                              const float* data, uint32_t size,
-                              uint32_t blockCount, int mode) {
-  if (!h || !data || size == 0)
-    return false;
-  uint32_t targetSize = specbleach_2d_get_noise_profile_size(h);
-  if (targetSize == 0)
-    return false;
+static bool loadProfile1DSafe(SpectralBleachHandle h, const float* data,
+                              uint32_t size, uint32_t blockCount, int mode) {
+  return loadProfileSafeHelper(h, data, size, blockCount, mode,
+                               specbleach_get_noise_profile_size,
+                               specbleach_load_noise_profile_for_mode);
+}
 
-  if (size == targetSize) {
-    return specbleach_2d_load_noise_profile_for_mode(h, data, size,
-                                                     blockCount, mode);
-  } else {
-    std::vector<float> resampled(targetSize);
-    float maxSrcIdx = static_cast<float>(size - 1);
-    float maxTargetIdx = static_cast<float>(targetSize - 1);
-    for (uint32_t i = 0; i < targetSize; ++i) {
-      float normPos = static_cast<float>(i) / maxTargetIdx;
-      float exactIdx = normPos * maxSrcIdx;
-      uint32_t idx0 =
-          std::clamp(static_cast<uint32_t>(exactIdx), 0u, size - 1);
-      uint32_t idx1 = std::min(idx0 + 1, size - 1);
-      float frac = exactIdx - static_cast<float>(idx0);
-      resampled[i] = (1.0f - frac) * data[idx0] + frac * data[idx1];
-    }
-    return specbleach_2d_load_noise_profile_for_mode(
-        h, resampled.data(), targetSize, blockCount, mode);
-  }
+static bool loadProfile2DSafe(SpectralBleachHandle h, const float* data,
+                              uint32_t size, uint32_t blockCount, int mode) {
+  return loadProfileSafeHelper(h, data, size, blockCount, mode,
+                               specbleach_2d_get_noise_profile_size,
+                               specbleach_2d_load_noise_profile_for_mode);
 }
 
 void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
@@ -388,9 +376,12 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   dryWetMixer.setWetLatency(static_cast<float>(latency));
 
   // Pre-allocate persistent buffers to prevent audio-thread allocations
-  dryInputL.resize(static_cast<size_t>(samplesPerBlock), 0.0f);
-  crossfadeBuffer.setSize(getTotalNumOutputChannels(), samplesPerBlock, false,
+  const int bufferCapacity = std::max(samplesPerBlock, 8192);
+  dryInputL.resize(static_cast<size_t>(bufferCapacity), 0.0f);
+  crossfadeBuffer.setSize(getTotalNumOutputChannels(), bufferCapacity, false,
                           false, true);
+  jassert(dryInputL.size() >= static_cast<size_t>(samplesPerBlock));
+  jassert(crossfadeBuffer.getNumSamples() >= samplesPerBlock);
   crossfadeProgress = 1.0f;
   targetAlgoMode = currentAlgoMode;
 
@@ -464,14 +455,22 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   // Sync profiles if manual noise learning was just turned off
   if (wasLearning && !learnNoise) {
-    syncNoiseProfiles(currentAlgoMode);
+    juce::SpinLock::ScopedTryLockType tryLock(profileLock);
+    if (tryLock.isLocked()) {
+      syncNoiseProfiles(currentAlgoMode);
+    }
   }
   wasLearning = learnNoise;
 
   // Update latency dynamically, sync profiles, and start smooth crossfade when
   // algorithm mode changes
   if (algoMode != currentAlgoMode) {
-    syncNoiseProfiles(currentAlgoMode);
+    {
+      juce::SpinLock::ScopedTryLockType tryLock(profileLock);
+      if (tryLock.isLocked()) {
+        syncNoiseProfiles(currentAlgoMode);
+      }
+    }
     targetAlgoMode = algoMode;
     currentAlgoMode = algoMode;
 
@@ -530,38 +529,38 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   if (crossfadeProgress < 1.0f) {
     // Smooth crossfade mode: run both engines and blend sample-by-sample
-    const int maxSamples = std::min(numSamples, crossfadeBuffer.getNumSamples());
+    jassert(numSamples <= crossfadeBuffer.getNumSamples());
     const int maxChannels = std::min(numChannels, crossfadeBuffer.getNumChannels());
 
     for (int ch = 0; ch < maxChannels; ++ch)
-      std::copy_n(buffer.getReadPointer(ch), maxSamples,
+      std::copy_n(buffer.getReadPointer(ch), numSamples,
                   crossfadeBuffer.getWritePointer(ch));
 
     // Process 1D on buffer
     if (specbleach1D_L) {
       specbleach_load_parameters(specbleach1D_L, p);
       float* ch0 = buffer.getWritePointer(0);
-      specbleach_process(specbleach1D_L, static_cast<uint32_t>(maxSamples), ch0,
+      specbleach_process(specbleach1D_L, static_cast<uint32_t>(numSamples), ch0,
                          ch0);
     }
     if (numChannels >= 2 && specbleach1D_R) {
       specbleach_load_parameters(specbleach1D_R, p);
       float* ch1 = buffer.getWritePointer(1);
-      specbleach_process(specbleach1D_R, static_cast<uint32_t>(maxSamples), ch1,
+      specbleach_process(specbleach1D_R, static_cast<uint32_t>(numSamples), ch1,
                          ch1);
     }
 
     // Process 2D on crossfadeBuffer
-    if (specbleach2D_L) {
+    if (maxChannels >= 1 && specbleach2D_L) {
       specbleach_2d_load_parameters(specbleach2D_L, p2);
       float* ch0 = crossfadeBuffer.getWritePointer(0);
-      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(maxSamples),
+      specbleach_2d_process(specbleach2D_L, static_cast<uint32_t>(numSamples),
                             ch0, ch0);
     }
     if (numChannels >= 2 && specbleach2D_R && maxChannels >= 2) {
       specbleach_2d_load_parameters(specbleach2D_R, p2);
       float* ch1 = crossfadeBuffer.getWritePointer(1);
-      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(maxSamples),
+      specbleach_2d_process(specbleach2D_R, static_cast<uint32_t>(numSamples),
                             ch1, ch1);
     }
 
@@ -571,7 +570,7 @@ void NoiseRepellentAudioProcessor::processBlock(
       const float* out2D = crossfadeBuffer.getReadPointer(ch);
 
       float currentP = crossfadeProgress;
-      for (int s = 0; s < maxSamples; ++s) {
+      for (int s = 0; s < numSamples; ++s) {
         float pVal = std::min(1.0f, currentP);
         float rad = pVal * juce::MathConstants<float>::halfPi;
         float w1D = (targetAlgoMode == 1) ? std::cos(rad) : std::sin(rad);
@@ -581,7 +580,7 @@ void NoiseRepellentAudioProcessor::processBlock(
         currentP += crossfadeStep;
       }
     }
-    crossfadeProgress += maxSamples * crossfadeStep;
+    crossfadeProgress += numSamples * crossfadeStep;
     if (crossfadeProgress > 1.0f)
       crossfadeProgress = 1.0f;
   } else if (algoMode == 0) {
@@ -625,7 +624,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   const float* outputSrc =
       (numChannels >= 1) ? buffer.getReadPointer(0) : nullptr;
 
-  for (int s = 0; s < numSamples; ++s) {
+  for (size_t s = 0; s < copySamples; ++s) {
     if (fftAccumCount < kFftSize) {
       fftAccumInput[fftAccumCount] = inputSrc[s];
       fftAccumOutput[fftAccumCount] = outputSrc ? outputSrc[s] : 0.0f;
@@ -672,45 +671,48 @@ void NoiseRepellentAudioProcessor::processBlock(
         bool isAdaptive = adaptiveNoise;
         bool profileHasAnyMode = false;
 
-        if (algoMode == 0 && specbleach1D_L) {
-          for (int m = 1; m <= 4; ++m) {
-            if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
-              profileHasAnyMode = true;
-              break;
-            }
-          }
-          if (isAdaptive || profileHasAnyMode) {
-            actualNoiseProfile = specbleach_get_active_noise_profile(specbleach1D_L);
-            profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
-            if (!actualNoiseProfile && profileHasAnyMode) {
-              for (int m = 1; m <= 4; ++m) {
-                if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
-                  actualNoiseProfile = specbleach_get_noise_profile_for_mode(specbleach1D_L, m);
-                  break;
-                }
+        juce::SpinLock::ScopedTryLockType profileTryLock(profileLock);
+        if (profileTryLock.isLocked()) {
+          if (algoMode == 0 && specbleach1D_L) {
+            for (int m = 1; m <= 4; ++m) {
+              if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
+                profileHasAnyMode = true;
+                break;
               }
             }
-            profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
-          }
-        } else if (algoMode == 1 && specbleach2D_L) {
-          for (int m = 1; m <= 4; ++m) {
-            if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
-              profileHasAnyMode = true;
-              break;
-            }
-          }
-          if (isAdaptive || profileHasAnyMode) {
-            actualNoiseProfile = specbleach_2d_get_active_noise_profile(specbleach2D_L);
-            profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
-            if (!actualNoiseProfile && profileHasAnyMode) {
-              for (int m = 1; m <= 4; ++m) {
-                if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
-                  actualNoiseProfile = specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, m);
-                  break;
+            if (isAdaptive || profileHasAnyMode) {
+              actualNoiseProfile = specbleach_get_active_noise_profile(specbleach1D_L);
+              profileSize = specbleach_get_noise_profile_size(specbleach1D_L);
+              if (!actualNoiseProfile && profileHasAnyMode) {
+                for (int m = 1; m <= 4; ++m) {
+                  if (specbleach_noise_profile_available_for_mode(specbleach1D_L, m)) {
+                    actualNoiseProfile = specbleach_get_noise_profile_for_mode(specbleach1D_L, m);
+                    break;
+                  }
                 }
               }
+              profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
             }
-            profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+          } else if (algoMode == 1 && specbleach2D_L) {
+            for (int m = 1; m <= 4; ++m) {
+              if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
+                profileHasAnyMode = true;
+                break;
+              }
+            }
+            if (isAdaptive || profileHasAnyMode) {
+              actualNoiseProfile = specbleach_2d_get_active_noise_profile(specbleach2D_L);
+              profileSize = specbleach_2d_get_noise_profile_size(specbleach2D_L);
+              if (!actualNoiseProfile && profileHasAnyMode) {
+                for (int m = 1; m <= 4; ++m) {
+                  if (specbleach_2d_noise_profile_available_for_mode(specbleach2D_L, m)) {
+                    actualNoiseProfile = specbleach_2d_get_noise_profile_for_mode(specbleach2D_L, m);
+                    break;
+                  }
+                }
+              }
+              profileAvailable = (actualNoiseProfile != nullptr && profileSize > 0);
+            }
           }
         }
 
@@ -838,6 +840,8 @@ juce::AudioProcessorEditor* NoiseRepellentAudioProcessor::createEditor() {
 
 void NoiseRepellentAudioProcessor::getStateInformation(
     juce::MemoryBlock& destData) {
+  juce::SpinLock::ScopedLockType lock(profileLock);
+
   // Sync profiles across engines before state serialization
   syncNoiseProfiles(currentAlgoMode);
 
@@ -971,6 +975,10 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
       // Sync loaded profiles to ensure both engines are fully populated
       syncNoiseProfiles(0);
       syncNoiseProfiles(1);
+
+      if (specbleach1D_L != nullptr) {
+        pendingProfiles.clear();
+      }
     }
   }
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -116,6 +116,9 @@ private:
 
     std::vector<PendingProfile> pendingProfiles;
 
+    // Lock to protect noise profile synchronization and serialization
+    juce::SpinLock profileLock;
+
     // Persistent dry input copy for FFT visualization (prevents RT audio thread allocation)
     std::vector<float> dryInputL;
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -106,6 +106,19 @@ private:
     int currentAlgoMode = 1; // Track for dynamic latency updates
     bool wasLearning = false; // Track learn mode state transition to sync profiles
 
+    struct PendingProfile {
+        int channel = 0; // 0 = Left, 1 = Right
+        int mode = 1;
+        uint32_t size = 0;
+        uint32_t blockCount = 0;
+        std::vector<float> data;
+    };
+
+    std::vector<PendingProfile> pendingProfiles;
+
+    // Persistent dry input copy for FFT visualization (prevents RT audio thread allocation)
+    std::vector<float> dryInputL;
+
     // Crossfading between 1D and 2D engines to prevent clicks/pops during mode changes
     juce::AudioBuffer<float> crossfadeBuffer;
     int targetAlgoMode = 1;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -41,6 +41,7 @@ public:
 
     void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
     void processBlockBypassed(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    juce::AudioProcessorParameter* getBypassParameter() const override;
 
     juce::AudioProcessorEditor* createEditor() override;
     bool hasEditor() const override { return true; }
@@ -98,6 +99,7 @@ private:
     SpectralBleachHandle specbleach2D_L = nullptr;
     SpectralBleachHandle specbleach2D_R = nullptr;
 
+    juce::AudioParameterBool* bypassParameter = nullptr;
     juce::dsp::DryWetMixer<float> dryWetMixer;
 
     double currentSampleRate = 44100.0;


### PR DESCRIPTION
Fixes #160 

### Summary of Completed Improvements

  1. Host Bypass Deduplication & Clean Naming:
      • Implemented getBypassParameter() override returning bypassParameter to prevent host DAWs from generating duplicate host bypass controls.
      • Updated internal bypass display name to "Internal Bypass" for clear distinction in DAWs.
      • Fixed latency alignment in DryWetMixer (dryWetMixer(16384)) so host delay compensation aligns wet/dry paths and eliminates audio clicks when toggling bypass.
  2. Parameter Layout & Automation Cleanup:
      • Excluded UI-only controls (show_advanced, link_reduction) from host automation while keeping their IDs, attachments, and state persistence intact.
      • Removed obsolete nlm_smoothing parameter so a single unified "Smoothing" parameter controls both 1D and 2D algorithms.
  3. Algorithm-Independent & Stereo Noise Profile Persistence:
      • Noise profiles are saved per channel (Left & Right) across modes 1–4 and recalled into both 1D and 2D engines simultaneously.
      • Added automatic linear interpolation (loadProfile1DSafe / loadProfile2DSafe) so profiles learned at one sample rate (e.g. 44.1 kHz) seamlessly adapt if reopened at a different sample rate (e.g. 48 kHz).
      • Added active profile fallback in processBlock() and pre-replaceState() profile tree extraction so state restoration is robust across all host DAWs.