### PR TITLE
feat(ui): interactive HPSS toggle on visualizer LED and streamlined controls

### DIFF
--- a/Source/GUI/LookAndFeel.cpp
+++ b/Source/GUI/LookAndFeel.cpp
@@ -19,254 +19,284 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "LookAndFeel.h"
 
-const juce::Colour NoiseRepellentLookAndFeel::kColorNoiseProfile = juce::Colour(0xffe5a000);
-const juce::Colour NoiseRepellentLookAndFeel::kColorDenoising    = juce::Colour(0xff5cc0d4);
-const juce::Colour NoiseRepellentLookAndFeel::kColorFineTuning   = juce::Colour(0xffb4bfce);
-const juce::Colour NoiseRepellentLookAndFeel::kColorInputSignal  = juce::Colour(0xff6184a8);
-const juce::Colour NoiseRepellentLookAndFeel::kColorTonalPeaks   = juce::Colour(0xffe07055);
-const juce::Colour NoiseRepellentLookAndFeel::kColorReductionCurve = juce::Colour(0xff4caf50);
-const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBg      = juce::Colour(0xff343a48);
-const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBorder  = juce::Colour(0xff4f586c);
+const juce::Colour NoiseRepellentLookAndFeel::kColorNoiseProfile =
+    juce::Colour(0xffe5a000);
+const juce::Colour NoiseRepellentLookAndFeel::kColorDenoising =
+    juce::Colour(0xff5cc0d4);
+const juce::Colour NoiseRepellentLookAndFeel::kColorFineTuning =
+    juce::Colour(0xffb4bfce);
+const juce::Colour NoiseRepellentLookAndFeel::kColorInputSignal =
+    juce::Colour(0xff6184a8);
+const juce::Colour NoiseRepellentLookAndFeel::kColorTonalPeaks =
+    juce::Colour(0xffe07055);
+const juce::Colour NoiseRepellentLookAndFeel::kColorReductionCurve =
+    juce::Colour(0xff4caf50);
+const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBg =
+    juce::Colour(0xff343a48);
+const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBorder =
+    juce::Colour(0xff4f586c);
 
-NoiseRepellentLookAndFeel::NoiseRepellentLookAndFeel()
-{
-    setColour(juce::Slider::thumbColourId, juce::Colour(0xff525c70));
-    setColour(juce::Slider::trackColourId, juce::Colour(0xff1c2028));
-    setColour(juce::TextButton::textColourOffId, juce::Colour(0xffd0d7e2));
-    setColour(juce::TextButton::textColourOnId, kColorNoiseProfile);
-    setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff262b36));
-    setColour(juce::ComboBox::outlineColourId, kColorPanelBorder);
+NoiseRepellentLookAndFeel::NoiseRepellentLookAndFeel() {
+  setColour(juce::Slider::thumbColourId, juce::Colour(0xff525c70));
+  setColour(juce::Slider::trackColourId, juce::Colour(0xff1c2028));
+  setColour(juce::TextButton::textColourOffId, juce::Colour(0xffd0d7e2));
+  setColour(juce::TextButton::textColourOnId, kColorNoiseProfile);
+  setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff262b36));
+  setColour(juce::ComboBox::outlineColourId, kColorPanelBorder);
 }
 
-void NoiseRepellentLookAndFeel::drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height,
-                                                 float sliderPos, float minSliderPos, float maxSliderPos,
-                                                 const juce::Slider::SliderStyle style, juce::Slider& slider)
-{
-    juce::Colour fillColour = slider.findColour(juce::Slider::rotarySliderFillColourId, true);
-    if (fillColour.isTransparent()) {
-        fillColour = kColorFineTuning;
-    }
+void NoiseRepellentLookAndFeel::drawLinearSlider(
+    juce::Graphics& g, int x, int y, int width, int height, float sliderPos,
+    float minSliderPos, float maxSliderPos,
+    const juce::Slider::SliderStyle style, juce::Slider& slider) {
+  juce::Colour fillColour =
+      slider.findColour(juce::Slider::rotarySliderFillColourId, true);
+  if (fillColour.isTransparent()) {
+    fillColour = kColorFineTuning;
+  }
 
-    if (style == juce::Slider::LinearVertical)
-    {
-        float trackW = 4.0f;
-        float trackX = x + (width - trackW) * 0.5f;
+  if (style == juce::Slider::LinearVertical) {
+    float trackW = 4.0f;
+    float trackX = x + (width - trackW) * 0.5f;
 
-        // Background track
-        g.setColour(juce::Colour(0xff1c2028));
-        g.fillRoundedRectangle(trackX, (float)y, trackW, (float)height, 2.0f);
+    // Background track
+    g.setColour(juce::Colour(0xff1c2028));
+    g.fillRoundedRectangle(trackX, (float)y, trackW, (float)height, 2.0f);
 
-        // Solid Single-Color Fill
-        g.setColour(fillColour);
-        g.fillRoundedRectangle(trackX, sliderPos, trackW, (float)y + (float)height - sliderPos, 2.0f);
+    // Solid Single-Color Fill
+    g.setColour(fillColour);
+    g.fillRoundedRectangle(trackX, sliderPos, trackW,
+                           (float)y + (float)height - sliderPos, 2.0f);
 
-        // Thumb Cap
-        float thumbW = 18.0f;
-        float thumbH = 12.0f;
-        float thumbX = x + (width - thumbW) * 0.5f;
-        float thumbY = sliderPos - thumbH * 0.5f;
+    // Thumb Cap
+    float thumbW = 18.0f;
+    float thumbH = 12.0f;
+    float thumbX = x + (width - thumbW) * 0.5f;
+    float thumbY = sliderPos - thumbH * 0.5f;
 
-        g.setColour(juce::Colour(0xff525c70));
-        g.fillRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f);
+    g.setColour(juce::Colour(0xff525c70));
+    g.fillRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f);
 
-        g.setColour(juce::Colour(0xff8492a8));
-        g.drawRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f, 1.0f);
+    g.setColour(juce::Colour(0xff8492a8));
+    g.drawRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f, 1.0f);
 
-        g.setColour(fillColour);
-        g.fillRect(thumbX + 5.0f, thumbY + 5.0f, 8.0f, 2.0f);
-    }
-    else if (style == juce::Slider::LinearHorizontal)
-    {
-        float trackH = 4.0f;
-        float trackY = y + (height - trackH) * 0.5f;
+    g.setColour(fillColour);
+    g.fillRect(thumbX + 5.0f, thumbY + 5.0f, 8.0f, 2.0f);
+  } else if (style == juce::Slider::LinearHorizontal) {
+    float trackH = 4.0f;
+    float trackY = y + (height - trackH) * 0.5f;
 
-        g.setColour(juce::Colour(0xff1c2028));
-        g.fillRoundedRectangle((float)x, trackY, (float)width, trackH, 2.0f);
+    g.setColour(juce::Colour(0xff1c2028));
+    g.fillRoundedRectangle((float)x, trackY, (float)width, trackH, 2.0f);
 
-        g.setColour(fillColour);
-        g.fillRoundedRectangle((float)x, trackY, sliderPos - (float)x, trackH, 2.0f);
+    g.setColour(fillColour);
+    g.fillRoundedRectangle((float)x, trackY, sliderPos - (float)x, trackH,
+                           2.0f);
 
-        float thumbW = 12.0f;
-        float thumbH = 16.0f;
-        float thumbX = sliderPos - thumbW * 0.5f;
-        float thumbY = y + (height - thumbH) * 0.5f;
+    float thumbW = 12.0f;
+    float thumbH = 16.0f;
+    float thumbX = sliderPos - thumbW * 0.5f;
+    float thumbY = y + (height - thumbH) * 0.5f;
 
-        g.setColour(juce::Colour(0xff525c70));
-        g.fillRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f);
+    g.setColour(juce::Colour(0xff525c70));
+    g.fillRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f);
 
-        g.setColour(juce::Colour(0xff8492a8));
-        g.drawRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f, 1.0f);
+    g.setColour(juce::Colour(0xff8492a8));
+    g.drawRoundedRectangle(thumbX, thumbY, thumbW, thumbH, 2.0f, 1.0f);
 
-        g.setColour(fillColour);
-        g.fillRect(thumbX + 5.0f, thumbY + 4.0f, 2.0f, 8.0f);
-    }
+    g.setColour(fillColour);
+    g.fillRect(thumbX + 5.0f, thumbY + 4.0f, 2.0f, 8.0f);
+  }
 }
 
