### PR TITLE
feat: query active engine for tonal peaks and update aggressiveness tooltips

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -482,9 +482,8 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   lblOffset.setTooltip(
       "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).");
   const juce::String aggrTip =
-      "Adjust noise profile aggressiveness by morphing between median, "
-      "average,\nand max noise statistics (-1.0: Median, 0.0: Average, +1.0: "
-      "Max).";
+      "Adjust noise profile aggressiveness using statistical variance.\n"
+      "(-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).";
   sliderAggressiveness.setTooltip(aggrTip);
   lblAggressiveness.setTooltip(aggrTip);
   btnDelta.setTooltip(
@@ -785,9 +784,8 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
 
   if (aggressivenessEnabled) {
     const juce::String aggrTip =
-        "Adjust noise profile aggressiveness by morphing between median, "
-        "average,\nand max noise statistics (-1.0: Median, 0.0: Average, +1.0: "
-        "Max).";
+        "Adjust noise profile aggressiveness using statistical variance.\n"
+        "(-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).";
     sliderAggressiveness.setTooltip(aggrTip);
     lblAggressiveness.setTooltip(aggrTip);
   } else {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1124,17 +1124,15 @@ void NoiseRepellentAudioProcessor::processBlock(
 
           // Query libspecbleach directly for reported tonal peak frequencies
           // computed on this real noise profile
-          std::array<float, 16> peakBuf{};
+          std::array<float, 32> peakBuf{};
           uint32_t numPeaks = 0;
           if (algoMode == 0 && specbleach1D_L) {
-            numPeaks = specbleach_get_tonal_peaks_for_profile(
-                specbleach1D_L, actualNoiseProfile,
-                static_cast<uint32_t>(realProfileBins), peakBuf.data(),
+            numPeaks = specbleach_get_tonal_peaks(
+                specbleach1D_L, peakBuf.data(),
                 static_cast<uint32_t>(peakBuf.size()));
           } else if (algoMode == 1 && specbleach2D_L) {
-            numPeaks = specbleach_2d_get_tonal_peaks_for_profile(
-                specbleach2D_L, actualNoiseProfile,
-                static_cast<uint32_t>(realProfileBins), peakBuf.data(),
+            numPeaks = specbleach_2d_get_tonal_peaks(
+                specbleach2D_L, peakBuf.data(),
                 static_cast<uint32_t>(peakBuf.size()));
           }
 


### PR DESCRIPTION
Fixes #171 

### Summary
- Queries active DSP engines directly for tonal peak frequencies in visualizer to match the new CV mask.
- Expands visualizer peak buffer capacity to 32 peaks.
- Updates UI tooltips for the Aggressiveness parameter to reflect statistical variance math (-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).