### PR TITLE
feat(ui/dsp): establish simplified default experience and integrate linear libspecbleach API

### DIFF
--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -289,8 +289,8 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
     g.strokePath(noisePath, juce::PathStrokeType(2.0f));
   }
 
-  // 3b. Reduction Curve Bias Overlay & Nodes
-  if (currentFrame.reductionCurveEnabled) {
+  // 3b. Reduction Curve Bias Overlay & Nodes (Only shown in Advanced mode)
+  if (isAdvancedVisible && currentFrame.reductionCurveEnabled) {
     const auto& nodes = processor.getCurveNodes();
     if (nodes.size() >= 2) {
       auto nodeToPoint = [&](const NoiseRepellentAudioProcessor::CurveNode& n)
@@ -386,9 +386,9 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   }
 
   // 4. Tonal Peak Markers (Dashed vertical lines with staggered multi-tier
-  // frequency tags; shown ONLY when Reduction is UNLINKED)
-  if (!currentFrame.isLinked && currentFrame.hasNoiseProfile &&
-      !currentFrame.tonalPeaksHz.empty()) {
+  // frequency tags; shown ONLY in Advanced mode when Reduction is UNLINKED)
+  if (isAdvancedVisible && !currentFrame.isLinked &&
+      currentFrame.hasNoiseProfile && !currentFrame.tonalPeaksHz.empty()) {
     // 3 Y-tiers starting at Y = 42.0f to guarantee zero collision with top HUD
     // overlay bar
     constexpr float kStartTagY = 42.0f;
@@ -449,8 +449,9 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   // 5. HUD Color Legend (Top-Right Overlay, positioned to the left of Advanced
   // Controls button)
   {
-    const bool showTonalSwatch = !currentFrame.isLinked;
-    const bool showCurveSwatch = currentFrame.reductionCurveEnabled;
+    const bool showTonalSwatch = isAdvancedVisible && !currentFrame.isLinked;
+    const bool showCurveSwatch =
+        isAdvancedVisible && currentFrame.reductionCurveEnabled;
     const float padding = 10.0f;
     const float swatch1W = 10.0f + 4.0f + 32.0f + 14.0f; // Input (60)
     const float swatch2W = 12.0f + 4.0f + 38.0f + 14.0f; // Profile (68)
@@ -539,8 +540,8 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
     }
   }
 
-  // 6. HPSS Dual-Path LED Indicator (Top-Right Corner: click to toggle ON/OFF)
-  {
+  // 6. HPSS Dual-Path LED Indicator (Top-Right Corner: click to toggle ON/OFF, visible in Advanced mode)
+  if (isAdvancedVisible) {
     const bool isTransient = hpssActive && (ledBrightness > 0.35f);
     const float badgeW = 92.0f;
     const float badgeH = 24.0f;
@@ -632,25 +633,27 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
   const float w = static_cast<float>(getWidth());
   const float h = static_cast<float>(getHeight());
 
-  // Check HPSS Toggle Badge click (Top-Right corner)
-  const float badgeW = 92.0f;
-  const float badgeH = 24.0f;
-  const float badgeX = w - badgeW - 10.0f;
-  const float badgeY = 10.0f;
-  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
-  if (badgeBounds.contains(e.position)) {
-    auto* hpssParam = processor.getAPVTS().getParameter("hpss_enable");
-    if (hpssParam != nullptr) {
-      float currentVal = hpssParam->getValue();
-      float newVal = (currentVal > 0.5f) ? 0.0f : 1.0f;
-      hpssParam->setValueNotifyingHost(newVal);
-      repaint();
-      return;
+  // Check HPSS Toggle Badge click (Top-Right corner, only active when advanced controls are visible)
+  if (isAdvancedVisible) {
+    const float badgeW = 92.0f;
+    const float badgeH = 24.0f;
+    const float badgeX = w - badgeW - 10.0f;
+    const float badgeY = 10.0f;
+    juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+    if (badgeBounds.contains(e.position)) {
+      auto* hpssParam = processor.getAPVTS().getParameter("hpss_enable");
+      if (hpssParam != nullptr) {
+        float currentVal = hpssParam->getValue();
+        float newVal = (currentVal > 0.5f) ? 0.0f : 1.0f;
+        hpssParam->setValueNotifyingHost(newVal);
+        repaint();
+        return;
+      }
     }
   }
 
-  // Check Reduction Curve nodes (if enabled)
-  if (currentFrame.reductionCurveEnabled) {
+  // Check Reduction Curve nodes (if enabled and in Advanced mode)
+  if (isAdvancedVisible && currentFrame.reductionCurveEnabled) {
     const auto& nodes = processor.getCurveNodes();
     for (size_t i = 0; i < nodes.size(); ++i) {
       float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
@@ -690,20 +693,19 @@ void SpectralVisualizerComponent::mouseUp(const juce::MouseEvent&) {
 }
 
 void SpectralVisualizerComponent::mouseDoubleClick(const juce::MouseEvent& e) {
-  if (!currentFrame.reductionCurveEnabled)
-    return;
+  if (isAdvancedVisible && currentFrame.reductionCurveEnabled) {
+    const auto& nodes = processor.getCurveNodes();
+    const float w = static_cast<float>(getWidth());
+    const float h = static_cast<float>(getHeight());
 
-  const float w = static_cast<float>(getWidth());
-  const float h = static_cast<float>(getHeight());
-  const auto& nodes = processor.getCurveNodes();
-
-  for (size_t i = 1; i < nodes.size() - 1; ++i) {
-    float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
-    float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
-    if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
-      processor.removeCurveNode(static_cast<int>(i));
-      repaint();
-      return;
+    for (size_t i = 1; i < nodes.size() - 1; ++i) {
+      float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
+      float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
+      if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
+        processor.removeCurveNode(static_cast<int>(i));
+        repaint();
+        return;
+      }
     }
   }
 }
@@ -716,7 +718,7 @@ void SpectralVisualizerComponent::mouseMove(const juce::MouseEvent& e) {
   const float badgeY = 10.0f;
   juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
 
-  if (badgeBounds.contains(e.position)) {
+  if (isAdvancedVisible && badgeBounds.contains(e.position)) {
     setMouseCursor(juce::MouseCursor::PointingHandCursor);
   } else {
     setMouseCursor(juce::MouseCursor::NormalCursor);
@@ -728,17 +730,19 @@ void SpectralVisualizerComponent::mouseExit(const juce::MouseEvent&) {
 }
 
 juce::String SpectralVisualizerComponent::getTooltip() {
-  const float w = static_cast<float>(getWidth());
-  const float badgeW = 92.0f;
-  const float badgeH = 24.0f;
-  const float badgeX = w - badgeW - 10.0f;
-  const float badgeY = 10.0f;
-  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+  if (isAdvancedVisible) {
+    const float w = static_cast<float>(getWidth());
+    const float badgeW = 92.0f;
+    const float badgeH = 24.0f;
+    const float badgeX = w - badgeW - 10.0f;
+    const float badgeY = 10.0f;
+    juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
 
-  auto mousePos = getMouseXYRelative().toFloat();
-  if (badgeBounds.contains(mousePos)) {
-    return "Toggle Harmonic-Percussive transient protection.\nPreserves "
-           "attack clarity on percussive and plucked sounds.";
+    auto mousePos = getMouseXYRelative().toFloat();
+    if (badgeBounds.contains(mousePos)) {
+      return "Toggle Harmonic-Percussive transient protection.\nPreserves "
+             "attack clarity on percussive and plucked sounds.";
+    }
   }
   return {};
 }

--- a/Source/GUI/SpectralVisualizer.h
+++ b/Source/GUI/SpectralVisualizer.h
@@ -43,9 +43,17 @@ public:
 
   juce::String getTooltip() override;
 
+  void setAdvancedControlsVisible(bool visible) {
+    if (isAdvancedVisible != visible) {
+      isAdvancedVisible = visible;
+      repaint();
+    }
+  }
+
 private:
   NoiseRepellentAudioProcessor& processor;
   NoiseRepellentAudioProcessor::SpectralFrame currentFrame;
+  bool isAdvancedVisible = false;
 
   std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedInputDB;
   std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedOutputDB;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -432,7 +432,9 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   lblAlgoHeader.setTooltip(
       "Select denoising algorithm: 1D STFT (fast & low latency)\nor 2D NLM "
       "Patch (high quality non-local means processing).");
-  btnAdvancedToggle.setTooltip("Toggle Advanced DSP Controls");
+  btnAdvancedToggle.setTooltip(
+      "Show Advanced DSP Controls (Smoothing, Masking Protect, Whitening,\n "
+      "Suppression, Bias Curve, Tonal Split & Aggressiveness).");
   btnLearn.setTooltip(
       "Capture static noise profile from current audio input\n(supports "
       "multi-section accumulation).");
@@ -605,13 +607,14 @@ void NoiseRepellentAudioProcessorEditor::updateLayout() {
   bool isCurveOn = btnCurveToggle.getToggleState();
 
   sliderMasterRed.setVisible(true);
-  sliderTonalRed.setVisible(!isLinked);
+  sliderTonalRed.setVisible(isAdvancedVisible && !isLinked);
 
-  lblMasterRed.setVisible(!isLinked);
-  lblTonalRed.setVisible(!isLinked);
+  lblMasterRed.setVisible(isAdvancedVisible && !isLinked);
+  lblTonalRed.setVisible(isAdvancedVisible && !isLinked);
 
-  btnCurveToggle.setVisible(true);
-  btnResetCurve.setVisible(isCurveOn);
+  btnLink.setVisible(isAdvancedVisible);
+  btnCurveToggle.setVisible(isAdvancedVisible);
+  btnResetCurve.setVisible(isAdvancedVisible && isCurveOn);
 
   sliderOffset.setVisible(true);
   lblOffset.setVisible(true);
@@ -621,7 +624,7 @@ void NoiseRepellentAudioProcessorEditor::updateLayout() {
   groupAdvanced.setVisible(isAdvancedVisible);
   btnLearn.setVisible(true);
   btnAdaptiveNoise.setVisible(true);
-  btnAdaptiveArrow.setVisible(true);
+  btnAdaptiveArrow.setVisible(isAdvancedVisible);
   btnResetProfile.setVisible(true);
   comboMethod.setVisible(false);
   lblMethod.setVisible(false);
@@ -633,6 +636,8 @@ void NoiseRepellentAudioProcessorEditor::updateLayout() {
   lblWhitening.setVisible(isAdvancedVisible);
   sliderSuppression.setVisible(isAdvancedVisible);
   lblSuppression.setVisible(isAdvancedVisible);
+
+  spectralVisualizer.setAdvancedControlsVisible(isAdvancedVisible);
 
   btnAdvancedToggle.setButtonText(juce::CharPointer_UTF8(
       isAdvancedVisible ? "ADVANCED \xe2\x96\xb2" : "ADVANCED \xe2\x96\xbc"));
@@ -964,7 +969,8 @@ void NoiseRepellentAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
   g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
                               juce::Font::plain));
   g.drawText(
-      "DSP processing in progress...\nVisualizer and UI disabled for maximum speed.",
+      "DSP processing in progress...\nVisualizer and UI disabled for maximum "
+      "speed.",
       contentArea, juce::Justification::centred, false);
 }
 
@@ -998,7 +1004,10 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   constexpr int kArrowW = 18;
   constexpr int kResetW = 22;
   constexpr int kBtnGap = 4;
-  int buttonsWidth = kLearnW + kBtnGap + kAdaptW + kArrowW + kBtnGap + kResetW;
+  int buttonsWidth =
+      isAdvancedVisible
+          ? (kLearnW + kBtnGap + kAdaptW + kArrowW + kBtnGap + kResetW)
+          : (kLearnW + kBtnGap + kAdaptW + kBtnGap + kResetW);
 
   constexpr int kAlgoWidth = 210;
   int kProfileWidth =
@@ -1036,8 +1045,10 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   auto bAdapt = profileRow.removeFromLeft(kAdaptW);
   btnAdaptiveNoise.setBounds(bAdapt.withSizeKeepingCentre(kAdaptW, 24));
 
-  auto bAdaptArrow = profileRow.removeFromLeft(kArrowW);
-  btnAdaptiveArrow.setBounds(bAdaptArrow.withSizeKeepingCentre(kArrowW, 24));
+  if (isAdvancedVisible) {
+    auto bAdaptArrow = profileRow.removeFromLeft(kArrowW);
+    btnAdaptiveArrow.setBounds(bAdaptArrow.withSizeKeepingCentre(kArrowW, 24));
+  }
   profileRow.removeFromLeft(kBtnGap);
 
   auto bReset = profileRow.removeFromLeft(kResetW);
@@ -1142,27 +1153,30 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   auto denoiseInner = area.reduced(10);
   denoiseInner.removeFromTop(10);
 
-  bool isLinked = btnLink.getToggleState();
+  bool isLinked = !isAdvancedVisible || btnLink.getToggleState();
   int faderBankWidth = isLinked ? 95 : 155;
 
   auto faderBankArea = denoiseInner.removeFromLeft(faderBankWidth);
   lblReductionHeader.setBounds(faderBankArea.removeFromTop(16));
   faderBankArea.removeFromTop(2);
-  btnLink.setBounds(faderBankArea.removeFromTop(22));
-  faderBankArea.removeFromTop(6);
 
-  // Carve bottom area of faderBankArea for Curve split button [ Curve ][ ↺ ]
-  bool isCurveOn = btnCurveToggle.getToggleState();
-  auto faderBottomArea = faderBankArea.removeFromBottom(22);
-  faderBankArea.removeFromBottom(6);
+  if (isAdvancedVisible) {
+    btnLink.setBounds(faderBankArea.removeFromTop(22));
+    faderBankArea.removeFromTop(6);
 
-  if (isCurveOn) {
-    btnCurveToggle.setBounds(
-        faderBottomArea.removeFromLeft(faderBottomArea.getWidth() - 22));
-    faderBottomArea.removeFromLeft(2);
-    btnResetCurve.setBounds(faderBottomArea);
-  } else {
-    btnCurveToggle.setBounds(faderBottomArea);
+    // Carve bottom area of faderBankArea for Curve split button [ Curve ][ ↺ ]
+    bool isCurveOn = btnCurveToggle.getToggleState();
+    auto faderBottomArea = faderBankArea.removeFromBottom(22);
+    faderBankArea.removeFromBottom(6);
+
+    if (isCurveOn) {
+      btnCurveToggle.setBounds(
+          faderBottomArea.removeFromLeft(faderBottomArea.getWidth() - 22));
+      faderBottomArea.removeFromLeft(2);
+      btnResetCurve.setBounds(faderBottomArea);
+    } else {
+      btnCurveToggle.setBounds(faderBottomArea);
+    }
   }
 
   if (isLinked) {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -48,7 +48,7 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
 
   params.push_back(std::make_unique<juce::AudioParameterChoice>(
       "algorithm_mode", "Algorithm",
-      juce::StringArray{"1D Spectral", "2D NLM Patch HQ"}, 1));
+      juce::StringArray{"1D Spectral", "2D NLM Patch HQ"}, 0));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "hpss_enable", "HPSS Protection", true));
@@ -67,7 +67,7 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
 
   params.push_back(std::make_unique<juce::AudioParameterFloat>(
       "aggressiveness", "Aggressiveness",
-      juce::NormalisableRange<float>(-1.0f, 1.0f, 0.1f), 0.0f));
+      juce::NormalisableRange<float>(-1.0f, 1.0f, 0.1f), 0.5f));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "link_reduction", "Link Reduction", true,
@@ -76,11 +76,11 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
 
   params.push_back(std::make_unique<juce::AudioParameterFloat>(
       "reduction_amount", "Master Reduction",
-      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
+      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 12.0f));
 
   params.push_back(std::make_unique<juce::AudioParameterFloat>(
       "tonal_reduction", "Tonal Reduction",
-      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 15.0f));
+      juce::NormalisableRange<float>(0.0f, 40.0f, 0.1f), 12.0f));
 
   params.push_back(std::make_unique<juce::AudioParameterFloat>(
       "smoothing_factor", "Smoothing",
@@ -96,7 +96,7 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
 
   params.push_back(std::make_unique<juce::AudioParameterFloat>(
       "suppression_strength", "Suppression",
-      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 50.0f));
+      juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 100.0f));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "residual_listen", "Residual Listen", false));
@@ -693,23 +693,29 @@ void NoiseRepellentAudioProcessor::processBlock(
       syncNoiseProfiles(currentAlgoMode);
     }
   }
-  wasLearning = learnNoise;
+  // Compute linear parameters for libspecbleach
+  const float reductionGain = juce::Decibels::decibelsToGain(-masterRed);
+  const float tonalReductionGain = juce::Decibels::decibelsToGain(-tonalRed);
+  const float smoothingNorm = smoothing / 100.0f;
+  const float whiteningNorm = whitening / 100.0f;
+  const float suppressionNorm = suppression / 100.0f;
+  const float profileScale = std::pow(10.0f, profileOffset / 10.0f);
 
   // Prepare parameters for DSP engines
   SpectralBleachDenoiserParameters p;
   p.learn_noise = learnNoise ? 1 : 0;
   p.residual_listen = residualListen;
-  p.reduction_amount = masterRed;
-  p.smoothing_factor = smoothing;
-  p.whitening_factor = whitening;
+  p.reduction_gain = reductionGain;
+  p.smoothing_factor = smoothingNorm;
+  p.whitening_factor = whiteningNorm;
   p.adaptive_noise = adaptiveNoise ? 1 : 0;
   p.noise_estimation_method = adaptiveMethod;
   p.masking_depth = masking;
-  p.suppression_strength = suppression;
+  p.suppression_strength = suppressionNorm;
   p.aggressiveness = aggressiveness;
-  p.tonal_reduction = tonalRed;
+  p.tonal_reduction_gain = tonalReductionGain;
   p.hpss_enable = hpssEnable ? 1 : 0;
-  p.noise_profile_offset_db = profileOffset;
+  p.noise_profile_scale = profileScale;
   p.reduction_curve_enabled = curveEnabled;
   p.reduction_curve_bias =
       curveEnabled ? interpolatedCurveBias.data() : nullptr;
@@ -717,17 +723,17 @@ void NoiseRepellentAudioProcessor::processBlock(
   SpectralBleach2DDenoiserParameters p2;
   p2.learn_noise = learnNoise ? 1 : 0;
   p2.residual_listen = residualListen;
-  p2.reduction_amount = masterRed;
-  p2.smoothing_factor = smoothing;
-  p2.whitening_factor = whitening;
+  p2.reduction_gain = reductionGain;
+  p2.smoothing_factor = smoothingNorm;
+  p2.whitening_factor = whiteningNorm;
   p2.adaptive_noise = adaptiveNoise ? 1 : 0;
   p2.noise_estimation_method = adaptiveMethod;
   p2.nlm_masking_protection = masking;
-  p2.suppression_strength = suppression;
+  p2.suppression_strength = suppressionNorm;
   p2.aggressiveness = aggressiveness;
-  p2.tonal_reduction = tonalRed;
+  p2.tonal_reduction_gain = tonalReductionGain;
   p2.hpss_enable = hpssEnable ? 1 : 0;
-  p2.noise_profile_offset_db = profileOffset;
+  p2.noise_profile_scale = profileScale;
   p2.reduction_curve_enabled = curveEnabled;
   p2.reduction_curve_bias =
       curveEnabled ? interpolatedCurveBias.data() : nullptr;


### PR DESCRIPTION
Fixes #176 

## Summary
1. **Simplified Default Workflow**:
   - Starting state on plugin insert defaults to standard **1D Spectral** engine, **12 dB** reduction, **100%** suppression, and **0.5** aggressiveness.
   - Hides advanced parameters (HPSS LED badge, Reduction Curve editor/reset, Link/Unlink split toggle, Adaptive estimation method arrow, and Aggressiveness slider) behind the `[ADVANCED ▲]` toggle.
   - When advanced controls are hidden, FFT visualization elements (Curve line/nodes, Tonal markers, Curve/Tonal HUD legend swatches) are also hidden for a clean basic display.
2. **Linear-First DSP Integration**:
   - Converts APVTS dB and percentage values to linear gains (1.$) and linear power scales in `processBlock()` before passing to `libspecbleach`.