-void NoiseRepellentLookAndFeel::drawButtonBackground(juce::Graphics& g, juce::Button& button,
-                                                      const juce::Colour& backgroundColour,
-                                                      bool shouldDrawButtonAsHighlighted,
-                                                      bool shouldDrawButtonAsDown)
-{
-    auto bounds = button.getLocalBounds().toFloat();
-    bool isOn = button.getToggleState();
+void NoiseRepellentLookAndFeel::drawButtonBackground(
+    juce::Graphics& g, juce::Button& button,
+    const juce::Colour& backgroundColour, bool shouldDrawButtonAsHighlighted,
+    bool shouldDrawButtonAsDown) {
+  auto bounds = button.getLocalBounds().toFloat();
+  bool isOn = button.getToggleState();
 
-    juce::Colour base;
-    if (isOn) {
-        juce::Colour onCol = button.findColour(juce::TextButton::buttonOnColourId, false);
-        base = onCol.isOpaque() ? onCol : kColorNoiseProfile;
-    } else {
-        juce::Colour offCol = button.findColour(juce::TextButton::buttonColourId, false);
-        base = (offCol.isOpaque() && !offCol.isTransparent()) ? offCol : (backgroundColour.isTransparent() ? juce::Colour(0xff3f4757) : backgroundColour);
-    }
+  juce::Colour base;
+  if (isOn) {
+    juce::Colour onCol =
+        button.findColour(juce::TextButton::buttonOnColourId, false);
+    base = onCol.isOpaque() ? onCol : kColorNoiseProfile;
+  } else {
+    juce::Colour offCol =
+        button.findColour(juce::TextButton::buttonColourId, false);
+    base = (offCol.isOpaque() && !offCol.isTransparent())
+               ? offCol
+               : (backgroundColour.isTransparent() ? juce::Colour(0xff3f4757)
+                                                   : backgroundColour);
+  }
 
-    if (shouldDrawButtonAsDown)      base = base.darker(0.2f);
-    else if (shouldDrawButtonAsHighlighted) base = base.brighter(0.15f);
+  if (shouldDrawButtonAsDown)
+    base = base.darker(0.2f);
+  else if (shouldDrawButtonAsHighlighted)
+    base = base.brighter(0.15f);
 
-    g.setColour(base);
-    g.fillRoundedRectangle(bounds, 4.0f);
+  g.setColour(base);
+  g.fillRoundedRectangle(bounds, 4.0f);
 
-    g.setColour(kColorPanelBorder);
-    g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
+  g.setColour(kColorPanelBorder);
+  g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
 }
 
-juce::Font NoiseRepellentLookAndFeel::getTextButtonFont(juce::TextButton&, int)
-{
-    return juce::FontOptions(kFontSizeLabel, juce::Font::bold);
+juce::Font NoiseRepellentLookAndFeel::getTextButtonFont(juce::TextButton&,
+                                                        int) {
+  return juce::FontOptions(kFontSizeLabel, juce::Font::bold);
 }
 
-void NoiseRepellentLookAndFeel::drawButtonText(juce::Graphics& g, juce::TextButton& button,
-                                               bool shouldDrawButtonAsHighlighted,
-                                               bool shouldDrawButtonAsDown)
-{
-    juce::ignoreUnused(shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
-    juce::Font font(getTextButtonFont(button, button.getHeight()));
+void NoiseRepellentLookAndFeel::drawButtonText(
+    juce::Graphics& g, juce::TextButton& button,
+    bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) {
+  juce::ignoreUnused(shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+  juce::Font font(getTextButtonFont(button, button.getHeight()));
+  g.setFont(font);
+
+  bool isOn = button.getToggleState();
+  juce::Colour activeBg =
+      button.findColour(isOn ? juce::TextButton::buttonOnColourId
+                             : juce::TextButton::buttonColourId,
+                        false);
+
+  juce::Colour textColour;
+  if (activeBg == juce::Colour(0xffc0392b) ||
+      activeBg == juce::Colour(0xffe74c3c)) {
+    textColour = juce::Colours::white;
+  } else if (activeBg == kColorNoiseProfile || isOn) {
+    textColour = juce::Colour(0xff101216);
+  } else {
+    textColour = juce::Colour(0xffe6e8ed);
+  }
+
+  if (!button.isEnabled())
+    textColour = textColour.withAlpha(0.4f);
+
+  g.setColour(textColour);
+  g.drawText(button.getButtonText(), button.getLocalBounds(),
+             juce::Justification::centred);
+}
+
+void NoiseRepellentLookAndFeel::drawToggleButton(
+    juce::Graphics& g, juce::ToggleButton& button,
+    bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) {
+  juce::ignoreUnused(shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+  auto bounds = button.getLocalBounds().toFloat();
+  bool isOn = button.getToggleState();
+
+  g.setColour(isOn ? kColorNoiseProfile : juce::Colour(0xff3f4757));
+  g.fillRoundedRectangle(bounds, 4.0f);
+
+  g.setColour(kColorPanelBorder);
+  g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
+
+  juce::Colour textColour =
+      isOn ? juce::Colour(0xff101216) : juce::Colour(0xffe6e8ed);
+  if (!button.isEnabled())
+    textColour = textColour.withAlpha(0.4f);
+
+  g.setColour(textColour);
+  g.setFont(juce::FontOptions(kFontSizeLabel, juce::Font::bold));
+  g.drawText(button.getButtonText(), bounds, juce::Justification::centred);
+}
+
+void NoiseRepellentLookAndFeel::drawComboBox(juce::Graphics& g, int width,
+                                             int height, bool isButtonDown,
+                                             int buttonX, int buttonY,
+                                             int buttonW, int buttonH,
+                                             juce::ComboBox& box) {
+  auto cornerSize = 4.0f;
+  juce::Rectangle<float> boxBounds(0.0f, 0.0f, (float)width, (float)height);
+
+  g.setColour(findColour(juce::ComboBox::backgroundColourId));
+  g.fillRoundedRectangle(boxBounds, cornerSize);
+
+  g.setColour(findColour(juce::ComboBox::outlineColourId));
+  g.drawRoundedRectangle(boxBounds, cornerSize, 1.0f);
+
+  juce::Rectangle<float> arrowZone((float)buttonX, (float)buttonY,
+                                   (float)buttonW, (float)buttonH);
+  juce::Path path;
+  path.addTriangle(arrowZone.getCentreX() - 4.0f, arrowZone.getCentreY() - 2.0f,
+                   arrowZone.getCentreX() + 4.0f, arrowZone.getCentreY() - 2.0f,
+                   arrowZone.getCentreX(), arrowZone.getCentreY() + 3.0f);
+
+  g.setColour(juce::Colour(0xff808896));
+  g.fillPath(path);
+}
+
+void NoiseRepellentLookAndFeel::drawGroupComponentOutline(
+    juce::Graphics& g, int width, int height, const juce::String& text,
+    const juce::Justification& position, juce::GroupComponent& group) {
+  juce::ignoreUnused(position);
+
+  auto textH = 14.0f;
+  auto textEdgeGap = 4.0f;
+  auto cs = 4.0f;
+
+  juce::Font font(juce::FontOptions(kFontSizeLabel, juce::Font::bold));
+  juce::GlyphArrangement ga;
+  ga.addFittedText(font, text, 0.0f, 0.0f, 1000.0f, textH,
+                   juce::Justification::left, 1);
+  auto textW = text.isEmpty() ? 0.0f
+                              : ga.getBoundingBox(0, -1, true).getWidth() +
+                                    textEdgeGap * 2.0f;
+
+  auto bounds =
+      juce::Rectangle<float>((float)width, (float)height).reduced(0.5f);
+  auto textBounds = juce::Rectangle<float>(10.0f, 0.0f, textW, textH);
+
+  juce::Path p;
+  p.startNewSubPath(textBounds.getRight(), bounds.getY() + textH * 0.5f);
+  p.lineTo(bounds.getRight() - cs, bounds.getY() + textH * 0.5f);
+  p.addArc(bounds.getRight() - cs * 2.0f, bounds.getY() + textH * 0.5f,
+           cs * 2.0f, cs * 2.0f, 0.0f, juce::MathConstants<float>::halfPi);
+  p.lineTo(bounds.getRight(), bounds.getBottom() - cs);
+  p.addArc(bounds.getRight() - cs * 2.0f, bounds.getBottom() - cs * 2.0f,
+           cs * 2.0f, cs * 2.0f, juce::MathConstants<float>::halfPi,
+           juce::MathConstants<float>::pi);
+  p.lineTo(bounds.getX() + cs, bounds.getBottom());
+  p.addArc(bounds.getX(), bounds.getBottom() - cs * 2.0f, cs * 2.0f, cs * 2.0f,
+           juce::MathConstants<float>::pi,
+           juce::MathConstants<float>::pi * 1.5f);
+  p.lineTo(bounds.getX(), bounds.getY() + textH * 0.5f + cs);
+  p.addArc(bounds.getX(), bounds.getY() + textH * 0.5f, cs * 2.0f, cs * 2.0f,
+           juce::MathConstants<float>::pi * 1.5f,
+           juce::MathConstants<float>::twoPi);
+  p.lineTo(textBounds.getX(), bounds.getY() + textH * 0.5f);
+
+  g.setColour(group.findColour(juce::GroupComponent::outlineColourId));
+  g.strokePath(p, juce::PathStrokeType(1.0f));
+
+  if (text.isNotEmpty()) {
+    g.setColour(group.findColour(juce::GroupComponent::textColourId));
     g.setFont(font);
-
-    bool isOn = button.getToggleState();
-    juce::Colour activeBg = button.findColour(isOn ? juce::TextButton::buttonOnColourId : juce::TextButton::buttonColourId, false);
-
-    juce::Colour textColour;
-    if (activeBg == juce::Colour(0xffc0392b) || activeBg == juce::Colour(0xffe74c3c)) {
-        textColour = juce::Colours::white;
-    } else if (activeBg == kColorNoiseProfile || isOn) {
-        textColour = juce::Colour(0xff101216);
-    } else {
-        textColour = juce::Colour(0xffe6e8ed);
-    }
-
-    if (!button.isEnabled())
-        textColour = textColour.withAlpha(0.4f);
-
-    g.setColour(textColour);
-    g.drawText(button.getButtonText(), button.getLocalBounds(), juce::Justification::centred);
+    g.drawText(text, textBounds, juce::Justification::centred, false);
+  }
 }
 
-void NoiseRepellentLookAndFeel::drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
-                                                 bool shouldDrawButtonAsHighlighted,
-                                                 bool shouldDrawButtonAsDown)
-{
-    juce::ignoreUnused(shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
-    auto bounds = button.getLocalBounds().toFloat();
-    bool isOn = button.getToggleState();
-
-    g.setColour(isOn ? kColorNoiseProfile : juce::Colour(0xff3f4757));
-    g.fillRoundedRectangle(bounds, 4.0f);
-
-    g.setColour(kColorPanelBorder);
-    g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
-
-    juce::Colour textColour = isOn ? juce::Colour(0xff101216) : juce::Colour(0xffe6e8ed);
-    if (!button.isEnabled())
-        textColour = textColour.withAlpha(0.4f);
-
-    g.setColour(textColour);
-    g.setFont(juce::FontOptions(kFontSizeLabel, juce::Font::bold));
-    g.drawText(button.getButtonText(), bounds, juce::Justification::centred);
+juce::Font NoiseRepellentLookAndFeel::getComboBoxFont(juce::ComboBox&) {
+  return juce::FontOptions(kFontSizeLabel, juce::Font::bold);
 }
 
-void NoiseRepellentLookAndFeel::drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown,
-                                             int buttonX, int buttonY, int buttonW, int buttonH,
-                                             juce::ComboBox& box)
-{
-    auto cornerSize = 4.0f;
-    juce::Rectangle<float> boxBounds(0.0f, 0.0f, (float)width, (float)height);
-
-    g.setColour(findColour(juce::ComboBox::backgroundColourId));
-    g.fillRoundedRectangle(boxBounds, cornerSize);
-
-    g.setColour(findColour(juce::ComboBox::outlineColourId));
-    g.drawRoundedRectangle(boxBounds, cornerSize, 1.0f);
-
-    juce::Rectangle<float> arrowZone((float)buttonX, (float)buttonY, (float)buttonW, (float)buttonH);
-    juce::Path path;
-    path.addTriangle(arrowZone.getCentreX() - 4.0f, arrowZone.getCentreY() - 2.0f,
-                      arrowZone.getCentreX() + 4.0f, arrowZone.getCentreY() - 2.0f,
-                      arrowZone.getCentreX(),        arrowZone.getCentreY() + 3.0f);
-
-    g.setColour(juce::Colour(0xff808896));
-    g.fillPath(path);
+juce::Font NoiseRepellentLookAndFeel::getPopupMenuFont() {
+  return juce::FontOptions(kFontSizeLabel, juce::Font::plain);
 }
 
-void NoiseRepellentLookAndFeel::drawGroupComponentOutline(juce::Graphics& g, int width, int height,
-                                                           const juce::String& text, const juce::Justification& position,
-                                                           juce::GroupComponent& group)
-{
-    juce::ignoreUnused(position);
-
-    auto textH = 14.0f;
-    auto textEdgeGap = 4.0f;
-    auto cs = 4.0f;
-
-    juce::Font font(juce::FontOptions(kFontSizeLabel, juce::Font::bold));
-    juce::GlyphArrangement ga;
-    ga.addFittedText(font, text, 0.0f, 0.0f, 1000.0f, textH, juce::Justification::left, 1);
-    auto textW = text.isEmpty() ? 0.0f : ga.getBoundingBox(0, -1, true).getWidth() + textEdgeGap * 2.0f;
-
-    auto bounds = juce::Rectangle<float>((float)width, (float)height).reduced(0.5f);
-    auto textBounds = juce::Rectangle<float>(10.0f, 0.0f, textW, textH);
-
-    juce::Path p;
-    p.startNewSubPath(textBounds.getRight(), bounds.getY() + textH * 0.5f);
-    p.lineTo(bounds.getRight() - cs, bounds.getY() + textH * 0.5f);
-    p.addArc(bounds.getRight() - cs * 2.0f, bounds.getY() + textH * 0.5f, cs * 2.0f, cs * 2.0f, 0.0f, juce::MathConstants<float>::halfPi);
-    p.lineTo(bounds.getRight(), bounds.getBottom() - cs);
-    p.addArc(bounds.getRight() - cs * 2.0f, bounds.getBottom() - cs * 2.0f, cs * 2.0f, cs * 2.0f, juce::MathConstants<float>::halfPi, juce::MathConstants<float>::pi);
-    p.lineTo(bounds.getX() + cs, bounds.getBottom());
-    p.addArc(bounds.getX(), bounds.getBottom() - cs * 2.0f, cs * 2.0f, cs * 2.0f, juce::MathConstants<float>::pi, juce::MathConstants<float>::pi * 1.5f);
-    p.lineTo(bounds.getX(), bounds.getY() + textH * 0.5f + cs);
-    p.addArc(bounds.getX(), bounds.getY() + textH * 0.5f, cs * 2.0f, cs * 2.0f, juce::MathConstants<float>::pi * 1.5f, juce::MathConstants<float>::twoPi);
-    p.lineTo(textBounds.getX(), bounds.getY() + textH * 0.5f);
-
-    g.setColour(group.findColour(juce::GroupComponent::outlineColourId));
-    g.strokePath(p, juce::PathStrokeType(1.0f));
-
-    if (text.isNotEmpty())
-    {
-        g.setColour(group.findColour(juce::GroupComponent::textColourId));
-        g.setFont(font);
-        g.drawText(text, textBounds, juce::Justification::centred, false);
-    }
+void NoiseRepellentLookAndFeel::drawPopupMenuSectionHeader(
+    juce::Graphics& g, const juce::Rectangle<int>& area,
+    const juce::String& sectionName) {
+  g.setColour(juce::Colour(0xff64748b)); // Slate Gray
+  g.setFont(juce::FontOptions(kFontSizeLabel - 1.0f, juce::Font::bold));
+  g.drawText(sectionName, area.reduced(12, 0), juce::Justification::centredLeft,
+             true);
 }
 
-juce::Font NoiseRepellentLookAndFeel::getComboBoxFont(juce::ComboBox&)
-{
-    return juce::FontOptions(kFontSizeLabel, juce::Font::bold);
-}
-
-juce::Font NoiseRepellentLookAndFeel::getPopupMenuFont()
-{
-    return juce::FontOptions(kFontSizeLabel, juce::Font::plain);
-}
-
-void NoiseRepellentLookAndFeel::drawPopupMenuSectionHeader(juce::Graphics& g, const juce::Rectangle<int>& area, const juce::String& sectionName)
-{
-    g.setColour(juce::Colour(0xff64748b)); // Slate Gray
-    g.setFont(juce::FontOptions(kFontSizeLabel - 1.0f, juce::Font::bold));
-    g.drawText(sectionName, area.reduced(12, 0), juce::Justification::centredLeft, true);
-}
-
-void NoiseRepellentLookAndFeel::getIdealPopupMenuItemSize(const juce::String& text, bool isSeparator, int standardMenuItemHeight, int& idealWidth, int& idealHeight)
-{
-    juce::LookAndFeel_V4::getIdealPopupMenuItemSize(text, isSeparator, standardMenuItemHeight, idealWidth, idealHeight);
-    idealHeight = 24; // Match standard combobox height
+void NoiseRepellentLookAndFeel::getIdealPopupMenuItemSize(
+    const juce::String& text, bool isSeparator, int standardMenuItemHeight,
+    int& idealWidth, int& idealHeight) {
+  juce::LookAndFeel_V4::getIdealPopupMenuItemSize(
+      text, isSeparator, standardMenuItemHeight, idealWidth, idealHeight);
+  idealHeight = 24; // Match standard combobox height
 }

--- a/Source/GUI/LookAndFeel.h
+++ b/Source/GUI/LookAndFeel.h
@@ -21,56 +21,64 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
-class NoiseRepellentLookAndFeel : public juce::LookAndFeel_V4
-{
+class NoiseRepellentLookAndFeel : public juce::LookAndFeel_V4 {
 public:
-    NoiseRepellentLookAndFeel();
-    ~NoiseRepellentLookAndFeel() override = default;
+  NoiseRepellentLookAndFeel();
+  ~NoiseRepellentLookAndFeel() override = default;
 
-    void drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height,
-                          float sliderPos, float minSliderPos, float maxSliderPos,
-                          const juce::Slider::SliderStyle style, juce::Slider& slider) override;
+  void drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height,
+                        float sliderPos, float minSliderPos, float maxSliderPos,
+                        const juce::Slider::SliderStyle style,
+                        juce::Slider& slider) override;
 
-    void drawButtonBackground(juce::Graphics& g, juce::Button& button,
-                               const juce::Colour& backgroundColour,
-                               bool shouldDrawButtonAsHighlighted,
-                               bool shouldDrawButtonAsDown) override;
+  void drawButtonBackground(juce::Graphics& g, juce::Button& button,
+                            const juce::Colour& backgroundColour,
+                            bool shouldDrawButtonAsHighlighted,
+                            bool shouldDrawButtonAsDown) override;
 
-    juce::Font getTextButtonFont(juce::TextButton&, int buttonHeight) override;
+  juce::Font getTextButtonFont(juce::TextButton&, int buttonHeight) override;
 
-    void drawButtonText(juce::Graphics& g, juce::TextButton& button,
+  void drawButtonText(juce::Graphics& g, juce::TextButton& button,
+                      bool shouldDrawButtonAsHighlighted,
+                      bool shouldDrawButtonAsDown) override;
+
+  void drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
                         bool shouldDrawButtonAsHighlighted,
                         bool shouldDrawButtonAsDown) override;
 
-    void drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
-                          bool shouldDrawButtonAsHighlighted,
-                          bool shouldDrawButtonAsDown) override;
+  void drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown,
+                    int buttonX, int buttonY, int buttonW, int buttonH,
+                    juce::ComboBox& box) override;
 
-    void drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown,
-                      int buttonX, int buttonY, int buttonW, int buttonH,
-                      juce::ComboBox& box) override;
+  void drawGroupComponentOutline(juce::Graphics& g, int width, int height,
+                                 const juce::String& text,
+                                 const juce::Justification& position,
+                                 juce::GroupComponent& group) override;
 
-    void drawGroupComponentOutline(juce::Graphics& g, int width, int height,
-                                   const juce::String& text, const juce::Justification& position,
-                                   juce::GroupComponent& group) override;
+  juce::Font getComboBoxFont(juce::ComboBox& box) override;
+  juce::Font getPopupMenuFont() override;
+  void drawPopupMenuSectionHeader(juce::Graphics& g,
+                                  const juce::Rectangle<int>& area,
+                                  const juce::String& sectionName) override;
+  void getIdealPopupMenuItemSize(const juce::String& text, bool isSeparator,
+                                 int standardMenuItemHeight, int& idealWidth,
+                                 int& idealHeight) override;
 
-    juce::Font getComboBoxFont(juce::ComboBox& box) override;
-    juce::Font getPopupMenuFont() override;
-    void drawPopupMenuSectionHeader(juce::Graphics& g, const juce::Rectangle<int>& area, const juce::String& sectionName) override;
-    void getIdealPopupMenuItemSize(const juce::String& text, bool isSeparator, int standardMenuItemHeight, int& idealWidth, int& idealHeight) override;
+  // Domain Colors
+  static const juce::Colour kColorNoiseProfile;   // Warm Amber 0xffe5a000
+  static const juce::Colour kColorDenoising;      // Slate Blue  0xff00b4d8
+  static const juce::Colour kColorFineTuning;     // Slate Gray  0xff64748b
+  static const juce::Colour kColorInputSignal;    // Soft Teal   0xff486581
+  static const juce::Colour kColorTonalPeaks;     // Muted Violet 0xff9d65c9
+  static const juce::Colour kColorReductionCurve; // Soft Green 0xff4caf50
+  static const juce::Colour kColorPanelBg;        // Matte Dark  0xff171a21
+  static const juce::Colour kColorPanelBorder;    // Border      0xff272c37
 
-    // Domain Colors
-    static const juce::Colour kColorNoiseProfile; // Warm Amber 0xffe5a000
-    static const juce::Colour kColorDenoising;    // Slate Blue  0xff00b4d8
-    static const juce::Colour kColorFineTuning;   // Slate Gray  0xff64748b
-    static const juce::Colour kColorInputSignal;  // Soft Teal   0xff486581
-    static const juce::Colour kColorTonalPeaks;   // Muted Violet 0xff9d65c9
-    static const juce::Colour kColorReductionCurve; // Soft Green 0xff4caf50
-    static const juce::Colour kColorPanelBg;      // Matte Dark  0xff171a21
-    static const juce::Colour kColorPanelBorder;  // Border      0xff272c37
-
-    // Typography Scale
-    static constexpr float kFontSizeLabel = 12.0f;  // Standardized UI font size for all labels, headers, buttons, dropdowns
-    static constexpr float kFontSizeTooltip = 13.5f; // Increased font size for footer tooltips
-    static constexpr float kFontSizeBrand = 18.0f;  // Brand name only
+  // Typography Scale
+  static constexpr float kFontSizeLabel =
+      12.0f; // Standardized UI font size for all labels, headers, buttons,
+             // dropdowns
+  static constexpr float kFontSizeTooltip =
+      13.5f; // Increased font size for footer tooltips
+  static constexpr float kFontSizeBrand = 18.0f; // Brand name only
 };

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -19,548 +19,727 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "SpectralVisualizer.h"
 #include "LookAndFeel.h"
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
-SpectralVisualizerComponent::SpectralVisualizerComponent(NoiseRepellentAudioProcessor& p)
-    : processor(p)
-{
-    smoothedInputDB.fill(-100.0f);
-    smoothedOutputDB.fill(-100.0f);
-    startTimerHz(30);
+SpectralVisualizerComponent::SpectralVisualizerComponent(
+    NoiseRepellentAudioProcessor& p)
+    : processor(p) {
+  smoothedInputDB.fill(-100.0f);
+  smoothedOutputDB.fill(-100.0f);
+  startTimerHz(60);
 }
 
-SpectralVisualizerComponent::~SpectralVisualizerComponent()
-{
-    stopTimer();
+SpectralVisualizerComponent::~SpectralVisualizerComponent() {
+  stopTimer();
 }
 
-void SpectralVisualizerComponent::timerCallback()
-{
-    if (processor.getNextSpectralFrame(currentFrame))
-    {
-        const size_t numBins = NoiseRepellentAudioProcessor::kFftBins;
+void SpectralVisualizerComponent::timerCallback() {
+  bool frameReceived = processor.getNextSpectralFrame(currentFrame);
+  if (frameReceived) {
+    const size_t numBins = NoiseRepellentAudioProcessor::kFftBins;
 
-        if (!isSmoothedInitialized)
-        {
-            smoothedInputDB = currentFrame.inputMagnitudeDB;
-            smoothedOutputDB = currentFrame.outputMagnitudeDB;
-            isSmoothedInitialized = true;
-        }
-        else
-        {
-            // Asymmetric Exponential Moving Average (Fast Attack, Smooth Fluid Decay)
-            constexpr float kAttackAlpha  = 0.35f; // Fast response to audio transients
-            constexpr float kReleaseAlpha = 0.10f; // Smooth, liquid decay on falling signals
+    if (!isSmoothedInitialized) {
+      smoothedInputDB = currentFrame.inputMagnitudeDB;
+      smoothedOutputDB = currentFrame.outputMagnitudeDB;
+      isSmoothedInitialized = true;
+    } else {
+      // Asymmetric Exponential Moving Average (Fast Attack, Smooth Fluid Decay)
+      constexpr float kAttackAlpha = 0.35f; // Fast response to audio transients
+      constexpr float kReleaseAlpha =
+          0.10f; // Smooth, liquid decay on falling signals
 
-            for (size_t i = 0; i < numBins; ++i)
-            {
-                float targetIn = currentFrame.inputMagnitudeDB[i];
-                float alphaIn = (targetIn > smoothedInputDB[i]) ? kAttackAlpha : kReleaseAlpha;
-                smoothedInputDB[i] += alphaIn * (targetIn - smoothedInputDB[i]);
+      for (size_t i = 0; i < numBins; ++i) {
+        float targetIn = currentFrame.inputMagnitudeDB[i];
+        float alphaIn =
+            (targetIn > smoothedInputDB[i]) ? kAttackAlpha : kReleaseAlpha;
+        smoothedInputDB[i] += alphaIn * (targetIn - smoothedInputDB[i]);
 
-                float targetOut = currentFrame.outputMagnitudeDB[i];
-                float alphaOut = (targetOut > smoothedOutputDB[i]) ? kAttackAlpha : kReleaseAlpha;
-                smoothedOutputDB[i] += alphaOut * (targetOut - smoothedOutputDB[i]);
-            }
-        }
-
-        repaint();
+        float targetOut = currentFrame.outputMagnitudeDB[i];
+        float alphaOut =
+            (targetOut > smoothedOutputDB[i]) ? kAttackAlpha : kReleaseAlpha;
+        smoothedOutputDB[i] += alphaOut * (targetOut - smoothedOutputDB[i]);
+      }
     }
+  }
+
+  // Update transient protection LED activity synchronized with the displayed frame
+  hpssActive = currentFrame.isHpssActive;
+  bool isProtected = currentFrame.isTransientProtected;
+
+  if (isProtected) {
+    transientHoldTicks = 2; // ~33ms hold at 60Hz
+    ledBrightness = 1.0f;
+  } else if (transientHoldTicks > 0) {
+    transientHoldTicks--;
+    ledBrightness = 1.0f;
+  } else if (ledBrightness > 0.0f) {
+    // Fast, crisp decay back to harmonic state (~35ms)
+    ledBrightness *= 0.40f;
+    if (ledBrightness < 0.01f)
+      ledBrightness = 0.0f;
+  }
+
+  repaint();
 }
 
-void SpectralVisualizerComponent::resized()
-{
+void SpectralVisualizerComponent::resized() {
 }
 
 // Map a frequency (Hz) to an X pixel position using logarithmic scale
-static float freqToX(float freqHz, float width, float minFreq = 20.0f, float maxFreq = 20000.0f)
-{
-    if (freqHz <= minFreq) return 0.0f;
-    if (freqHz >= maxFreq) return width;
-    return (std::log10(freqHz / minFreq) / std::log10(maxFreq / minFreq)) * width;
+static float freqToX(float freqHz, float width, float minFreq = 20.0f,
+                     float maxFreq = 20000.0f) {
+  if (freqHz <= minFreq)
+    return 0.0f;
+  if (freqHz >= maxFreq)
+    return width;
+  return (std::log10(freqHz / minFreq) / std::log10(maxFreq / minFreq)) * width;
 }
 
 // Map a dB value to a Y pixel position
-static float dbToY(float db, float height, float minDB = -100.0f, float maxDB = -20.0f)
-{
-    float clamped = juce::jlimit(minDB, maxDB, db);
-    float normalized = (clamped - minDB) / (maxDB - minDB); // 0 at bottom, 1 at top
-    return height * (1.0f - normalized);
+static float dbToY(float db, float height, float minDB = -100.0f,
+                   float maxDB = -20.0f) {
+  float clamped = juce::jlimit(minDB, maxDB, db);
+  float normalized =
+      (clamped - minDB) / (maxDB - minDB); // 0 at bottom, 1 at top
+  return height * (1.0f - normalized);
 }
 
-// Apply variable fractional-octave spatial frequency smoothing across FFT bins (UI display only).
-// Low frequencies (bass/hum) get minimal smoothing (preserving sharp peaks),
-// while high frequencies get progressively wider smoothing windows matching log-scale visuals.
-static void smoothBinsLogarithmicFrequencyDomain(const float* src, float* dst, size_t numBins)
-{
-    if (numBins == 0) return;
+// Apply variable fractional-octave spatial frequency smoothing across FFT bins
+// (UI display only). Low frequencies (bass/hum) get minimal smoothing
+// (preserving sharp peaks), while high frequencies get progressively wider
+// smoothing windows matching log-scale visuals.
+static void smoothBinsLogarithmicFrequencyDomain(const float* src, float* dst,
+                                                 size_t numBins) {
+  if (numBins == 0)
+    return;
 
-    for (size_t i = 0; i < numBins; ++i)
-    {
-        // Half-window radius grows proportionally with bin index i (fractional octave)
-        // i = 5 (~50 Hz)   -> radius = 0 (exact bin value)
-        // i = 20 (~200 Hz) -> radius = 1 (3-bin window)
-        // i = 100 (~1 kHz) -> radius = 3 (7-bin window)
-        // i = 500 (~5 kHz) -> radius = 12 (25-bin window)
-        // i = 1000 (~10 kHz)-> radius = 20 (41-bin window)
-        int radius = std::clamp(static_cast<int>(std::round(static_cast<float>(i) * 0.025f)), 0, 20);
+  for (size_t i = 0; i < numBins; ++i) {
+    // Half-window radius grows proportionally with bin index i (fractional
+    // octave) i = 5 (~50 Hz)   -> radius = 0 (exact bin value) i = 20 (~200 Hz)
+    // -> radius = 1 (3-bin window) i = 100 (~1 kHz) -> radius = 3 (7-bin
+    // window) i = 500 (~5 kHz) -> radius = 12 (25-bin window) i = 1000 (~10
+    // kHz)-> radius = 20 (41-bin window)
+    int radius = std::clamp(
+        static_cast<int>(std::round(static_cast<float>(i) * 0.025f)), 0, 20);
 
-        if (radius == 0)
-        {
-            dst[i] = src[i];
-            continue;
-        }
-
-        int minIdx = std::max(0, static_cast<int>(i) - radius);
-        int maxIdx = std::min(static_cast<int>(numBins - 1), static_cast<int>(i) + radius);
-
-        float sum = 0.0f;
-        float totalWeight = 0.0f;
-
-        for (int k = minIdx; k <= maxIdx; ++k)
-        {
-            // Triangular window weight: highest weight at center bin i, tapering down to edges
-            float dist = std::abs(static_cast<float>(k - static_cast<int>(i)));
-            float weight = 1.0f - (dist / static_cast<float>(radius + 1));
-
-            sum += src[k] * weight;
-            totalWeight += weight;
-        }
-
-        dst[i] = (totalWeight > 0.0f) ? (sum / totalWeight) : src[i];
+    if (radius == 0) {
+      dst[i] = src[i];
+      continue;
     }
+
+    int minIdx = std::max(0, static_cast<int>(i) - radius);
+    int maxIdx =
+        std::min(static_cast<int>(numBins - 1), static_cast<int>(i) + radius);
+
+    float sum = 0.0f;
+    float totalWeight = 0.0f;
+
+    for (int k = minIdx; k <= maxIdx; ++k) {
+      // Triangular window weight: highest weight at center bin i, tapering down
+      // to edges
+      float dist = std::abs(static_cast<float>(k - static_cast<int>(i)));
+      float weight = 1.0f - (dist / static_cast<float>(radius + 1));
+
+      sum += src[k] * weight;
+      totalWeight += weight;
+    }
+
+    dst[i] = (totalWeight > 0.0f) ? (sum / totalWeight) : src[i];
+  }
 }
 
-void SpectralVisualizerComponent::paint(juce::Graphics& g)
-{
-    g.fillAll(juce::Colour(0xff232832));
+void SpectralVisualizerComponent::paint(juce::Graphics& g) {
+  g.fillAll(juce::Colour(0xff232832));
 
-    const float w = static_cast<float>(getWidth());
-    const float h = static_cast<float>(getHeight());
-    const float minDB = -100.0f;
-    const float maxDB = -20.0f;
-    const float minFreq = 20.0f;
-    const float maxFreq = 20000.0f;
+  const float w = static_cast<float>(getWidth());
+  const float h = static_cast<float>(getHeight());
+  const float minDB = -100.0f;
+  const float maxDB = -20.0f;
+  const float minFreq = 20.0f;
+  const float maxFreq = 20000.0f;
 
-    const double sampleRate = processor.getSampleRate();
-    const size_t numBins = NoiseRepellentAudioProcessor::kFftBins;
-    const float binWidth = static_cast<float>(sampleRate) / static_cast<float>(NoiseRepellentAudioProcessor::kFftSize);
+  const double sampleRate = processor.getSampleRate();
+  const size_t numBins = NoiseRepellentAudioProcessor::kFftBins;
+  const float binWidth =
+      static_cast<float>(sampleRate) /
+      static_cast<float>(NoiseRepellentAudioProcessor::kFftSize);
 
-    // Frequency-domain spatially smoothed display buffers (UI display smoothing only)
-    std::vector<float> freqSmoothedInput(numBins);
-    std::vector<float> freqSmoothedOutput(numBins);
-    std::vector<float> freqSmoothedProfile(numBins);
+  // Frequency-domain spatially smoothed display buffers (UI display smoothing
+  // only)
+  std::vector<float> freqSmoothedInput(numBins);
+  std::vector<float> freqSmoothedOutput(numBins);
+  std::vector<float> freqSmoothedProfile(numBins);
 
-    smoothBinsLogarithmicFrequencyDomain(smoothedInputDB.data(), freqSmoothedInput.data(), numBins);
-    smoothBinsLogarithmicFrequencyDomain(smoothedOutputDB.data(), freqSmoothedOutput.data(), numBins);
-    if (currentFrame.hasNoiseProfile) {
-        smoothBinsLogarithmicFrequencyDomain(currentFrame.noiseFloorDB.data(), freqSmoothedProfile.data(), numBins);
-    }
+  smoothBinsLogarithmicFrequencyDomain(smoothedInputDB.data(),
+                                       freqSmoothedInput.data(), numBins);
+  smoothBinsLogarithmicFrequencyDomain(smoothedOutputDB.data(),
+                                       freqSmoothedOutput.data(), numBins);
+  if (currentFrame.hasNoiseProfile) {
+    smoothBinsLogarithmicFrequencyDomain(currentFrame.noiseFloorDB.data(),
+                                         freqSmoothedProfile.data(), numBins);
+  }
 
-    // ── Grid lines ──
-    g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
+  // ── Grid lines ──
+  g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                              juce::Font::bold));
 
-    // dB Y-grid (-90 dB to -20 dB in 10 dB steps)
-    for (int db = -90; db <= -20; db += 10)
+  // dB Y-grid (-90 dB to -20 dB in 10 dB steps)
+  for (int db = -90; db <= -20; db += 10) {
+    float y = dbToY(static_cast<float>(db), h, minDB, maxDB);
+    g.setColour(juce::Colour(0xff3d4657));
+    g.drawHorizontalLine(static_cast<int>(y), 0.0f, w);
+
+    g.setColour(juce::Colour(0xffa8b3c4));
+    juce::String label = juce::String(db) + " dB";
+    g.drawText(label, 8, static_cast<int>(y) - 12, 60, 12,
+               juce::Justification::left);
+  }
+
+  // Frequency X-grid (logarithmic)
+  static const float freqs[] = {50,   100,  200,   500,  1000,
+                                2000, 5000, 10000, 20000};
+  for (float f : freqs) {
+    float x = freqToX(f, w, minFreq, maxFreq);
+    g.setColour(juce::Colour(0xff3d4657));
+    g.drawVerticalLine(static_cast<int>(x), 0.0f, h);
+
+    g.setColour(juce::Colour(0xffa8b3c4));
+    juce::String label = f >= 1000.0f ? juce::String(f / 1000.0f, 0) + "k"
+                                      : juce::String(static_cast<int>(f));
+    g.drawText(label, static_cast<int>(x) + 4, static_cast<int>(h) - 14, 40, 12,
+               juce::Justification::left);
+  }
+
+  // ── Helper: build a path by mapping FFT bins to log-frequency X positions ──
+  auto buildLogFreqPath = [&](const float* dbData, size_t bins) -> juce::Path {
+    juce::Path path;
+    bool started = false;
+
+    for (size_t i = 1; i < bins; ++i) // skip bin 0 (DC)
     {
-        float y = dbToY(static_cast<float>(db), h, minDB, maxDB);
-        g.setColour(juce::Colour(0xff3d4657));
-        g.drawHorizontalLine(static_cast<int>(y), 0.0f, w);
+      float freq = static_cast<float>(i) * binWidth;
+      if (freq < minFreq || freq > maxFreq)
+        continue;
 
-        g.setColour(juce::Colour(0xffa8b3c4));
-        juce::String label = juce::String(db) + " dB";
-        g.drawText(label, 8, static_cast<int>(y) - 12, 60, 12, juce::Justification::left);
+      float x = freqToX(freq, w, minFreq, maxFreq);
+      float y = dbToY(dbData[i], h, minDB, maxDB);
+
+      if (!started) {
+        path.startNewSubPath(x, y);
+        started = true;
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    return path;
+  };
+
+  // 1. Input Signal Spectrum (Filled Translucent Area)
+  {
+    juce::Path inputAreaPath;
+    bool started = false;
+    float firstX = 0.0f;
+    float lastX = 0.0f;
+
+    for (size_t i = 1; i < numBins; ++i) {
+      float freq = static_cast<float>(i) * binWidth;
+      if (freq < minFreq || freq > maxFreq)
+        continue;
+
+      float x = freqToX(freq, w, minFreq, maxFreq);
+      float y = dbToY(freqSmoothedInput[i], h, minDB, maxDB);
+
+      if (!started) {
+        firstX = x;
+        inputAreaPath.startNewSubPath(x, h);
+        inputAreaPath.lineTo(x, y);
+        started = true;
+      } else {
+        inputAreaPath.lineTo(x, y);
+      }
+      lastX = x;
     }
 
-    // Frequency X-grid (logarithmic)
-    static const float freqs[] = { 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000 };
-    for (float f : freqs)
-    {
-        float x = freqToX(f, w, minFreq, maxFreq);
-        g.setColour(juce::Colour(0xff3d4657));
-        g.drawVerticalLine(static_cast<int>(x), 0.0f, h);
+    if (started) {
+      inputAreaPath.lineTo(lastX, h);
+      inputAreaPath.lineTo(firstX, h);
+      inputAreaPath.closeSubPath();
 
-        g.setColour(juce::Colour(0xffa8b3c4));
-        juce::String label = f >= 1000.0f ? juce::String(f / 1000.0f, 0) + "k" : juce::String(static_cast<int>(f));
-        g.drawText(label, static_cast<int>(x) + 4, static_cast<int>(h) - 14, 40, 12, juce::Justification::left);
+      g.setColour(
+          NoiseRepellentLookAndFeel::kColorInputSignal.withAlpha(0.30f));
+      g.fillPath(inputAreaPath);
     }
+  }
 
-    // ── Helper: build a path by mapping FFT bins to log-frequency X positions ──
-    auto buildLogFreqPath = [&](const float* dbData, size_t bins) -> juce::Path {
-        juce::Path path;
-        bool started = false;
+  // 2. Denoised Output Signal Curve (Bright Solid Cyan Line)
+  {
+    juce::Path outputPath =
+        buildLogFreqPath(freqSmoothedOutput.data(), numBins);
+    g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
+    g.strokePath(outputPath, juce::PathStrokeType(1.8f));
+  }
 
-        for (size_t i = 1; i < bins; ++i) // skip bin 0 (DC)
-        {
-            float freq = static_cast<float>(i) * binWidth;
-            if (freq < minFreq || freq > maxFreq) continue;
+  // 3. Noise Floor Profile Curve (Solid Warm Amber Line)
+  if (currentFrame.hasNoiseProfile) {
+    juce::Path noisePath =
+        buildLogFreqPath(freqSmoothedProfile.data(), numBins);
+    g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
+    g.strokePath(noisePath, juce::PathStrokeType(2.0f));
+  }
 
-            float x = freqToX(freq, w, minFreq, maxFreq);
-            float y = dbToY(dbData[i], h, minDB, maxDB);
-
-            if (!started) {
-                path.startNewSubPath(x, y);
-                started = true;
-            } else {
-                path.lineTo(x, y);
-            }
-        }
-        return path;
-    };
-
-    // 1. Input Signal Spectrum (Filled Translucent Area)
-    {
-        juce::Path inputAreaPath;
-        bool started = false;
-        float firstX = 0.0f;
-        float lastX = 0.0f;
-
-        for (size_t i = 1; i < numBins; ++i)
-        {
-            float freq = static_cast<float>(i) * binWidth;
-            if (freq < minFreq || freq > maxFreq) continue;
-
-            float x = freqToX(freq, w, minFreq, maxFreq);
-            float y = dbToY(freqSmoothedInput[i], h, minDB, maxDB);
-
-            if (!started) {
-                firstX = x;
-                inputAreaPath.startNewSubPath(x, h);
-                inputAreaPath.lineTo(x, y);
-                started = true;
-            } else {
-                inputAreaPath.lineTo(x, y);
-            }
-            lastX = x;
-        }
-
-        if (started) {
-            inputAreaPath.lineTo(lastX, h);
-            inputAreaPath.lineTo(firstX, h);
-            inputAreaPath.closeSubPath();
-
-            g.setColour(NoiseRepellentLookAndFeel::kColorInputSignal.withAlpha(0.30f));
-            g.fillPath(inputAreaPath);
-        }
-    }
-
-    // 2. Denoised Output Signal Curve (Bright Solid Cyan Line)
-    {
-        juce::Path outputPath = buildLogFreqPath(freqSmoothedOutput.data(), numBins);
-        g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
-        g.strokePath(outputPath, juce::PathStrokeType(1.8f));
-    }
-
-    // 3. Noise Floor Profile Curve (Solid Warm Amber Line)
-    if (currentFrame.hasNoiseProfile)
-    {
-        juce::Path noisePath = buildLogFreqPath(freqSmoothedProfile.data(), numBins);
-        g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
-        g.strokePath(noisePath, juce::PathStrokeType(2.0f));
-    }
-
-    // 3b. Reduction Curve Bias Overlay & Nodes
-    if (currentFrame.reductionCurveEnabled)
-    {
-        const auto& nodes = processor.getCurveNodes();
-        if (nodes.size() >= 2)
-        {
-            auto nodeToPoint = [&](const NoiseRepellentAudioProcessor::CurveNode& n) -> juce::Point<float> {
-                float nx = std::clamp(n.normX, 0.0f, 1.0f);
-                float ny = h * 0.5f - (n.biasDB / 24.0f) * (h * 0.4f);
-                return { nx * w, ny };
-            };
-
-            // Draw zero-bias centerline (dashed soft green)
-            g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve.withAlpha(0.35f));
-            juce::Line<float> zeroLine(0.0f, h * 0.5f, w, h * 0.5f);
-            float dashLen[] = { 4.0f, 4.0f };
-            g.drawDashedLine(zeroLine, dashLen, 2, 1.0f);
-
-            // Draw smooth cubic spline curve path using JUCE Path cubicTo
-            juce::Path curvePath;
-            juce::Point<float> pStart = nodeToPoint(nodes.front());
-            curvePath.startNewSubPath(pStart);
-
-            size_t numNodes = nodes.size();
-            if (numNodes == 2)
-            {
-                curvePath.lineTo(nodeToPoint(nodes.back()));
-            }
-            else
-            {
-                std::vector<juce::Point<float>> pts(numNodes);
-                for (size_t i = 0; i < numNodes; ++i)
-                    pts[i] = nodeToPoint(nodes[i]);
-
-                std::vector<float> dY(numNodes - 1);
-                std::vector<float> dX(numNodes - 1);
-                for (size_t i = 0; i < numNodes - 1; ++i)
-                {
-                    dX[i] = pts[i + 1].x - pts[i].x;
-                    dY[i] = pts[i + 1].y - pts[i].y;
-                }
-
-                std::vector<float> m(numNodes, 0.0f);
-                m.front() = (dX.front() > 1e-5f) ? dY.front() / dX.front() : 0.0f;
-                m.back() = (dX.back() > 1e-5f) ? dY.back() / dX.back() : 0.0f;
-
-                for (size_t i = 1; i < numNodes - 1; ++i)
-                {
-                    float secant1 = (dX[i - 1] > 1e-5f) ? dY[i - 1] / dX[i - 1] : 0.0f;
-                    float secant2 = (dX[i] > 1e-5f) ? dY[i] / dX[i] : 0.0f;
-                    if (secant1 * secant2 <= 0.0f)
-                        m[i] = 0.0f;
-                    else
-                        m[i] = 0.5f * (secant1 + secant2);
-                }
-
-                for (size_t i = 0; i < numNodes - 1; ++i)
-                {
-                    float dx = dX[i];
-                    juce::Point<float> c1(pts[i].x + (1.0f / 3.0f) * dx, pts[i].y + (1.0f / 3.0f) * dx * m[i]);
-                    juce::Point<float> c2(pts[i + 1].x - (1.0f / 3.0f) * dx, pts[i + 1].y - (1.0f / 3.0f) * dx * m[i + 1]);
-                    curvePath.cubicTo(c1, c2, pts[i + 1]);
-                }
-            }
-
-            g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
-            g.strokePath(curvePath, juce::PathStrokeType(2.2f));
-
-            // Draw nodes
-            for (size_t i = 0; i < nodes.size(); ++i)
-            {
-                juce::Point<float> pt = nodeToPoint(nodes[i]);
-                g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
-                g.fillEllipse(pt.x - 5.0f, pt.y - 5.0f, 10.0f, 10.0f);
-                g.setColour(juce::Colours::white);
-                g.drawEllipse(pt.x - 5.0f, pt.y - 5.0f, 10.0f, 10.0f, 1.5f);
-            }
-
-            // Draw dB Reference Y-Scale for Reduction Curve on Right Margin
-            const float scaleX = w - 42.0f;
-            const float textX = w - 38.0f;
-            static const int biasLevels[] = { +24, +12, 0, -12, -24 };
-
-            for (int biasVal : biasLevels)
-            {
-                float ny = h * 0.5f - (static_cast<float>(biasVal) / 24.0f) * (h * 0.4f);
-                g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve.withAlpha(0.35f));
-                g.drawHorizontalLine(static_cast<int>(ny), scaleX, w);
-
-                g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
-                g.setFont(juce::FontOptions(10.0f, juce::Font::bold));
-                int reductionVal = -biasVal;
-                juce::String labelStr = (reductionVal > 0 ? "+" : "") + juce::String(reductionVal) + "dB";
-                g.drawText(labelStr, static_cast<int>(textX), static_cast<int>(ny) - 7, 36, 14, juce::Justification::left);
-            }
-        }
-    }
-
-    // 4. Tonal Peak Markers (Dashed vertical lines with staggered multi-tier frequency tags; shown ONLY when Reduction is UNLINKED)
-    if (!currentFrame.isLinked && currentFrame.hasNoiseProfile && !currentFrame.tonalPeaksHz.empty())
-    {
-        // 3 Y-tiers starting at Y = 42.0f to guarantee zero collision with top HUD overlay bar
-        constexpr float kStartTagY = 42.0f;
-        float lastTagRight[3] = { -100.0f, -100.0f, -100.0f };
-
-        for (float peakHz : currentFrame.tonalPeaksHz)
-        {
-            float x = freqToX(peakHz, w, minFreq, maxFreq);
-            if (x <= 4.0f || x >= w - 4.0f) continue;
-
-            // Dashed vertical line across the display
-            juce::Line<float> line(x, 0.0f, x, h);
-            float dashLengths[] = { 3.0f, 3.0f };
-            g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.75f));
-            g.drawDashedLine(line, dashLengths, 2, 1.5f);
-
-            // Frequency Tag Badge
-            juce::String tag = peakHz >= 1000.0f ? juce::String(peakHz / 1000.0f, 1) + "k" : juce::String(static_cast<int>(peakHz)) + "Hz";
-            float tagW = 38.0f;
-            float tagH = 14.0f;
-            float tagX = std::clamp(x - tagW * 0.5f, 4.0f, w - tagW - 4.0f);
-
-            // Find first non-colliding Y-tier
-            int chosenTier = -1;
-            for (int t = 0; t < 3; ++t) {
-                if (tagX > lastTagRight[t] + 2.0f) {
-                    chosenTier = t;
-                    break;
-                }
-            }
-
-            if (chosenTier != -1)
-            {
-                float tagY = kStartTagY + static_cast<float>(chosenTier) * 16.0f;
-
-                // Draw vertical leader connector line from top to badge
-                g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.5f));
-                g.drawVerticalLine(static_cast<int>(x), 0.0f, tagY);
-
-                g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.9f));
-                g.fillRoundedRectangle(tagX, tagY, tagW, tagH, 3.0f);
-
-                g.setColour(juce::Colours::white);
-                g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
-                g.drawText(tag, static_cast<int>(tagX), static_cast<int>(tagY), static_cast<int>(tagW), static_cast<int>(tagH), juce::Justification::centred);
-
-                lastTagRight[chosenTier] = tagX + tagW;
-            }
-        }
-    }
-
-    // 5. HUD Color Legend (Top-Right Overlay, positioned to the left of Advanced Controls button)
-    {
-        const bool showTonalSwatch = !currentFrame.isLinked;
-        const bool showCurveSwatch = currentFrame.reductionCurveEnabled;
-        const float padding = 10.0f;
-        const float swatch1W = 10.0f + 4.0f + 32.0f + 14.0f; // Input (60)
-        const float swatch2W = 12.0f + 4.0f + 38.0f + 14.0f; // Profile (68)
-        const float swatch3W = 12.0f + 4.0f + 40.0f + ((showTonalSwatch || showCurveSwatch) ? 14.0f : 0.0f); // Output
-        const float swatch4W = showTonalSwatch ? (12.0f + 4.0f + 64.0f + (showCurveSwatch ? 14.0f : 0.0f)) : 0.0f; // Tonal Peaks
-        const float swatch5W = showCurveSwatch ? (12.0f + 4.0f + 38.0f) : 0.0f; // Curve (54)
-
-        const float legendW = padding + swatch1W + swatch2W + swatch3W + swatch4W + swatch5W + padding;
-        const float legendH = 24.0f;
-        const float legendX = (w - legendW) * 0.5f;
-        const float legendY = 10.0f;
-
-        if (legendX >= 10.0f && (legendX + legendW) <= w - 10.0f)
-        {
-            // Semi-transparent dark glass background
-            g.setColour(juce::Colour(0xeb252a35));
-            g.fillRoundedRectangle(legendX, legendY, legendW, legendH, 4.0f);
-            g.setColour(juce::Colour(0xff4c566a));
-            g.drawRoundedRectangle(legendX, legendY, legendW, legendH, 4.0f, 1.0f);
-
-            g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
-
-            float curX = legendX + padding;
-
-            // Swatch 1: Live Input (Filled Area)
-            g.setColour(NoiseRepellentLookAndFeel::kColorInputSignal.withAlpha(0.70f));
-            g.fillRect(curX, legendY + 7.0f, 10.0f, 8.0f);
-            curX += 14.0f;
-            g.setColour(juce::Colour(0xffd8e0ec));
-            g.drawText("Input", static_cast<int>(curX), static_cast<int>(legendY), 32, static_cast<int>(legendH), juce::Justification::left);
-            curX += 32.0f + 14.0f;
-
-            // Swatch 2: Noise Profile (Solid Amber Line)
-            g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
-            g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
-            curX += 16.0f;
-            g.setColour(juce::Colour(0xffd8e0ec));
-            g.drawText("Profile", static_cast<int>(curX), static_cast<int>(legendY), 38, static_cast<int>(legendH), juce::Justification::left);
-            curX += 38.0f + 14.0f;
-
-            // Swatch 3: Output Area (Solid Cyan Line)
-            g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
-            g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
-            curX += 16.0f;
-            g.setColour(juce::Colour(0xffd8e0ec));
-            g.drawText("Output", static_cast<int>(curX), static_cast<int>(legendY), 40, static_cast<int>(legendH), juce::Justification::left);
-            curX += 40.0f;
-
-            // Swatch 4: Tonal Peaks (Only when Reduction is Unlinked)
-            if (showTonalSwatch)
-            {
-                curX += 14.0f;
-                g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks);
-                juce::Line<float> dashLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f);
-                float dLen[] = { 2.0f, 2.0f };
-                g.drawDashedLine(dashLine, dLen, 2, 1.5f);
-                curX += 16.0f;
-                g.setColour(juce::Colour(0xffd8e0ec));
-                g.drawText("Tonal Peaks", static_cast<int>(curX), static_cast<int>(legendY), 64, static_cast<int>(legendH), juce::Justification::left);
-                curX += 64.0f;
-            }
-
-            // Swatch 5: Reduction Curve (Only when enabled)
-            if (showCurveSwatch)
-            {
-                curX += 14.0f;
-                g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
-                g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
-                curX += 16.0f;
-                g.setColour(juce::Colour(0xffd8e0ec));
-                g.drawText("Curve", static_cast<int>(curX), static_cast<int>(legendY), 38, static_cast<int>(legendH), juce::Justification::left);
-            }
-        }
-    }
-}
-
-void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e)
-{
-    activeDragTarget = DragTarget::None;
-    activeNodeIndex = -1;
-    dragStartPos = e.position;
-
-    const float w = static_cast<float>(getWidth());
-    const float h = static_cast<float>(getHeight());
-
-    // Check Reduction Curve nodes (if enabled)
-    if (currentFrame.reductionCurveEnabled)
-    {
-        const auto& nodes = processor.getCurveNodes();
-        for (size_t i = 0; i < nodes.size(); ++i)
-        {
-            float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
-            float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
-            if (e.position.getDistanceFrom({ nx * w, ny }) <= 12.0f)
-            {
-                activeDragTarget = DragTarget::CurveNode;
-                activeNodeIndex = static_cast<int>(i);
-                return;
-            }
-        }
-
-        // Add a new curve node on empty click
-        float clickNormX = std::clamp(e.position.x / w, 0.01f, 0.99f);
-        float clickBiasDB = std::clamp(((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f, -24.0f, 24.0f);
-        processor.addCurveNode(clickNormX, clickBiasDB);
-        repaint();
-    }
-}
-
-void SpectralVisualizerComponent::mouseDrag(const juce::MouseEvent& e)
-{
-    const float w = static_cast<float>(getWidth());
-    const float h = static_cast<float>(getHeight());
-
-    if (activeDragTarget == DragTarget::CurveNode && activeNodeIndex >= 0)
-    {
-        float normX = std::clamp(e.position.x / w, 0.0f, 1.0f);
-        float biasDB = std::clamp(((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f, -24.0f, 24.0f);
-        processor.updateCurveNode(activeNodeIndex, normX, biasDB);
-        repaint();
-    }
-}
-
-void SpectralVisualizerComponent::mouseUp(const juce::MouseEvent&)
-{
-    activeDragTarget = DragTarget::None;
-    activeNodeIndex = -1;
-}
-
-void SpectralVisualizerComponent::mouseDoubleClick(const juce::MouseEvent& e)
-{
-    if (!currentFrame.reductionCurveEnabled) return;
-
-    const float w = static_cast<float>(getWidth());
-    const float h = static_cast<float>(getHeight());
+  // 3b. Reduction Curve Bias Overlay & Nodes
+  if (currentFrame.reductionCurveEnabled) {
     const auto& nodes = processor.getCurveNodes();
+    if (nodes.size() >= 2) {
+      auto nodeToPoint = [&](const NoiseRepellentAudioProcessor::CurveNode& n)
+          -> juce::Point<float> {
+        float nx = std::clamp(n.normX, 0.0f, 1.0f);
+        float ny = h * 0.5f - (n.biasDB / 24.0f) * (h * 0.4f);
+        return {nx * w, ny};
+      };
 
-    for (size_t i = 1; i < nodes.size() - 1; ++i)
-    {
-        float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
-        float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
-        if (e.position.getDistanceFrom({ nx * w, ny }) <= 12.0f)
-        {
-            processor.removeCurveNode(static_cast<int>(i));
-            repaint();
-            return;
+      // Draw zero-bias centerline (dashed soft green)
+      g.setColour(
+          NoiseRepellentLookAndFeel::kColorReductionCurve.withAlpha(0.35f));
+      juce::Line<float> zeroLine(0.0f, h * 0.5f, w, h * 0.5f);
+      float dashLen[] = {4.0f, 4.0f};
+      g.drawDashedLine(zeroLine, dashLen, 2, 1.0f);
+
+      // Draw smooth cubic spline curve path using JUCE Path cubicTo
+      juce::Path curvePath;
+      juce::Point<float> pStart = nodeToPoint(nodes.front());
+      curvePath.startNewSubPath(pStart);
+
+      size_t numNodes = nodes.size();
+      if (numNodes == 2) {
+        curvePath.lineTo(nodeToPoint(nodes.back()));
+      } else {
+        std::vector<juce::Point<float>> pts(numNodes);
+        for (size_t i = 0; i < numNodes; ++i)
+          pts[i] = nodeToPoint(nodes[i]);
+
+        std::vector<float> dY(numNodes - 1);
+        std::vector<float> dX(numNodes - 1);
+        for (size_t i = 0; i < numNodes - 1; ++i) {
+          dX[i] = pts[i + 1].x - pts[i].x;
+          dY[i] = pts[i + 1].y - pts[i].y;
         }
+
+        std::vector<float> m(numNodes, 0.0f);
+        m.front() = (dX.front() > 1e-5f) ? dY.front() / dX.front() : 0.0f;
+        m.back() = (dX.back() > 1e-5f) ? dY.back() / dX.back() : 0.0f;
+
+        for (size_t i = 1; i < numNodes - 1; ++i) {
+          float secant1 = (dX[i - 1] > 1e-5f) ? dY[i - 1] / dX[i - 1] : 0.0f;
+          float secant2 = (dX[i] > 1e-5f) ? dY[i] / dX[i] : 0.0f;
+          if (secant1 * secant2 <= 0.0f)
+            m[i] = 0.0f;
+          else
+            m[i] = 0.5f * (secant1 + secant2);
+        }
+
+        for (size_t i = 0; i < numNodes - 1; ++i) {
+          float dx = dX[i];
+          juce::Point<float> c1(pts[i].x + (1.0f / 3.0f) * dx,
+                                pts[i].y + (1.0f / 3.0f) * dx * m[i]);
+          juce::Point<float> c2(pts[i + 1].x - (1.0f / 3.0f) * dx,
+                                pts[i + 1].y - (1.0f / 3.0f) * dx * m[i + 1]);
+          curvePath.cubicTo(c1, c2, pts[i + 1]);
+        }
+      }
+
+      g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
+      g.strokePath(curvePath, juce::PathStrokeType(2.2f));
+
+      // Draw nodes
+      for (size_t i = 0; i < nodes.size(); ++i) {
+        juce::Point<float> pt = nodeToPoint(nodes[i]);
+        g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
+        g.fillEllipse(pt.x - 5.0f, pt.y - 5.0f, 10.0f, 10.0f);
+        g.setColour(juce::Colours::white);
+        g.drawEllipse(pt.x - 5.0f, pt.y - 5.0f, 10.0f, 10.0f, 1.5f);
+      }
+
+      // Draw dB Reference Y-Scale for Reduction Curve on Right Margin
+      const float scaleX = w - 42.0f;
+      const float textX = w - 38.0f;
+      static const int biasLevels[] = {+24, +12, 0, -12, -24};
+
+      for (int biasVal : biasLevels) {
+        float ny =
+            h * 0.5f - (static_cast<float>(biasVal) / 24.0f) * (h * 0.4f);
+        g.setColour(
+            NoiseRepellentLookAndFeel::kColorReductionCurve.withAlpha(0.35f));
+        g.drawHorizontalLine(static_cast<int>(ny), scaleX, w);
+
+        g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
+        g.setFont(juce::FontOptions(10.0f, juce::Font::bold));
+        int reductionVal = -biasVal;
+        juce::String labelStr =
+            (reductionVal > 0 ? "+" : "") + juce::String(reductionVal) + "dB";
+        g.drawText(labelStr, static_cast<int>(textX), static_cast<int>(ny) - 7,
+                   36, 14, juce::Justification::left);
+      }
     }
+  }
+
+  // 4. Tonal Peak Markers (Dashed vertical lines with staggered multi-tier
+  // frequency tags; shown ONLY when Reduction is UNLINKED)
+  if (!currentFrame.isLinked && currentFrame.hasNoiseProfile &&
+      !currentFrame.tonalPeaksHz.empty()) {
+    // 3 Y-tiers starting at Y = 42.0f to guarantee zero collision with top HUD
+    // overlay bar
+    constexpr float kStartTagY = 42.0f;
+    float lastTagRight[3] = {-100.0f, -100.0f, -100.0f};
+
+    for (float peakHz : currentFrame.tonalPeaksHz) {
+      float x = freqToX(peakHz, w, minFreq, maxFreq);
+      if (x <= 4.0f || x >= w - 4.0f)
+        continue;
+
+      // Dashed vertical line across the display
+      juce::Line<float> line(x, 0.0f, x, h);
+      float dashLengths[] = {3.0f, 3.0f};
+      g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.75f));
+      g.drawDashedLine(line, dashLengths, 2, 1.5f);
+
+      // Frequency Tag Badge
+      juce::String tag = peakHz >= 1000.0f
+                             ? juce::String(peakHz / 1000.0f, 1) + "k"
+                             : juce::String(static_cast<int>(peakHz)) + "Hz";
+      float tagW = 38.0f;
+      float tagH = 14.0f;
+      float tagX = std::clamp(x - tagW * 0.5f, 4.0f, w - tagW - 4.0f);
+
+      // Find first non-colliding Y-tier
+      int chosenTier = -1;
+      for (int t = 0; t < 3; ++t) {
+        if (tagX > lastTagRight[t] + 2.0f) {
+          chosenTier = t;
+          break;
+        }
+      }
+
+      if (chosenTier != -1) {
+        float tagY = kStartTagY + static_cast<float>(chosenTier) * 16.0f;
+
+        // Draw vertical leader connector line from top to badge
+        g.setColour(
+            NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.5f));
+        g.drawVerticalLine(static_cast<int>(x), 0.0f, tagY);
+
+        g.setColour(
+            NoiseRepellentLookAndFeel::kColorTonalPeaks.withAlpha(0.9f));
+        g.fillRoundedRectangle(tagX, tagY, tagW, tagH, 3.0f);
+
+        g.setColour(juce::Colours::white);
+        g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                                    juce::Font::bold));
+        g.drawText(tag, static_cast<int>(tagX), static_cast<int>(tagY),
+                   static_cast<int>(tagW), static_cast<int>(tagH),
+                   juce::Justification::centred);
+
+        lastTagRight[chosenTier] = tagX + tagW;
+      }
+    }
+  }
+
+  // 5. HUD Color Legend (Top-Right Overlay, positioned to the left of Advanced
+  // Controls button)
+  {
+    const bool showTonalSwatch = !currentFrame.isLinked;
+    const bool showCurveSwatch = currentFrame.reductionCurveEnabled;
+    const float padding = 10.0f;
+    const float swatch1W = 10.0f + 4.0f + 32.0f + 14.0f; // Input (60)
+    const float swatch2W = 12.0f + 4.0f + 38.0f + 14.0f; // Profile (68)
+    const float swatch3W =
+        12.0f + 4.0f + 40.0f +
+        ((showTonalSwatch || showCurveSwatch) ? 14.0f : 0.0f); // Output
+    const float swatch4W =
+        showTonalSwatch
+            ? (12.0f + 4.0f + 64.0f + (showCurveSwatch ? 14.0f : 0.0f))
+            : 0.0f; // Tonal Peaks
+    const float swatch5W =
+        showCurveSwatch ? (12.0f + 4.0f + 38.0f) : 0.0f; // Curve (54)
+
+    const float legendW = padding + swatch1W + swatch2W + swatch3W + swatch4W +
+                          swatch5W + padding;
+    const float legendH = 24.0f;
+    const float legendX = (w - legendW) * 0.5f;
+    const float legendY = 10.0f;
+
+    if (legendX >= 10.0f && (legendX + legendW) <= w - 10.0f) {
+      // Semi-transparent dark glass background
+      g.setColour(juce::Colour(0xeb252a35));
+      g.fillRoundedRectangle(legendX, legendY, legendW, legendH, 4.0f);
+      g.setColour(juce::Colour(0xff4c566a));
+      g.drawRoundedRectangle(legendX, legendY, legendW, legendH, 4.0f, 1.0f);
+
+      g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                                  juce::Font::bold));
+
+      float curX = legendX + padding;
+
+      // Swatch 1: Live Input (Filled Area)
+      g.setColour(
+          NoiseRepellentLookAndFeel::kColorInputSignal.withAlpha(0.70f));
+      g.fillRect(curX, legendY + 7.0f, 10.0f, 8.0f);
+      curX += 14.0f;
+      g.setColour(juce::Colour(0xffd8e0ec));
+      g.drawText("Input", static_cast<int>(curX), static_cast<int>(legendY), 32,
+                 static_cast<int>(legendH), juce::Justification::left);
+      curX += 32.0f + 14.0f;
+
+      // Swatch 2: Noise Profile (Solid Amber Line)
+      g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
+      g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
+      curX += 16.0f;
+      g.setColour(juce::Colour(0xffd8e0ec));
+      g.drawText("Profile", static_cast<int>(curX), static_cast<int>(legendY),
+                 38, static_cast<int>(legendH), juce::Justification::left);
+      curX += 38.0f + 14.0f;
+
+      // Swatch 3: Output Area (Solid Cyan Line)
+      g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
+      g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
+      curX += 16.0f;
+      g.setColour(juce::Colour(0xffd8e0ec));
+      g.drawText("Output", static_cast<int>(curX), static_cast<int>(legendY),
+                 40, static_cast<int>(legendH), juce::Justification::left);
+      curX += 40.0f;
+
+      // Swatch 4: Tonal Peaks (Only when Reduction is Unlinked)
+      if (showTonalSwatch) {
+        curX += 14.0f;
+        g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks);
+        juce::Line<float> dashLine(curX, legendY + 11.0f, curX + 12.0f,
+                                   legendY + 11.0f);
+        float dLen[] = {2.0f, 2.0f};
+        g.drawDashedLine(dashLine, dLen, 2, 1.5f);
+        curX += 16.0f;
+        g.setColour(juce::Colour(0xffd8e0ec));
+        g.drawText("Tonal Peaks", static_cast<int>(curX),
+                   static_cast<int>(legendY), 64, static_cast<int>(legendH),
+                   juce::Justification::left);
+        curX += 64.0f;
+      }
+
+      // Swatch 5: Reduction Curve (Only when enabled)
+      if (showCurveSwatch) {
+        curX += 14.0f;
+        g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
+        g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
+        curX += 16.0f;
+        g.setColour(juce::Colour(0xffd8e0ec));
+        g.drawText("Curve", static_cast<int>(curX), static_cast<int>(legendY),
+                   38, static_cast<int>(legendH), juce::Justification::left);
+      }
+    }
+  }
+
+  // 6. HPSS Dual-Path LED Indicator (Top-Right Corner: click to toggle ON/OFF)
+  {
+    const bool isTransient = hpssActive && (ledBrightness > 0.35f);
+    const float badgeW = 92.0f;
+    const float badgeH = 24.0f;
+    const float badgeX = w - badgeW - 10.0f;
+    const float badgeY = 10.0f;
+
+    if (badgeX > 10.0f) {
+      // Semi-transparent dark glass badge container
+      g.setColour(juce::Colour(0xeb252a35));
+      g.fillRoundedRectangle(badgeX, badgeY, badgeW, badgeH, 4.0f);
+      g.setColour(hpssActive ? juce::Colour(0xff4c566a)
+                             : juce::Colour(0xff3a414e));
+      g.drawRoundedRectangle(badgeX, badgeY, badgeW, badgeH, 4.0f, 1.0f);
+
+      const float ledCenterX = badgeX + 13.0f;
+      const float ledCenterY = badgeY + badgeH * 0.5f;
+      const float ledRadius = 4.5f;
+
+      if (!hpssActive) {
+        // Off State: Dim inactive LED
+        const juce::Colour offColor = juce::Colour(0xff555e70);
+        g.setColour(offColor);
+        g.fillEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f);
+        g.setColour(offColor.withAlpha(0.4f));
+        g.drawEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f, 1.0f);
+
+        // Label: HPSS OFF
+        g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                                    juce::Font::bold));
+        g.setColour(juce::Colour(0xff808896));
+        g.drawText("HPSS OFF", static_cast<int>(badgeX + 22.0f),
+                   static_cast<int>(badgeY), static_cast<int>(badgeW - 24.0f),
+                   static_cast<int>(badgeH), juce::Justification::centredLeft);
+      } else if (isTransient) {
+        // Transient Path: Vivid Bright Cyan LED with outer glow
+        g.setColour(NoiseRepellentLookAndFeel::kColorDenoising.withAlpha(
+            0.5f * ledBrightness));
+        g.fillEllipse(ledCenterX - 9.0f, ledCenterY - 9.0f, 18.0f, 18.0f);
+
+        juce::Colour litColor =
+            NoiseRepellentLookAndFeel::kColorDenoising.interpolatedWith(
+                juce::Colours::white, 0.5f);
+        g.setColour(litColor);
+        g.fillEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f);
+
+        g.setColour(juce::Colours::white);
+        g.drawEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f, 1.0f);
+
+        // Label: TRANSIENT
+        g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                                    juce::Font::bold));
+        g.setColour(juce::Colours::white);
+        g.drawText("TRANSIENT", static_cast<int>(badgeX + 22.0f),
+                   static_cast<int>(badgeY), static_cast<int>(badgeW - 24.0f),
+                   static_cast<int>(badgeH), juce::Justification::centredLeft);
+      } else {
+        // Harmonic Path: Steady Warm Amber/Gold LED
+        const juce::Colour harmColor =
+            NoiseRepellentLookAndFeel::kColorNoiseProfile;
+        g.setColour(harmColor);
+        g.fillEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f);
+
+        g.setColour(harmColor.withAlpha(0.6f));
+        g.drawEllipse(ledCenterX - ledRadius, ledCenterY - ledRadius,
+                      ledRadius * 2.0f, ledRadius * 2.0f, 1.0f);
+
+        // Label: HARMONIC
+        g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                                    juce::Font::bold));
+        g.setColour(juce::Colour(0xffd8e0ec));
+        g.drawText("HARMONIC", static_cast<int>(badgeX + 22.0f),
+                   static_cast<int>(badgeY), static_cast<int>(badgeW - 24.0f),
+                   static_cast<int>(badgeH), juce::Justification::centredLeft);
+      }
+    }
+  }
+}
+
+void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
+  activeDragTarget = DragTarget::None;
+  activeNodeIndex = -1;
+  dragStartPos = e.position;
+
+  const float w = static_cast<float>(getWidth());
+  const float h = static_cast<float>(getHeight());
+
+  // Check HPSS Toggle Badge click (Top-Right corner)
+  const float badgeW = 92.0f;
+  const float badgeH = 24.0f;
+  const float badgeX = w - badgeW - 10.0f;
+  const float badgeY = 10.0f;
+  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+  if (badgeBounds.contains(e.position)) {
+    auto* hpssParam =
+        processor.getAPVTS().getParameter("hpss_quality");
+    if (hpssParam != nullptr) {
+      float currentVal = hpssParam->getValue();
+      // If active (> 0), turn Off (0.0). If Off (0), turn On to Mid (index 2 / 3.0 = 0.667)
+      float newVal = (currentVal > 0.05f) ? 0.0f : (2.0f / 3.0f);
+      hpssParam->setValueNotifyingHost(newVal);
+      repaint();
+      return;
+    }
+  }
+
+  // Check Reduction Curve nodes (if enabled)
+  if (currentFrame.reductionCurveEnabled) {
+    const auto& nodes = processor.getCurveNodes();
+    for (size_t i = 0; i < nodes.size(); ++i) {
+      float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
+      float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
+      if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
+        activeDragTarget = DragTarget::CurveNode;
+        activeNodeIndex = static_cast<int>(i);
+        return;
+      }
+    }
+
+    // Add a new curve node on empty click
+    float clickNormX = std::clamp(e.position.x / w, 0.01f, 0.99f);
+    float clickBiasDB = std::clamp(
+        ((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f, -24.0f, 24.0f);
+    processor.addCurveNode(clickNormX, clickBiasDB);
+    repaint();
+  }
+}
+
+void SpectralVisualizerComponent::mouseDrag(const juce::MouseEvent& e) {
+  const float w = static_cast<float>(getWidth());
+  const float h = static_cast<float>(getHeight());
+
+  if (activeDragTarget == DragTarget::CurveNode && activeNodeIndex >= 0) {
+    float normX = std::clamp(e.position.x / w, 0.0f, 1.0f);
+    float biasDB = std::clamp(((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f,
+                              -24.0f, 24.0f);
+    processor.updateCurveNode(activeNodeIndex, normX, biasDB);
+    repaint();
+  }
+}
+
+void SpectralVisualizerComponent::mouseUp(const juce::MouseEvent&) {
+  activeDragTarget = DragTarget::None;
+  activeNodeIndex = -1;
+}
+
+void SpectralVisualizerComponent::mouseDoubleClick(const juce::MouseEvent& e) {
+  if (!currentFrame.reductionCurveEnabled)
+    return;
+
+  const float w = static_cast<float>(getWidth());
+  const float h = static_cast<float>(getHeight());
+  const auto& nodes = processor.getCurveNodes();
+
+  for (size_t i = 1; i < nodes.size() - 1; ++i) {
+    float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
+    float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
+    if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
+      processor.removeCurveNode(static_cast<int>(i));
+      repaint();
+      return;
+    }
+  }
+}
+
+void SpectralVisualizerComponent::mouseMove(const juce::MouseEvent& e) {
+  const float w = static_cast<float>(getWidth());
+  const float badgeW = 92.0f;
+  const float badgeH = 24.0f;
+  const float badgeX = w - badgeW - 10.0f;
+  const float badgeY = 10.0f;
+  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+
+  if (badgeBounds.contains(e.position)) {
+    setMouseCursor(juce::MouseCursor::PointingHandCursor);
+  } else {
+    setMouseCursor(juce::MouseCursor::NormalCursor);
+  }
+}
+
+void SpectralVisualizerComponent::mouseExit(const juce::MouseEvent&) {
+  setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
+juce::String SpectralVisualizerComponent::getTooltip() {
+  const float w = static_cast<float>(getWidth());
+  const float badgeW = 92.0f;
+  const float badgeH = 24.0f;
+  const float badgeX = w - badgeW - 10.0f;
+  const float badgeY = 10.0f;
+  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+
+  auto mousePos = getMouseXYRelative().toFloat();
+  if (badgeBounds.contains(mousePos)) {
+    return "Toggle Harmonic-Percussive transient protection.\nPreserves "
+           "attack clarity on percussive and plucked sounds.";
+  }
+  return {};
 }

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -63,7 +63,8 @@ void SpectralVisualizerComponent::timerCallback() {
     }
   }
 
-  // Update transient protection LED activity synchronized with the displayed frame
+  // Update transient protection LED activity synchronized with the displayed
+  // frame
   hpssActive = currentFrame.isHpssActive;
   bool isProtected = currentFrame.isTransientProtected;
 
@@ -638,8 +639,7 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
   const float badgeY = 10.0f;
   juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
   if (badgeBounds.contains(e.position)) {
-    auto* hpssParam =
-        processor.getAPVTS().getParameter("hpss_enable");
+    auto* hpssParam = processor.getAPVTS().getParameter("hpss_enable");
     if (hpssParam != nullptr) {
       float currentVal = hpssParam->getValue();
       float newVal = (currentVal > 0.5f) ? 0.0f : 1.0f;

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -639,11 +639,10 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
   juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
   if (badgeBounds.contains(e.position)) {
     auto* hpssParam =
-        processor.getAPVTS().getParameter("hpss_quality");
+        processor.getAPVTS().getParameter("hpss_enable");
     if (hpssParam != nullptr) {
       float currentVal = hpssParam->getValue();
-      // If active (> 0), turn Off (0.0). If Off (0), turn On to Mid (index 2 / 3.0 = 0.667)
-      float newVal = (currentVal > 0.05f) ? 0.0f : (2.0f / 3.0f);
+      float newVal = (currentVal > 0.5f) ? 0.0f : 1.0f;
       hpssParam->setValueNotifyingHost(newVal);
       repaint();
       return;

--- a/Source/GUI/SpectralVisualizer.h
+++ b/Source/GUI/SpectralVisualizer.h
@@ -19,40 +19,49 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <juce_gui_basics/juce_gui_basics.h>
 #include "../PluginProcessor.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class SpectralVisualizerComponent : public juce::Component,
-                                    public juce::Timer
-{
+                                    public juce::Timer,
+                                    public juce::TooltipClient {
 public:
-    explicit SpectralVisualizerComponent(NoiseRepellentAudioProcessor& processorToUse);
-    ~SpectralVisualizerComponent() override;
+  explicit SpectralVisualizerComponent(
+      NoiseRepellentAudioProcessor& processorToUse);
+  ~SpectralVisualizerComponent() override;
 
-    void paint(juce::Graphics& g) override;
-    void resized() override;
-    void timerCallback() override;
+  void paint(juce::Graphics& g) override;
+  void resized() override;
+  void timerCallback() override;
 
-    void mouseDown(const juce::MouseEvent& e) override;
-    void mouseDrag(const juce::MouseEvent& e) override;
-    void mouseUp(const juce::MouseEvent& e) override;
-    void mouseDoubleClick(const juce::MouseEvent& e) override;
+  void mouseDown(const juce::MouseEvent& e) override;
+  void mouseDrag(const juce::MouseEvent& e) override;
+  void mouseUp(const juce::MouseEvent& e) override;
+  void mouseDoubleClick(const juce::MouseEvent& e) override;
+  void mouseMove(const juce::MouseEvent& e) override;
+  void mouseExit(const juce::MouseEvent& e) override;
+
+  juce::String getTooltip() override;
 
 private:
-    NoiseRepellentAudioProcessor& processor;
-    NoiseRepellentAudioProcessor::SpectralFrame currentFrame;
+  NoiseRepellentAudioProcessor& processor;
+  NoiseRepellentAudioProcessor::SpectralFrame currentFrame;
 
-    std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedInputDB;
-    std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedOutputDB;
-    bool isSmoothedInitialized = false;
+  std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedInputDB;
+  std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedOutputDB;
+  bool isSmoothedInitialized = false;
 
-    // Mouse Interaction
-    enum class DragTarget { None, CurveNode };
-    DragTarget activeDragTarget = DragTarget::None;
-    int activeNodeIndex = -1;
-    juce::Point<float> dragStartPos;
-    float dragStartNormX = 0.0f;
-    float dragStartBiasDB = 0.0f;
+  float ledBrightness = 0.0f;
+  int transientHoldTicks = 0;
+  bool hpssActive = false;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpectralVisualizerComponent)
+  // Mouse Interaction
+  enum class DragTarget { None, CurveNode };
+  DragTarget activeDragTarget = DragTarget::None;
+  int activeNodeIndex = -1;
+  juce::Point<float> dragStartPos;
+  float dragStartNormX = 0.0f;
+  float dragStartBiasDB = 0.0f;
+
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpectralVisualizerComponent)
 };

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -304,23 +304,12 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
                           1);
   addAndMakeVisible(comboMethod);
 
-  comboHpssQuality.addItemList(
-      {"Off", "Low (Fast)", "Mid (Balanced)", "High (Ultra)"}, 1);
-  addAndMakeVisible(comboHpssQuality);
-
   lblMethod.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
                                       juce::Font::bold));
   lblMethod.setColour(juce::Label::textColourId,
                       NoiseRepellentLookAndFeel::kColorDenoising);
   lblMethod.setJustificationType(juce::Justification::left);
   addAndMakeVisible(lblMethod);
-
-  lblHpssQuality.setFont(juce::FontOptions(
-      NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
-  lblHpssQuality.setColour(juce::Label::textColourId,
-                           NoiseRepellentLookAndFeel::kColorDenoising);
-  lblHpssQuality.setJustificationType(juce::Justification::centred);
-  addAndMakeVisible(lblHpssQuality);
 
   lblOffset.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
                                       juce::Font::bold));
@@ -417,8 +406,6 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
 
   attachMethod = std::make_unique<ComboBoxAttachment>(apvts, "adaptive_method",
                                                       comboMethod);
-  attachHpssQuality = std::make_unique<ComboBoxAttachment>(
-      apvts, "hpss_quality", comboHpssQuality);
 
   attachMasterRed = std::make_unique<SliderAttachment>(
       apvts, "reduction_amount", sliderMasterRed);
@@ -445,14 +432,6 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   lblAlgoHeader.setTooltip(
       "Select denoising algorithm: 1D STFT (fast & low latency)\nor 2D NLM "
       "Patch (high quality non-local means processing).");
-  comboHpssQuality.setTooltip(
-      "Select transient protection algorithm quality. Separates transient "
-      "attacks from \nstationary components to preserve plucks and percussive "
-      "clarity.");
-  lblHpssQuality.setTooltip(
-      "Select transient protection algorithm quality. Separates transient "
-      "attacks from \nstationary components to preserve plucks and percussive "
-      "clarity.");
   btnAdvancedToggle.setTooltip("Toggle Advanced DSP Controls");
   btnLearn.setTooltip(
       "Capture static noise profile from current audio input\n(supports "
@@ -646,8 +625,6 @@ void NoiseRepellentAudioProcessorEditor::updateLayout() {
   btnResetProfile.setVisible(true);
   comboMethod.setVisible(false);
   lblMethod.setVisible(false);
-  comboHpssQuality.setVisible(isAdvancedVisible);
-  lblHpssQuality.setVisible(isAdvancedVisible);
   sliderSmoothing.setVisible(isAdvancedVisible);
   lblSmoothing.setVisible(isAdvancedVisible);
   sliderMasking.setVisible(isAdvancedVisible);
@@ -926,26 +903,21 @@ void NoiseRepellentAudioProcessorEditor::paint(juce::Graphics& g) {
     float topY = (float)groupAdvanced.getY() + 22.0f;
     float bottomY = (float)groupAdvanced.getBottom() - 10.0f;
 
-    // 4 Separator lines between 5 controls in Advanced Controls
-    if (comboHpssQuality.getWidth() > 0 && sliderSmoothing.getWidth() > 0) {
+    // 3 Separator lines between 4 controls in Advanced Controls
+    if (sliderSmoothing.getWidth() > 0 && sliderMasking.getWidth() > 0) {
       float x0 =
-          (float)(comboHpssQuality.getRight() + sliderSmoothing.getX()) / 2.0f;
+          (float)(sliderSmoothing.getRight() + sliderMasking.getX()) / 2.0f;
       g.drawVerticalLine(juce::roundToInt(x0), topY, bottomY);
     }
-    if (sliderSmoothing.getWidth() > 0 && sliderMasking.getWidth() > 0) {
+    if (sliderMasking.getWidth() > 0 && sliderWhitening.getWidth() > 0) {
       float x1 =
-          (float)(sliderSmoothing.getRight() + sliderMasking.getX()) / 2.0f;
+          (float)(sliderMasking.getRight() + sliderWhitening.getX()) / 2.0f;
       g.drawVerticalLine(juce::roundToInt(x1), topY, bottomY);
     }
-    if (sliderMasking.getWidth() > 0 && sliderWhitening.getWidth() > 0) {
-      float x2 =
-          (float)(sliderMasking.getRight() + sliderWhitening.getX()) / 2.0f;
-      g.drawVerticalLine(juce::roundToInt(x2), topY, bottomY);
-    }
     if (sliderWhitening.getWidth() > 0 && sliderSuppression.getWidth() > 0) {
-      float x3 =
+      float x2 =
           (float)(sliderWhitening.getRight() + sliderSuppression.getX()) / 2.0f;
-      g.drawVerticalLine(juce::roundToInt(x3), topY, bottomY);
+      g.drawVerticalLine(juce::roundToInt(x2), topY, bottomY);
     }
   }
 }
@@ -1074,8 +1046,8 @@ void NoiseRepellentAudioProcessorEditor::resized() {
     }
   }
 
-  // Bottom Collapsible Advanced Panel (5 Controls: HPSS Quality, Smoothing,
-  // Masking, Whitening, Suppression)
+  // Bottom Collapsible Advanced Panel (4 Controls: Smoothing, Masking,
+  // Whitening, Suppression)
   if (isAdvancedVisible) {
     auto advArea = area.removeFromBottom(68);
     groupAdvanced.setBounds(advArea);
@@ -1083,39 +1055,32 @@ void NoiseRepellentAudioProcessorEditor::resized() {
     auto advInner = advArea.reduced(10, 4);
     advInner.removeFromTop(12);
 
-    constexpr int kNumGaps = 4;
-    constexpr int kGapW = 10;
+    constexpr int kNumGaps = 3;
+    constexpr int kGapW = 14;
     int totalAvailWidth = advInner.getWidth() - (kNumGaps * kGapW);
-    int itemW = totalAvailWidth / 5;
+    int itemW = totalAvailWidth / 4;
 
-    // 1. HPSS Quality Combo Box
-    auto c0 = advInner.removeFromLeft(itemW);
-    lblHpssQuality.setBounds(c0.removeFromTop(16));
-    c0.removeFromTop(2);
-    comboHpssQuality.setBounds(c0.removeFromTop(20));
-
-    // 2. Smoothing Slider
-    advInner.removeFromLeft(kGapW);
+    // 1. Smoothing Slider
     auto s1 = advInner.removeFromLeft(itemW);
     lblSmoothing.setBounds(s1.removeFromTop(16));
     s1.removeFromTop(2);
     sliderSmoothing.setBounds(s1.removeFromTop(20));
 
-    // 3. Masking Slider
+    // 2. Masking Slider
     advInner.removeFromLeft(kGapW);
     auto s2 = advInner.removeFromLeft(itemW);
     lblMasking.setBounds(s2.removeFromTop(16));
     s2.removeFromTop(2);
     sliderMasking.setBounds(s2.removeFromTop(20));
 
-    // 4. Whitening Slider
+    // 3. Whitening Slider
     advInner.removeFromLeft(kGapW);
     auto s3 = advInner.removeFromLeft(itemW);
     lblWhitening.setBounds(s3.removeFromTop(16));
     s3.removeFromTop(2);
     sliderWhitening.setBounds(s3.removeFromTop(20));
 
-    // 5. Suppression Slider
+    // 4. Suppression Slider
     advInner.removeFromLeft(kGapW);
     auto s4 = advInner;
     lblSuppression.setBounds(s4.removeFromTop(16));

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -88,7 +88,6 @@ private:
   // Module 3: Advanced Controls Panel (Collapsible)
   juce::GroupComponent groupAdvanced{"groupAdvanced", "ADVANCED CONTROLS"};
   juce::ComboBox comboMethod;
-  juce::ComboBox comboHpssQuality;
   juce::Slider sliderAggressiveness{juce::Slider::LinearHorizontal,
                                     juce::Slider::NoTextBox};
   juce::Slider sliderSmoothing{juce::Slider::LinearHorizontal,
@@ -101,7 +100,6 @@ private:
                                  juce::Slider::NoTextBox};
 
   juce::Label lblMethod{"lblMethod", "ESTIMATION METHOD"};
-  juce::Label lblHpssQuality{"lblHpssQuality", "HPSS QUALITY"};
   juce::Label lblAggressiveness{"lblAggressiveness", "AGGRESSIVENESS"};
   juce::Label lblSmoothing{"lblSmoothing", "SMOOTHING"};
   juce::Label lblMasking{"lblMasking", "MASKING PROTECT"};
@@ -127,7 +125,6 @@ private:
   std::unique_ptr<ButtonAttachment> attachShowAdvanced;
 
   std::unique_ptr<ComboBoxAttachment> attachMethod;
-  std::unique_ptr<ComboBoxAttachment> attachHpssQuality;
 
   std::unique_ptr<SliderAttachment> attachMasterRed;
   std::unique_ptr<SliderAttachment> attachTonalRed;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -50,14 +50,8 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
       "algorithm_mode", "Algorithm",
       juce::StringArray{"1D Spectral", "2D NLM Patch HQ"}, 1));
 
-  params.push_back(std::make_unique<juce::AudioParameterChoice>(
-      "hpss_quality", "HPSS Quality",
-      juce::StringArray{"Off", "Low (Fast)", "Mid (Balanced)", "High (Ultra)"},
-      2));
-
-  params.push_back(std::make_unique<juce::AudioParameterFloat>(
-      "hpss_sensitivity", "HPSS Sensitivity",
-      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 50.0f));
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "hpss_enable", "HPSS Protection", true));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "learn_noise", "Learn Noise", false));
@@ -633,10 +627,8 @@ void NoiseRepellentAudioProcessor::processBlock(
       parameters.getRawParameterValue("bypass")->load() > 0.5f;
   const int algoMode = static_cast<int>(
       parameters.getRawParameterValue("algorithm_mode")->load());
-  const int hpssQuality =
-      static_cast<int>(parameters.getRawParameterValue("hpss_quality")->load());
-  const float hpssSensitivity =
-      parameters.getRawParameterValue("hpss_sensitivity")->load() / 100.0f;
+  const bool hpssEnable =
+      parameters.getRawParameterValue("hpss_enable")->load() > 0.5f;
   const bool learnNoise =
       parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
   const bool adaptiveNoise =
@@ -716,8 +708,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p.suppression_strength = suppression;
   p.aggressiveness = aggressiveness;
   p.tonal_reduction = tonalRed;
-  p.hpss_quality_mode = hpssQuality;
-  p.hpss_sensitivity = hpssSensitivity;
+  p.hpss_enable = hpssEnable ? 1 : 0;
   p.noise_profile_offset_db = profileOffset;
   p.reduction_curve_enabled = curveEnabled;
   p.reduction_curve_bias =
@@ -735,8 +726,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p2.suppression_strength = suppression;
   p2.aggressiveness = aggressiveness;
   p2.tonal_reduction = tonalRed;
-  p2.hpss_quality_mode = hpssQuality;
-  p2.hpss_sensitivity = hpssSensitivity;
+  p2.hpss_enable = hpssEnable ? 1 : 0;
   p2.noise_profile_offset_db = profileOffset;
   p2.reduction_curve_enabled = curveEnabled;
   p2.reduction_curve_bias =
@@ -784,8 +774,8 @@ void NoiseRepellentAudioProcessor::processBlock(
     }
   }
 
