### PR TITLE
feat(ui/dsp): unlinkable tonal threshold offset

### DIFF
--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -295,6 +295,60 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
         buildLogFreqPath(freqSmoothedProfile.data(), numBins);
     g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
     g.strokePath(noisePath, juce::PathStrokeType(2.0f));
+
+    // When Threshold Offset is unlinked, redraw the profile segments around
+    // detected tonal peaks using the tonal colour so the tonal threshold
+    // offset is visually distinguished from the broadband noise profile.
+    if (isAdvancedVisible && !currentFrame.isOffsetLinked &&
+        !currentFrame.tonalPeaksHz.empty()) {
+      constexpr float kTonalRegionRatio = 0.05f;
+
+      std::vector<bool> tonalBin(numBins, false);
+      for (size_t i = 1; i < numBins; ++i) {
+        float freq = static_cast<float>(i) * binWidth;
+        for (float peakHz : currentFrame.tonalPeaksHz) {
+          if (freq >= peakHz * (1.0f - kTonalRegionRatio) &&
+              freq <= peakHz * (1.0f + kTonalRegionRatio)) {
+            tonalBin[i] = true;
+            break;
+          }
+        }
+      }
+
+      size_t i = 1;
+      while (i < numBins) {
+        if (!tonalBin[i]) {
+          ++i;
+          continue;
+        }
+
+        size_t runEnd = i;
+        while (runEnd + 1 < numBins && tonalBin[runEnd + 1])
+          ++runEnd;
+
+        juce::Path segment;
+        bool started = false;
+        for (size_t b = i; b <= runEnd + 1 && b < numBins; ++b) {
+          float freq = static_cast<float>(b) * binWidth;
+          if (freq < minFreq || freq > maxFreq)
+            continue;
+          float x = freqToX(freq, w, minFreq, maxFreq);
+          float y = dbToY(freqSmoothedProfile[b], h, minDB, maxDB);
+          if (!started) {
+            segment.startNewSubPath(x, y);
+            started = true;
+          } else {
+            segment.lineTo(x, y);
+          }
+        }
+        if (started) {
+          g.setColour(NoiseRepellentLookAndFeel::kColorTonalPeaks);
+          g.strokePath(segment, juce::PathStrokeType(2.6f));
+        }
+
+        i = runEnd + 1;
+      }
+    }
   }
 
   // 3b. Reduction Curve Bias Overlay & Nodes (Only shown in Advanced mode)
@@ -394,8 +448,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   }
 
   // 4. Tonal Peak Markers (Dashed vertical lines with staggered multi-tier
