### PR TITLE
feat: add offline rendering support and UI notification overlay

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -890,6 +890,12 @@ void NoiseRepellentAudioProcessorEditor::timerCallback() {
     triggerAsyncUpdate();
   }
 
+  bool isOffline = audioProcessor.isNonRealtime();
+  if (isOffline != wasOfflineRendering) {
+    wasOfflineRendering = isOffline;
+    repaint();
+  }
+
   updateSliderLabels();
   updateProfileStatus();
 }
@@ -920,6 +926,46 @@ void NoiseRepellentAudioProcessorEditor::paint(juce::Graphics& g) {
       g.drawVerticalLine(juce::roundToInt(x2), topY, bottomY);
     }
   }
+}
+
+void NoiseRepellentAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
+  if (!audioProcessor.isNonRealtime())
+    return;
+
+  // Darken UI overlay
+  auto bounds = getLocalBounds();
+  g.setColour(juce::Colour(0xd0161a22));
+  g.fillRect(bounds);
+
+  // Center badge card
+  constexpr int cardW = 320;
+  constexpr int cardH = 96;
+  auto cardRect = bounds.withSizeKeepingCentre(cardW, cardH).toFloat();
+
+  g.setColour(juce::Colour(0xee212630));
+  g.fillRoundedRectangle(cardRect, 8.0f);
+
+  g.setColour(NoiseRepellentLookAndFeel::kColorPanelBorder);
+  g.drawRoundedRectangle(cardRect, 8.0f, 1.5f);
+
+  auto contentArea = cardRect.toNearestInt().reduced(12);
+
+  // Status title
+  g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
+  g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeBrand,
+                              juce::Font::bold));
+  g.drawText("OFFLINE RENDERING", contentArea.removeFromTop(24),
+             juce::Justification::centred, false);
+
+  contentArea.removeFromTop(4);
+
+  // Subtitle explanation
+  g.setColour(juce::Colour(0xff94a3b8));
+  g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
+                              juce::Font::plain));
+  g.drawText(
+      "DSP processing in progress...\nVisualizer and UI disabled for maximum speed.",
+      contentArea, juce::Justification::centred, false);
 }
 
 void NoiseRepellentAudioProcessorEditor::resized() {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -35,6 +35,7 @@ public:
   ~NoiseRepellentAudioProcessorEditor() override;
 
   void paint(juce::Graphics&) override;
+  void paintOverChildren(juce::Graphics&) override;
   void resized() override;
   void timerCallback() override;
   void mouseEnter(const juce::MouseEvent&) override;
@@ -136,6 +137,7 @@ private:
   std::unique_ptr<SliderAttachment> attachSuppression;
 
   bool isAdvancedVisible = true;
+  bool wasOfflineRendering = false;
 
   void updateLayout();
   void updateSliderLabels();

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -983,6 +983,12 @@ void NoiseRepellentAudioProcessor::processBlock(
   dryWetMixer.setWetMixProportion(isBypassed ? 0.0f : 1.0f);
   dryWetMixer.mixWetSamples(audioBlock);
 
+  // Skip FFT analysis and FIFO writes during offline rendering or if the GUI is closed
+  if (isNonRealtime() || getActiveEditor() == nullptr) {
+    fftAccumCount = 0;
+    return;
+  }
+
   // ── FFT-based spectral frame for GUI visualization ──
   // Accumulate samples until we have a full FFT window (kFftSize samples)
   const float* inputSrc = dryInputL.data();


### PR DESCRIPTION
## Summary
- Bypasses FFT calculations, logarithm conversions, and visualization FIFO writes when the DAW is in non-realtime offline processing mode (`isNonRealtime()`) or when the GUI window is closed, optimizing offline bounce and freeze speeds.
- Implements a darkened overlay via `paintOverChildren` in `NoiseRepellentAudioProcessorEditor` to visually indicate that offline processing is underway.
- Updates editor repainting on offline state transitions.

Fixes #178