-  if (hpssQuality != currentHpssQuality) {
-    currentHpssQuality = hpssQuality;
+  if (hpssEnable != currentHpssEnable) {
+    currentHpssEnable = hpssEnable;
     if (specbleach1D_L)
       specbleach_load_parameters(specbleach1D_L, p);
     if (specbleach1D_R)
@@ -969,7 +959,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   } else {
     transientActivity.store(0.0f, std::memory_order_relaxed);
   }
-  hpssActive.store(hpssQuality > 0, std::memory_order_relaxed);
+  hpssActive.store(hpssEnable, std::memory_order_relaxed);
 
   // Update dynamic latency if changed by algorithm mode or HPSS quality mode
   uint32_t activeLatency = 0;
@@ -1135,7 +1125,7 @@ void NoiseRepellentAudioProcessor::processBlock(
           }
         }
         frame.isTransientProtected = windowHasTransient;
-        frame.isHpssActive = (hpssQuality > 0);
+        frame.isHpssActive = hpssEnable;
         frame.tonalPeaksHz.clear();
 
         if (profileAvailable && actualNoiseProfile) {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -53,7 +53,11 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
   params.push_back(std::make_unique<juce::AudioParameterChoice>(
       "hpss_quality", "HPSS Quality",
       juce::StringArray{"Off", "Low (Fast)", "Mid (Balanced)", "High (Ultra)"},
-      0));
+      2));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "hpss_sensitivity", "HPSS Sensitivity",
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 50.0f));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "learn_noise", "Learn Noise", false));
@@ -594,6 +598,7 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   // Reset FFT accumulation
   fftAccumInput.fill(0.0f);
   fftAccumOutput.fill(0.0f);
