### PR TITLE
fix(windows): remove non-redistributable OpenMP runtime dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,7 +535,7 @@ jobs:
           fi
 
           HAS_ERRORS=0
-          ALLOWED_DLLS="KERNEL32\.dll|USER32\.dll|GDI32\.dll|SHELL32\.dll|ADVAPI32\.dll|OLE32\.dll|OLEAUT32\.dll|SETUPAPI\.dll|COMDLG32\.dll|WS2_32\.dll|IMM32\.dll|VERSION\.dll|WINMM\.dll|UXTHEME\.dll|SHLWAPI\.dll|WININET\.dll|dbghelp\.dll|COMCTL32\.dll|d2d1\.dll|dxgi\.dll|d3d11\.dll|dcomp\.dll|dwmapi\.dll|VCRUNTIME140.*\.dll|MSVCP140.*\.dll|libomp140.*\.dll|ucrtbase\.dll|api-ms-win-.*\.dll|MFPlat\.dll|bcrypt\.dll|RPCRT4\.dll|PROPSYS\.dll"
+          ALLOWED_DLLS="KERNEL32\.dll|USER32\.dll|GDI32\.dll|SHELL32\.dll|ADVAPI32\.dll|OLE32\.dll|OLEAUT32\.dll|SETUPAPI\.dll|COMDLG32\.dll|WS2_32\.dll|IMM32\.dll|VERSION\.dll|WINMM\.dll|UXTHEME\.dll|SHLWAPI\.dll|WININET\.dll|dbghelp\.dll|COMCTL32\.dll|d2d1\.dll|dxgi\.dll|d3d11\.dll|dcomp\.dll|dwmapi\.dll|VCRUNTIME140.*\.dll|MSVCP140.*\.dll|ucrtbase\.dll|api-ms-win-.*\.dll|MFPlat\.dll|bcrypt\.dll|RPCRT4\.dll|PROPSYS\.dll"
           
           for BINARY in $BINARIES; do
             NAME=$(basename "$BINARY")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ if(MSVC)
     add_compile_options($<$<COMPILE_LANGUAGE:C>:/std:c11>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++17>)
     add_compile_options(/experimental:c11atomics)
-    add_compile_options(/openmp:llvm)
 endif()
 
 include(FetchContent)
@@ -247,6 +246,13 @@ else()
     set(SPECBLEACH_INSTALL OFF CACHE BOOL "" FORCE)
     set(ENABLE_TESTS OFF CACHE BOOL "" FORCE)
     set(ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+    # Disable OpenMP for embedded plugin builds: the MSVC LLVM OpenMP runtime
+    # (libomp140.x86_64.dll) is non-redistributable, ships only with Visual
+    # Studio, and is absent on end-user machines, breaking DLL load. OpenMP
+    # fork/join inside the audio callback is not real-time safe either.
+    # Must be set BEFORE add_subdirectory/FetchContent so libspecbleach's
+    # option(ENABLE_OPENMP ON) does not re-enable it.
+    set(ENABLE_OPENMP OFF CACHE BOOL "" FORCE)
 
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../libspecbleach/CMakeLists.txt")
         message(STATUS "Using local libspecbleach from ../libspecbleach")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,13 +246,6 @@ else()
     set(SPECBLEACH_INSTALL OFF CACHE BOOL "" FORCE)
     set(ENABLE_TESTS OFF CACHE BOOL "" FORCE)
     set(ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
-    # Disable OpenMP for embedded plugin builds: the MSVC LLVM OpenMP runtime
-    # (libomp140.x86_64.dll) is non-redistributable, ships only with Visual
-    # Studio, and is absent on end-user machines, breaking DLL load. OpenMP
-    # fork/join inside the audio callback is not real-time safe either.
-    # Must be set BEFORE add_subdirectory/FetchContent so libspecbleach's
-    # option(ENABLE_OPENMP ON) does not re-enable it.
-    set(ENABLE_OPENMP OFF CACHE BOOL "" FORCE)
 
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../libspecbleach/CMakeLists.txt")
         message(STATUS "Using local libspecbleach from ../libspecbleach")


### PR DESCRIPTION
Fixes #181

## Root cause

The Windows plugin DLLs (LV2 + VST3) dynamically imported `libomp140.x86_64.dll`:

- `CMakeLists.txt` applied `add_compile_options(/openmp:llvm)` globally on MSVC, and libspecbleach's NLM 2D filter compiles real OpenMP code, so MSVC auto-links the LLVM OpenMP runtime.
- That DLL is **not part of Windows**, **not in the VC++ Redistributable**, and ships only inside Visual Studio (`debug_nonredist`, explicitly non-redistributable per Microsoft docs).
- On end-user machines (e.g. the reporter's new Win11 laptop) `LoadLibrary` fails, so Ardour cannot load the plugin on any track. Linux was unaffected because `-fopenmp` links `libgomp`, present on every distro.

The "stereo track" detail was incidental: the LV2 is stereo-only, so that's the only track type it can be inserted on.

## Fix

- Remove the global `/openmp:llvm` flag from the plugin build.
- libspecbleach (lucianodato/libspecbleach@d07e578, on `main`): new `ENABLE_OPENMP` option — default ON for standalone builds, forced OFF by this repo before `add_subdirectory`/`FetchContent`. The NLM filter already has a generic single-threaded path; this also removes an OpenMP fork/join from the audio callback (real-time safety).
- CI: drop `libomp140.*\.dll` from the Windows import allowlist so a regression now fails verification.

## Verification

- CI run on this branch: https://github.com/lucianodato/noise-repellent/actions/runs/32840357501 — Windows configure shows `OpenMP: DISABLED`; both Windows binaries pass the hardened import check (no `libomp140` possible); macOS universal slices clean (also removes a latent homebrew-libomp portability hazard).
- libspecbleach: 30/30 tests pass with OpenMP both enabled and disabled; audio regression tests pass single-threaded.

## Note on #188

The "libspecbleach not embedded" diagnosis was a false positive: a successful link with referenced `specbleach_*` symbols and no `specbleach.dll` import means the static DSP was always embedded. The `strings` probe returns false negatives on MSVC Release DLLs (no COFF symbol table without `/DEBUG`), and 5.2 MB stripped PE vs 15 MB unstripped ELF is not a valid comparison.