-  // frequency tags; shown ONLY in Advanced mode when Reduction is UNLINKED)
-  if (isAdvancedVisible && !currentFrame.isLinked &&
+  // frequency tags; shown ONLY in Advanced mode when Reduction or Threshold
+  // Offset is UNLINKED)
+  if (isAdvancedVisible &&
+      (!currentFrame.isLinked || !currentFrame.isOffsetLinked) &&
       currentFrame.hasNoiseProfile && !currentFrame.tonalPeaksHz.empty()) {
     // 3 Y-tiers starting at Y = 42.0f to guarantee zero collision with top HUD
     // overlay bar
@@ -457,7 +513,9 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   // 5. HUD Color Legend (Top-Right Overlay, positioned to the left of Advanced
   // Controls button)
   {
-    const bool showTonalSwatch = isAdvancedVisible && !currentFrame.isLinked;
+    const bool showTonalSwatch =
+        isAdvancedVisible &&
+        (!currentFrame.isLinked || !currentFrame.isOffsetLinked);
     const bool showCurveSwatch =
         isAdvancedVisible && currentFrame.reductionCurveEnabled;
     const float padding = 10.0f;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -322,9 +322,52 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
                       NoiseRepellentLookAndFeel::kColorDenoising);
   lblOffset.setJustificationType(juce::Justification::centred);
   sliderOffset.setColour(juce::Slider::rotarySliderFillColourId,
-                         NoiseRepellentLookAndFeel::kColorDenoising);
+                         NoiseRepellentLookAndFeel::kColorNoiseProfile);
   addAndMakeVisible(sliderOffset);
   addAndMakeVisible(lblOffset);
+
+  lblMasterOffset.setText("BROADBAND", juce::dontSendNotification);
+  lblMasterOffset.setFont(juce::FontOptions(
+      NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
+  lblMasterOffset.setColour(juce::Label::textColourId,
+                            NoiseRepellentLookAndFeel::kColorNoiseProfile);
+  lblMasterOffset.setJustificationType(juce::Justification::centred);
+  addAndMakeVisible(lblMasterOffset);
+
+  lblTonalOffset.setText("TONAL", juce::dontSendNotification);
+  lblTonalOffset.setFont(juce::FontOptions(
+      NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
+  lblTonalOffset.setColour(juce::Label::textColourId,
+                           NoiseRepellentLookAndFeel::kColorTonalPeaks);
+  lblTonalOffset.setJustificationType(juce::Justification::centred);
+  addAndMakeVisible(lblTonalOffset);
+
+  sliderTonalOffset.setColour(juce::Slider::rotarySliderFillColourId,
+                              NoiseRepellentLookAndFeel::kColorTonalPeaks);
+
+  addAndMakeVisible(sliderTonalOffset);
+
+  addAndMakeVisible(btnLinkOffset);
+  // Attachment must be created before onClick is assigned (same reasoning as
+  // the reduction link button above).
+  attachLinkOffset = std::make_unique<ButtonAttachment>(
+      audioProcessor.getAPVTS(), "link_threshold_offset", btnLinkOffset);
+  btnLinkOffset.setButtonText(btnLinkOffset.getToggleState() ? "Linked"
+                                                             : "Unlinked");
+  btnLinkOffset.onClick = [this]() {
+    bool isLinked = btnLinkOffset.getToggleState();
+    btnLinkOffset.setButtonText(isLinked ? "Linked" : "Unlinked");
+    if (isLinked) {
+      // Reset threshold offset parameters to default when relinked
+      if (auto* pMaster =
+              audioProcessor.getAPVTS().getParameter("noise_profile_offset"))
+        pMaster->setValueNotifyingHost(pMaster->getDefaultValue());
+      if (auto* pTonal = audioProcessor.getAPVTS().getParameter(
+              "tonal_noise_profile_offset"))
+        pTonal->setValueNotifyingHost(pTonal->getDefaultValue());
+    }
+    updateLayout();
+  };
 
   lblAggressiveness.setFont(juce::FontOptions(
       NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
@@ -357,7 +400,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   lblMasking.setFont(juce::FontOptions(
       NoiseRepellentLookAndFeel::kFontSizeLabel, juce::Font::bold));
   lblMasking.setColour(juce::Label::textColourId,
-                         NoiseRepellentLookAndFeel::kColorDenoising);
+                       NoiseRepellentLookAndFeel::kColorDenoising);
   lblMasking.setJustificationType(juce::Justification::centred);
   addAndMakeVisible(lblMasking);
 
@@ -406,6 +449,8 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
                                                       sliderTonalRed);
   attachOffset = std::make_unique<SliderAttachment>(
       apvts, "noise_profile_offset", sliderOffset);
+  attachTonalOffset = std::make_unique<SliderAttachment>(
+      apvts, "tonal_noise_profile_offset", sliderTonalOffset);
   attachSmoothing = std::make_unique<SliderAttachment>(
       apvts, "smoothing_factor", sliderSmoothing);
   attachMasking =
@@ -476,8 +521,8 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
       "Link broadband and tonal reduction controls together\nfor unified "
       "adjustment.");
   btnCurveToggle.setTooltip(
-      "Enable per-frequency reduction bias curve\noverlay on spectral "
-      "display.");
+      "Enable per-frequency reduction bias curve overlay on spectral\n"
+      "display. Shapes both broadband and tonal reduction.");
   btnResetCurve.setTooltip("Reset reduction curve to flat 0 dB line.");
 
   // Initial Layout update
@@ -606,6 +651,13 @@ void NoiseRepellentAudioProcessorEditor::updateLayout() {
 
   sliderOffset.setVisible(true);
   lblOffset.setVisible(true);
+
+  bool isOffsetLinked = !isAdvancedVisible || btnLinkOffset.getToggleState();
+  sliderTonalOffset.setVisible(isAdvancedVisible && !isOffsetLinked);
+  lblMasterOffset.setVisible(isAdvancedVisible && !isOffsetLinked);
+  lblTonalOffset.setVisible(isAdvancedVisible && !isOffsetLinked);
+  btnLinkOffset.setVisible(isAdvancedVisible);
+
   sliderAggressiveness.setVisible(isAdvancedVisible);
   lblAggressiveness.setVisible(isAdvancedVisible);
 
@@ -735,10 +787,6 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   btnResetProfile.setEnabled(profileEnabled && (hasProfile || isAdaptive));
   sliderOffset.setEnabled(pluginActive);
   lblOffset.setEnabled(pluginActive);
-  sliderOffset.setTooltip(
-      "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).");
-  lblOffset.setTooltip(
-      "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).");
 
   // Aggressiveness (Profile Morphing) enabled in Noise Profile box when a
   // manual profile exists and Advanced Controls is ON
@@ -805,6 +853,37 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   lblMasterRed.setTooltip(masterRedTip);
   sliderTonalRed.setTooltip(tonalRedTip);
   lblTonalRed.setTooltip(tonalRedTip);
+
+  // Threshold Offset controls
+  btnLinkOffset.setEnabled(allowUnlink);
+
+  if (!canUnlink && !btnLinkOffset.getToggleState()) {
+    btnLinkOffset.setToggleState(true, juce::dontSendNotification);
+    btnLinkOffset.setButtonText("Linked");
+    if (auto* linkOffsetParam =
+            audioProcessor.getAPVTS().getParameter("link_threshold_offset"))
+      linkOffsetParam->setValueNotifyingHost(1.0f);
+  }
+
+  bool isOffsetLinked = btnLinkOffset.getToggleState();
+  bool tonalOffsetEnabled = pluginActive && !isOffsetLinked && allowUnlink;
+  sliderTonalOffset.setEnabled(tonalOffsetEnabled);
+  lblTonalOffset.setEnabled(tonalOffsetEnabled);
+
+  const juce::String masterOffsetTip =
+      isOffsetLinked ? "Shift noise profile threshold up or down\nin decibels "
+                       "(-12 to +12 dB)."
+                     : "Shift broadband noise threshold up or down\nin "
+                       "decibels (-12 to +12 dB).";
+  const juce::String tonalOffsetTip =
+      "Shift threshold for tonal noise components\nin decibels (-12 to +12 "
+      "dB).";
+
+  lblOffset.setTooltip(masterOffsetTip);
+  sliderOffset.setTooltip(masterOffsetTip);
+  lblMasterOffset.setTooltip(masterOffsetTip);
+  sliderTonalOffset.setTooltip(tonalOffsetTip);
+  lblTonalOffset.setTooltip(tonalOffsetTip);
 
   btnCurveToggle.setEnabled(pluginActive);
   btnResetCurve.setEnabled(pluginActive && btnCurveToggle.getToggleState());
@@ -1165,11 +1244,19 @@ void NoiseRepellentAudioProcessorEditor::resized() {
 
   // Right-side Threshold (Noise Profile Offset) vertical fader bank (symmetric
   // to reduction sliders on left)
-  auto offsetBankArea = denoiseInner.removeFromRight(95);
+  bool isOffsetLinked = !isAdvancedVisible || btnLinkOffset.getToggleState();
+  int offsetBankWidth = isOffsetLinked ? 95 : 155;
+
+  auto offsetBankArea = denoiseInner.removeFromRight(offsetBankWidth);
   denoiseInner.removeFromRight(10);
 
   lblOffset.setBounds(offsetBankArea.removeFromTop(16));
   offsetBankArea.removeFromTop(2);
+
+  if (isAdvancedVisible) {
+    btnLinkOffset.setBounds(offsetBankArea.removeFromTop(22));
+    offsetBankArea.removeFromTop(6);
+  }
 
   // Carve bottom area of offsetBankArea for Advanced Controls button below
   // threshold slider
@@ -1177,7 +1264,23 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   offsetBankArea.removeFromBottom(6);
   btnAdvancedToggle.setBounds(offsetBottomArea);
 
-  sliderOffset.setBounds(offsetBankArea);
+  if (isOffsetLinked) {
+    sliderOffset.setBounds(offsetBankArea);
+  } else {
+    int colW = (offsetBankArea.getWidth() - 6) / 2;
+
+    auto leftCol = offsetBankArea.removeFromLeft(colW);
+    offsetBankArea.removeFromLeft(6);
+    auto rightCol = offsetBankArea;
+
+    lblMasterOffset.setBounds(leftCol.removeFromTop(16));
+    leftCol.removeFromTop(2);
+    sliderOffset.setBounds(leftCol);
+
+    lblTonalOffset.setBounds(rightCol.removeFromTop(16));
+    rightCol.removeFromTop(2);
+    sliderTonalOffset.setBounds(rightCol);
+  }
 
   spectralVisualizer.setBounds(denoiseInner);
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -70,6 +70,11 @@ private:
   juce::Slider sliderOffset{juce::Slider::LinearVertical,
                             juce::Slider::TextBoxBelow};
   juce::Label lblOffset{"lblOffset", "THRESHOLD"};
+  juce::ToggleButton btnLinkOffset{"Linked"};
+  juce::Label lblMasterOffset{"lblMasterOffset", "BROADBAND"};
+  juce::Label lblTonalOffset{"lblTonalOffset", "TONAL"};
+  juce::Slider sliderTonalOffset{juce::Slider::LinearVertical,
+                                 juce::Slider::TextBoxBelow};
   juce::Label lblProfileStatus;
 
   // Module 2: Denoising & Spectrum
@@ -117,6 +122,7 @@ private:
   std::unique_ptr<ButtonAttachment> attachLearn;
   std::unique_ptr<ButtonAttachment> attachAdaptive;
   std::unique_ptr<ButtonAttachment> attachLink;
+  std::unique_ptr<ButtonAttachment> attachLinkOffset;
   std::unique_ptr<ButtonAttachment> attachCurveToggle;
   std::unique_ptr<ButtonAttachment> attachDelta;
   std::unique_ptr<ButtonAttachment> attachBypass;
@@ -127,6 +133,7 @@ private:
   std::unique_ptr<SliderAttachment> attachMasterRed;
   std::unique_ptr<SliderAttachment> attachTonalRed;
   std::unique_ptr<SliderAttachment> attachOffset;
+  std::unique_ptr<SliderAttachment> attachTonalOffset;
   std::unique_ptr<SliderAttachment> attachSmoothing;
   std::unique_ptr<SliderAttachment> attachMasking;
   std::unique_ptr<SliderAttachment> attachWhitening;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -120,6 +120,15 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
       juce::NormalisableRange<float>(-12.0f, 12.0f, 0.1f), 0.0f));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
+      "link_threshold_offset", "Link Threshold Offset", true,
+      juce::AudioParameterBoolAttributes().withAutomatable(false).withMeta(
+          true)));
+
+  params.push_back(std::make_unique<juce::AudioParameterFloat>(
+      "tonal_noise_profile_offset", "Tonal Noise Profile Offset",
+      juce::NormalisableRange<float>(-12.0f, 12.0f, 0.1f), 0.0f));
+
+  params.push_back(std::make_unique<juce::AudioParameterBool>(
       "reduction_curve_enabled", "Reduction Curve", false));
 
   return {params.begin(), params.end()};
@@ -659,6 +668,13 @@ void NoiseRepellentAudioProcessor::processBlock(
       parameters.getRawParameterValue("residual_listen")->load() > 0.5f;
   const float profileOffset =
       parameters.getRawParameterValue("noise_profile_offset")->load();
+  const bool linkThresholdOffset =
+      parameters.getRawParameterValue("link_threshold_offset")->load() > 0.5f;
+  const float tonalProfileOffsetDb =
+      linkThresholdOffset
+          ? profileOffset
+          : parameters.getRawParameterValue("tonal_noise_profile_offset")
+                ->load();
   const bool curveEnabled =
       parameters.getRawParameterValue("reduction_curve_enabled")->load() > 0.5f;
 
@@ -692,6 +708,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   const float smoothingNorm = smoothing / 100.0f;
   const float whiteningNorm = whitening / 100.0f;
   const float profileScale = std::pow(10.0f, profileOffset / 10.0f);
+  const float tonalProfileScale = std::pow(10.0f, tonalProfileOffsetDb / 10.0f);
 
   // Prepare parameters for DSP engines
   SpectralBleachDenoiserParameters p;
@@ -708,6 +725,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p.tonal_reduction_gain = tonalReductionGain;
   p.hpss_enable = transientProtectionEnable ? 1 : 0;
   p.noise_profile_scale = profileScale;
+  p.tonal_noise_profile_scale = tonalProfileScale;
   p.reduction_curve_enabled = curveEnabled;
   p.reduction_curve_bias =
       curveEnabled ? interpolatedCurveBias.data() : nullptr;
@@ -726,6 +744,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p2.tonal_reduction_gain = tonalReductionGain;
   p2.hpss_enable = transientProtectionEnable ? 1 : 0;
   p2.noise_profile_scale = profileScale;
+  p2.tonal_noise_profile_scale = tonalProfileScale;
   p2.reduction_curve_enabled = curveEnabled;
   p2.reduction_curve_bias =
       curveEnabled ? interpolatedCurveBias.data() : nullptr;
@@ -1143,6 +1162,9 @@ void NoiseRepellentAudioProcessor::processBlock(
           frame.isLinked =
               (parameters.getRawParameterValue("link_reduction")->load() >
                0.5f);
+          frame.isOffsetLinked =
+              (parameters.getRawParameterValue("link_threshold_offset")
+                   ->load() > 0.5f);
           frame.reductionCurveEnabled =
               (parameters.getRawParameterValue("reduction_curve_enabled")
                    ->load() > 0.5f);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -114,6 +114,7 @@ public:
     std::vector<float> tonalPeaksHz{}; // Detected tonal peak frequencies in Hz
     bool hasNoiseProfile = false;
     bool isLinked = true;
+    bool isOffsetLinked = true;
     bool reductionCurveEnabled = false;
     float transientIntensity = 0.0f; // Detected transient intensity [0.0, 1.0]
     bool isTransientProtected = false;


### PR DESCRIPTION
Fixes #186 

## Summary
- New APVTS params: `link_threshold_offset` (non-automatable meta bool, default linked) and `tonal_noise_profile_offset` (-12..+12 dB), mirroring the reduction link/unlink pattern
- When unlinked, the threshold fader bank splits into BROADBAND (amber) and TONAL (red) sliders; relinking resets both to defaults
- Same gating as reduction unlink: disabled in standalone adaptive mode without a captured profile
- FFT display: when threshold offset is unlinked, noise-profile regions around detected tonal peaks render in the tonal color; tonal peak markers now show when either reduction or threshold offset is unlinked
- Requires libspecbleach PR #135 (`tonal_noise_profile_scale`)

## Testing
- Release build clean; linked mode is behavior-identical to previous releases (equal scales collapse in processBlock)