+  fftAccumTransient.fill(0.0f);
   fftAccumCount = 0;
 }
 
@@ -630,6 +635,8 @@ void NoiseRepellentAudioProcessor::processBlock(
       parameters.getRawParameterValue("algorithm_mode")->load());
   const int hpssQuality =
       static_cast<int>(parameters.getRawParameterValue("hpss_quality")->load());
+  const float hpssSensitivity =
+      parameters.getRawParameterValue("hpss_sensitivity")->load() / 100.0f;
   const bool learnNoise =
       parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
   const bool adaptiveNoise =
@@ -710,6 +717,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p.aggressiveness = aggressiveness;
   p.tonal_reduction = tonalRed;
   p.hpss_quality_mode = hpssQuality;
+  p.hpss_sensitivity = hpssSensitivity;
   p.noise_profile_offset_db = profileOffset;
   p.reduction_curve_enabled = curveEnabled;
   p.reduction_curve_bias =
@@ -728,6 +736,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p2.aggressiveness = aggressiveness;
   p2.tonal_reduction = tonalRed;
   p2.hpss_quality_mode = hpssQuality;
+  p2.hpss_sensitivity = hpssSensitivity;
   p2.noise_profile_offset_db = profileOffset;
   p2.reduction_curve_enabled = curveEnabled;
   p2.reduction_curve_bias =
@@ -941,6 +950,27 @@ void NoiseRepellentAudioProcessor::processBlock(
     }
   }
 
+  // Query HPSS transient protection status
+  bool transientDetectedL = false;
+  bool transientDetectedR = false;
+  if (algoMode == 0) {
+    if (specbleach1D_L)
+      transientDetectedL = specbleach_is_transient_detected(specbleach1D_L);
+    if (numChannels >= 2 && specbleach1D_R)
+      transientDetectedR = specbleach_is_transient_detected(specbleach1D_R);
+  } else {
+    if (specbleach2D_L)
+      transientDetectedL = specbleach_2d_is_transient_detected(specbleach2D_L);
+    if (numChannels >= 2 && specbleach2D_R)
+      transientDetectedR = specbleach_2d_is_transient_detected(specbleach2D_R);
+  }
+  if (transientDetectedL || transientDetectedR) {
+    transientActivity.store(1.0f, std::memory_order_relaxed);
+  } else {
+    transientActivity.store(0.0f, std::memory_order_relaxed);
+  }
+  hpssActive.store(hpssQuality > 0, std::memory_order_relaxed);
+
   // Update dynamic latency if changed by algorithm mode or HPSS quality mode
   uint32_t activeLatency = 0;
   if (algoMode == 0 && specbleach1D_L) {
@@ -982,9 +1012,11 @@ void NoiseRepellentAudioProcessor::processBlock(
       visualizerDelayWritePos = (visualizerDelayWritePos + 1) % vBufSize;
     }
 
+    const float currentTransientVal = (transientDetectedL || transientDetectedR) ? 1.0f : 0.0f;
     if (fftAccumCount < kFftSize) {
       fftAccumInput[fftAccumCount] = alignedInputSample;
       fftAccumOutput[fftAccumCount] = outputSrc ? outputSrc[s] : 0.0f;
+      fftAccumTransient[fftAccumCount] = currentTransientVal;
       fftAccumCount++;
     }
 
@@ -1091,6 +1123,19 @@ void NoiseRepellentAudioProcessor::processBlock(
         frame.reductionCurveEnabled =
             (parameters.getRawParameterValue("reduction_curve_enabled")
                  ->load() > 0.5f);
+
+        // Sample-accurate alignment matching the center peak of the Hann FFT analysis window
+        bool windowHasTransient = false;
+        constexpr size_t centerStart = kFftSize / 4;
+        constexpr size_t centerEnd = (3 * kFftSize) / 4;
+        for (size_t t = centerStart; t < centerEnd; ++t) {
+          if (fftAccumTransient[t] > 0.5f) {
+            windowHasTransient = true;
+            break;
+          }
+        }
+        frame.isTransientProtected = windowHasTransient;
+        frame.isHpssActive = (hpssQuality > 0);
         frame.tonalPeaksHz.clear();
 
         if (profileAvailable && actualNoiseProfile) {
@@ -1151,6 +1196,8 @@ void NoiseRepellentAudioProcessor::processBlock(
       std::memmove(fftAccumInput.data(), fftAccumInput.data() + kHop,
                    (kFftSize - kHop) * sizeof(float));
       std::memmove(fftAccumOutput.data(), fftAccumOutput.data() + kHop,
+                   (kFftSize - kHop) * sizeof(float));
+      std::memmove(fftAccumTransient.data(), fftAccumTransient.data() + kHop,
                    (kFftSize - kHop) * sizeof(float));
       fftAccumCount = kFftSize - kHop;
     }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1002,7 +1002,8 @@ void NoiseRepellentAudioProcessor::processBlock(
       visualizerDelayWritePos = (visualizerDelayWritePos + 1) % vBufSize;
     }
 
-    const float currentTransientVal = (transientDetectedL || transientDetectedR) ? 1.0f : 0.0f;
+    const float currentTransientVal =
+        (transientDetectedL || transientDetectedR) ? 1.0f : 0.0f;
     if (fftAccumCount < kFftSize) {
       fftAccumInput[fftAccumCount] = alignedInputSample;
       fftAccumOutput[fftAccumCount] = outputSrc ? outputSrc[s] : 0.0f;
@@ -1114,7 +1115,8 @@ void NoiseRepellentAudioProcessor::processBlock(
             (parameters.getRawParameterValue("reduction_curve_enabled")
                  ->load() > 0.5f);
 
-        // Sample-accurate alignment matching the center peak of the Hann FFT analysis window
+        // Sample-accurate alignment matching the center peak of the Hann FFT
+        // analysis window
         bool windowHasTransient = false;
         constexpr size_t centerStart = kFftSize / 4;
         constexpr size_t centerEnd = (3 * kFftSize) / 4;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -162,7 +162,7 @@ private:
 
   double currentSampleRate = 44100.0;
   int currentAlgoMode = 1;    // Track for dynamic latency updates
-  int currentHpssQuality = 0; // Track for dynamic HPSS quality updates
+  bool currentHpssEnable = true; // Track for dynamic HPSS enable updates
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> hpssActive{false};
   bool wasLearning =

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -161,7 +161,7 @@ private:
   juce::dsp::DryWetMixer<float> dryWetMixer;
 
   double currentSampleRate = 44100.0;
-  int currentAlgoMode = 1;    // Track for dynamic latency updates
+  int currentAlgoMode = 1;       // Track for dynamic latency updates
   bool currentHpssEnable = true; // Track for dynamic HPSS enable updates
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> hpssActive{false};

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -115,6 +115,8 @@ public:
     bool hasNoiseProfile = false;
     bool isLinked = true;
     bool reductionCurveEnabled = false;
+    bool isTransientProtected = false;
+    bool isHpssActive = false;
   };
 
   bool getNextSpectralFrame(SpectralFrame& frame);
@@ -124,6 +126,14 @@ public:
 
   double getSampleRate() const {
     return currentSampleRate;
+  }
+
+  float consumeTransientActivity() {
+    return transientActivity.exchange(0.0f, std::memory_order_relaxed);
+  }
+
+  bool isHpssActive() const {
+    return hpssActive.load(std::memory_order_relaxed);
   }
 
 private:
@@ -153,6 +163,8 @@ private:
   double currentSampleRate = 44100.0;
   int currentAlgoMode = 1;    // Track for dynamic latency updates
   int currentHpssQuality = 0; // Track for dynamic HPSS quality updates
+  std::atomic<float> transientActivity{0.0f};
+  std::atomic<bool> hpssActive{false};
   bool wasLearning =
       false; // Track learn mode state transition to sync profiles
 
@@ -207,6 +219,7 @@ private:
   // Accumulation buffer for FFT (collects samples across processBlock calls)
   std::array<float, kFftSize> fftAccumInput{};
   std::array<float, kFftSize> fftAccumOutput{};
+  std::array<float, kFftSize> fftAccumTransient{};
   size_t fftAccumCount = 0;
 
   // Latency-compensated delay line for input FFT visualization


### PR DESCRIPTION
Fixes #173

### Summary of Changes
- Made the top-right HPSS LED badge clickable to toggle transient protection between ON and OFF directly from the FFT display.
- Implemented `juce::TooltipClient` and pointing cursor on hover with a concise 2-line explanation.
- Removed the obsolete manual sensitivity slider and re-arranged Advanced Controls into 4 balanced columns.