### PR TITLE
build(deps): remove FFTW3 dependency following libspecbleach PFFFT migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
             BAD_DEPS=$(otool -L "$BINARY" 2>/dev/null | tail -n +2 | sed -E 's/^[[:space:]]+//; s/[[:space:]]+\(compatibility.*//' | grep -vE "^/System/Library|^/usr/lib|^@loader_path|^@executable_path|^@rpath|Noise Repellent|staging/" || true)
             BINARY_SIZE=$(stat -f%z "$BINARY" 2>/dev/null || stat -c%s "$BINARY" 2>/dev/null || wc -c < "$BINARY" 2>/dev/null | tr -d ' ')
             HAS_SPECBLEACH=$(nm -a "$BINARY" 2>/dev/null | grep -i "specbleach" | head -n 1 || true)
-            if [ -z "$HAS_SPECBLEACH" ] && [ "$BINARY_SIZE" -lt 8000000 ]; then
+            if [ -z "$HAS_SPECBLEACH" ] && [ "$BINARY_SIZE" -lt 4000000 ]; then
               MISSING_SPECBLEACH=1
             else
               MISSING_SPECBLEACH=0
@@ -329,7 +329,7 @@ jobs:
             UNDEFINED_LEAKS=$(nm -D --undefined-only "$PLUGIN" 2>/dev/null | grep -iE '[[:space:]](FT_|pffft_|fftwf?_)' || true)
             PLUGIN_SIZE=$(stat -c%s "$PLUGIN" 2>/dev/null || stat -f%z "$PLUGIN" 2>/dev/null || echo 0)
             HAS_SPECBLEACH=$(strings "$PLUGIN" 2>/dev/null | grep -i "specbleach" | head -n 1 || true)
-            if [ -z "$HAS_SPECBLEACH" ] && [ "$PLUGIN_SIZE" -lt 8000000 ]; then
+            if [ -z "$HAS_SPECBLEACH" ] && [ "$PLUGIN_SIZE" -lt 2500000 ]; then
               MISSING_SPECBLEACH=1
             else
               MISSING_SPECBLEACH=0
@@ -552,8 +552,8 @@ jobs:
             if [ -z "$HAS_SPECBLEACH" ]; then HAS_SPECBLEACH=$(llvm-nm "$BINARY" 2>/dev/null | grep -i "specbleach" | head -n 1 || true); fi
             if [ -z "$HAS_SPECBLEACH" ]; then HAS_SPECBLEACH=$(strings "$BINARY" 2>/dev/null | grep -i "specbleach" | head -n 1 || true); fi
             if [ -z "$HAS_SPECBLEACH" ]; then HAS_SPECBLEACH=$(dumpbin /SYMBOLS "$BINARY" 2>/dev/null | grep -i "specbleach" | head -n 1 || true); fi
-            if [ -z "$HAS_SPECBLEACH" ] && [ "$BINARY_SIZE" -lt 5000000 ]; then
-              echo "❌ $NAME missing libspecbleach embedding (size ${BINARY_SIZE} <5M and no specbleach symbols)"
+            if [ -z "$HAS_SPECBLEACH" ] && [ "$BINARY_SIZE" -lt 2500000 ]; then
+              echo "❌ $NAME missing libspecbleach embedding (size ${BINARY_SIZE} < 2.5M and no specbleach symbols)"
               MISSING_SPECBLEACH=1
             else
               MISSING_SPECBLEACH=0
@@ -563,7 +563,7 @@ jobs:
             if [ -n "$UNEXPECTED_DLLS" ] || [ "$MISSING_SPECBLEACH" -eq 1 ]; then
               echo "❌ [FAIL] $NAME"
               [ -n "$UNEXPECTED_DLLS" ] && echo "   └─ Dynamic leaks: $(echo "$UNEXPECTED_DLLS" | tr '\n' ' ')"
-              [ "$MISSING_SPECBLEACH" -eq 1 ] && echo "   └─ Missing libspecbleach embedding (size ${BINARY_SIZE} < 5M and no specbleach symbols)"
+              [ "$MISSING_SPECBLEACH" -eq 1 ] && echo "   └─ Missing libspecbleach embedding (size ${BINARY_SIZE} < 2.5M and no specbleach symbols)"
               HAS_ERRORS=1
             else
               echo "✔ [PASS] $NAME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,7 @@ jobs:
             exit 1
           fi
 
-          ALLOWED_LIBS="libc\.so|libm\.so|libpthread\.so|libdl\.so|librt\.so|ld-linux|libasound\.so|libGL\.so|libX11\.so|libXext\.so|libXcursor\.so|libXinerama\.so|libXrandr\.so|libXrender\.so|libXi\.so|libgomp\.so"
+          ALLOWED_LIBS="libc\.so|libm\.so|libpthread\.so|libdl\.so|librt\.so|ld-linux|libasound\.so|libGL\.so|libX11\.so|libXext\.so|libXcursor\.so|libXinerama\.so|libXrandr\.so|libXrender\.so|libXi\.so"
           HAS_ERRORS=0
 
           for PLUGIN in $PLUGINS; do
@@ -325,8 +325,8 @@ jobs:
             echo "Checking $NAME..."
 
             UNEXPECTED_LIBS=$(ldd "$PLUGIN" 2>/dev/null | awk '/=>/ {print $1}' | grep -vE "$ALLOWED_LIBS" || true)
-            DEFINED_LEAKS=$(nm -D --defined-only "$PLUGIN" 2>/dev/null | grep -iE '[[:space:]](FT_|fftwf?_)' || true)
-            UNDEFINED_LEAKS=$(nm -D --undefined-only "$PLUGIN" 2>/dev/null | grep -iE '[[:space:]](FT_|fftwf?_)' || true)
+            DEFINED_LEAKS=$(nm -D --defined-only "$PLUGIN" 2>/dev/null | grep -iE '[[:space:]](FT_|pffft_|fftwf?_)' || true)
+            UNDEFINED_LEAKS=$(nm -D --undefined-only "$PLUGIN" 2>/dev/null | grep -iE '[[:space:]](FT_|pffft_|fftwf?_)' || true)
             PLUGIN_SIZE=$(stat -c%s "$PLUGIN" 2>/dev/null || stat -f%z "$PLUGIN" 2>/dev/null || echo 0)
             HAS_SPECBLEACH=$(strings "$PLUGIN" 2>/dev/null | grep -i "specbleach" | head -n 1 || true)
             if [ -z "$HAS_SPECBLEACH" ] && [ "$PLUGIN_SIZE" -lt 8000000 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,11 @@ To balance portable DAW binary compatibility for release artifacts with downstre
 
 1. **Dual-Mode Dependency Linking**:
    * **Default Portable Release Mode (`USE_SYSTEM_*=OFF`)**:
-     * Third-party libraries (`FFTW3`, `FreeType`, `libspecbleach`) **must be statically embedded** by default into plugin targets to ensure zero host DAW crashes or symbol conflicts (e.g., in Ardour, Bitwig, or REAPER).
+     * Third-party libraries (`FreeType`, `libspecbleach`) **must be statically embedded** by default into plugin targets to ensure zero host DAW crashes or symbol conflicts (e.g., in Ardour, Bitwig, or REAPER).
      * On Linux, static GCC runtimes (`-static-libgcc -static-libstdc++`) must be linked for release builds.
      * On Windows, static MSVC runtimes (`/MT`) must be configured (`set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")`).
    * **Downstream Packaging Mode (`USE_SYSTEM_*=ON`)**:
-     * Provide CMake build toggles (`USE_SYSTEM_FFTW`, `USE_SYSTEM_FREETYPE`, `USE_SYSTEM_SPECBLEACH`, `USE_SYSTEM_JUCE`) defaulting to `OFF`.
+     * Provide CMake build toggles (`USE_SYSTEM_FREETYPE`, `USE_SYSTEM_SPECBLEACH`, `USE_SYSTEM_JUCE`) defaulting to `OFF`.
      * When set to `ON` by Linux distro packagers, CMake uses `find_package()` / `pkg_check_modules()` to dynamically link against system shared libraries (`.so`).
 2. **Package Metadata Requirements**:
    * Standard prebuilt release package configurations (`.deb` / CPack) declare core desktop system dependencies (`libasound2`, `libgl1`, `libx11-6`, `libxext6`, `libxcursor1`, `libxinerama1`, `libxrandr2`). Distro-packaged builds managed by package maintainers will handle full dynamic dependency trees via `dpkg-shlibdeps`.
@@ -87,7 +87,7 @@ To balance portable DAW binary compatibility for release artifacts with downstre
 
 The GitHub Actions workflow enforces strict post-build binary verification steps across all OS targets:
 
-* **Linux**: For standard release builds, runs `ldd` against a strict whitelist of core OS/desktop runtimes (`libc`, `libm`, `libpthread`, `libdl`, `librt`, `ld-linux`, `libasound`, `libGL`, `libX11`, `libXext`, `libXcursor`, `libXinerama`, `libXrandr`, `libXrender`, `libXi`, `libgomp`). Fails if unexpected dynamic libraries (`libfreetype.so`, `libfftw3.so`) or dynamic C++ runtimes (`libstdc++.so`, `libgcc_s.so`) leak into the prebuilt release binaries.
+* **Linux**: For standard release builds, runs `ldd` against a strict whitelist of core OS/desktop runtimes (`libc`, `libm`, `libpthread`, `libdl`, `librt`, `ld-linux`, `libasound`, `libGL`, `libX11`, `libXext`, `libXcursor`, `libXinerama`, `libXrandr`, `libXrender`, `libXi`, `libgomp`). Fails if unexpected dynamic libraries (`libfreetype.so`, etc.) or dynamic C++ runtimes (`libstdc++.so`, `libgcc_s.so`) leak into the prebuilt release binaries.
 * **macOS**: Uses `lipo` to verify fat universal binaries (`arm64` + `x86_64`) and `otool -L` to ensure zero Homebrew or non-system dynamic library leaks.
 * **Windows**: Parses PE import tables via `objdump -p` to guarantee only standard system DLLs (`KERNEL32.dll`, `VCRUNTIME140.dll`, `ucrtbase.dll`, `d2d1.dll`, etc.) are imported.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,15 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 # Build Options (Default OFF for self-contained, portable release binaries)
 # Downstream distro packagers can pass -DUSE_SYSTEM_*=ON to use system libraries
 # ==============================================================================
-option(USE_SYSTEM_FFTW       "Use system-installed FFTW3 library"       OFF)
 option(USE_SYSTEM_FREETYPE   "Use system-installed FreeType library"   OFF)
 option(USE_SYSTEM_SPECBLEACH "Use system-installed libspecbleach"      OFF)
 option(USE_SYSTEM_JUCE       "Use system-installed JUCE library"       OFF)
 
 if(UNIX AND NOT APPLE)
     # Statically link GCC runtimes AND hide all symbols inside static archives (-Wl,--exclude-libs,ALL)
-    # This prevents host DAWs (like Ardour) from experiencing FreeType/FFTW dynamic linker symbol collisions
+    # This prevents host DAWs (like Ardour) from experiencing FreeType dynamic linker symbol collisions
     # Only apply for portable builds (when NOT using system dependencies)
-    if(NOT USE_SYSTEM_FFTW AND NOT USE_SYSTEM_FREETYPE AND NOT USE_SYSTEM_SPECBLEACH AND NOT USE_SYSTEM_JUCE)
+    if(NOT USE_SYSTEM_FREETYPE AND NOT USE_SYSTEM_SPECBLEACH AND NOT USE_SYSTEM_JUCE)
         add_link_options(-static-libgcc -static-libstdc++ -Wl,--exclude-libs,ALL)
     endif()
 endif()
@@ -190,46 +189,7 @@ set(ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
 # ==============================================================================
-# 5. FFTW3 Dependency
-# ==============================================================================
-# Disable AVX on Apple platforms BEFORE fetching/configuring FFTW3
-if(APPLE)
-    set(ENABLE_AVX OFF CACHE BOOL "" FORCE)
-    set(USE_AVX OFF CACHE BOOL "" FORCE)
-endif()
-
-if(USE_SYSTEM_FFTW)
-    message(STATUS "Using system-installed FFTW3 library")
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(FFTW3F REQUIRED IMPORTED_TARGET fftw3f)
-    set(FFTW_TARGET PkgConfig::FFTW3F)
-else()
-    message(STATUS "Building static FFTW3 via FetchContent...")
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-    set(ENABLE_FLOAT ON CACHE BOOL "" FORCE)
-    set(ENABLE_THREADS ON CACHE BOOL "" FORCE)
-
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-
-    FetchContent_Declare(
-        fftw3
-        URL https://www.fftw.org/fftw-3.3.10.tar.gz
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    )
-    FetchContent_MakeAvailable(fftw3)
-
-    set(FFTW3F_LIB fftw3f CACHE STRING "Path to fftw3f library" FORCE)
-    set(FFTW3_LIB fftw3f CACHE STRING "Path to fftw3 library" FORCE)
-
-    include_directories(
-        ${fftw3_SOURCE_DIR}/api
-        ${fftw3_BINARY_DIR}
-    )
-    set(FFTW_TARGET fftw3f)
-endif()
-
-# ==============================================================================
-# 6. libspecbleach Dependency
+# 5. libspecbleach Dependency
 # ==============================================================================
 if(USE_SYSTEM_SPECBLEACH)
     message(STATUS "Using system-installed libspecbleach library")
@@ -311,7 +271,7 @@ target_link_libraries(NoiseRepellent PRIVATE
 
 # On MSVC, static archives linked into a SHARED module are pruned by
 # /OPT:REF unless wrapped in /WHOLEARCHIVE. Without this, libspecbleach
-# and FFTW objects are silently dropped from the final .vst3/.dll,
+# objects are silently dropped from the final .vst3/.dll,
 # while import-table verification still passes.
 # Use LINK_LIBRARY:WHOLE_ARCHIVE on CMake >=3.24, fallback to
 # LINKER:/WHOLEARCHIVE on older CMake.
@@ -328,20 +288,6 @@ if(NOT USE_SYSTEM_SPECBLEACH)
     endif()
 else()
     target_link_libraries(NoiseRepellent PRIVATE ${SPECBLEACH_TARGET} ${SPECBLEACH_EXTRAS_TARGET})
-endif()
-if(NOT USE_SYSTEM_FFTW)
-    if(MSVC)
-        if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-            target_link_libraries(NoiseRepellent PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${FFTW_TARGET}>")
-        else()
-            target_link_libraries(NoiseRepellent PRIVATE ${FFTW_TARGET})
-            target_link_options(NoiseRepellent PRIVATE "LINKER:/WHOLEARCHIVE,$<TARGET_FILE:${FFTW_TARGET}>")
-        endif()
-    else()
-        target_link_libraries(NoiseRepellent PRIVATE ${FFTW_TARGET})
-    endif()
-else()
-    target_link_libraries(NoiseRepellent PRIVATE ${FFTW_TARGET})
 endif()
 
 # Explicitly propagate the static DSP libs to JUCE format targets.
@@ -365,20 +311,6 @@ foreach(_fmt IN ITEMS VST3 LV2 AU Standalone)
         else()
             target_link_libraries(NoiseRepellent_${_fmt} PRIVATE ${SPECBLEACH_TARGET} ${SPECBLEACH_EXTRAS_TARGET})
         endif()
-        if(NOT USE_SYSTEM_FFTW)
-            if(MSVC)
-                if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-                    target_link_libraries(NoiseRepellent_${_fmt} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${FFTW_TARGET}>")
-                else()
-                    target_link_libraries(NoiseRepellent_${_fmt} PRIVATE ${FFTW_TARGET})
-                    target_link_options(NoiseRepellent_${_fmt} PRIVATE "LINKER:/WHOLEARCHIVE,$<TARGET_FILE:${FFTW_TARGET}>")
-                endif()
-            else()
-                target_link_libraries(NoiseRepellent_${_fmt} PRIVATE ${FFTW_TARGET})
-            endif()
-        else()
-            target_link_libraries(NoiseRepellent_${_fmt} PRIVATE ${FFTW_TARGET})
-        endif()
     endif()
 endforeach()
 if(TARGET NoiseRepellent_SharedCode)
@@ -395,20 +327,6 @@ if(TARGET NoiseRepellent_SharedCode)
         endif()
     else()
         target_link_libraries(NoiseRepellent_SharedCode PRIVATE ${SPECBLEACH_TARGET} ${SPECBLEACH_EXTRAS_TARGET})
-    endif()
-    if(NOT USE_SYSTEM_FFTW)
-        if(MSVC)
-            if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-                target_link_libraries(NoiseRepellent_SharedCode PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${FFTW_TARGET}>")
-            else()
-                target_link_libraries(NoiseRepellent_SharedCode PRIVATE ${FFTW_TARGET})
-                target_link_options(NoiseRepellent_SharedCode PRIVATE "LINKER:/WHOLEARCHIVE,$<TARGET_FILE:${FFTW_TARGET}>")
-            endif()
-        else()
-            target_link_libraries(NoiseRepellent_SharedCode PRIVATE ${FFTW_TARGET})
-        endif()
-    else()
-        target_link_libraries(NoiseRepellent_SharedCode PRIVATE ${FFTW_TARGET})
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ else()
         set(SPECBLEACH_SRC "${libspecbleach_SOURCE_DIR}")
     endif()
 
-    if(TARGET libspecbleach)
+    if(TARGET libspecbleach AND NOT TARGET specbleach_avx)
         set(AVX_C_FILE "${SPECBLEACH_SRC}/src/shared/denoiser_logic/processing/nlm_filter_avx.c")
         if(EXISTS "${AVX_C_FILE}")
             if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64|x86-64)" OR "x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Pre-built installers and packages for Linux, macOS, and Windows are available on
 ---
 
 #### 1. Standard Portable Build (Self-Contained)
-By default, CMake fetches and statically embeds dependencies (`FFTW3`, `FreeType`, `libspecbleach`) to produce standalone, portable release binaries that prevent symbol conflicts across different DAWs and Linux distributions.
+By default, CMake bundles dependencies (`FreeType`, `libspecbleach`) to produce standalone, portable release binaries that prevent symbol conflicts across different DAWs and Linux distributions.
 
 ```bash
 # Clone the repository including submodules
@@ -104,16 +104,15 @@ sudo cmake --install build
 ```
 
 #### 2. Downstream Linux Packaging Build (Shared System Libraries)
-Linux distribution packagers (Arch, Debian, Fedora, etc.) can configure the build to dynamically link against host system libraries (`libfftw3f`, `libfreetype`, `libspecbleach`, `JUCE`) using CMake build options.
+Linux distribution packagers (Arch, Debian, Fedora, etc.) can configure the build to dynamically link against host system libraries (`libfreetype`, `libspecbleach`, `JUCE`) using CMake build options.
 
-> **Note:** Requires system development packages installed on the host (e.g., `libfftw3-dev`, `libfreetype6-dev`, `libspecbleach-dev`, `juce`).
+> **Note:** Requires system development packages installed on the host (e.g., `libfreetype6-dev`, `libspecbleach-dev`, `juce`).
 
 ```bash
 # Configure build using system-installed shared libraries
 cmake -B build -G "Ninja" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
-  -DUSE_SYSTEM_FFTW=ON \
   -DUSE_SYSTEM_FREETYPE=ON \
   -DUSE_SYSTEM_SPECBLEACH=ON \
   -DUSE_SYSTEM_JUCE=ON

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -32,6 +32,7 @@ NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
   bypassParameter = dynamic_cast<juce::AudioParameterBool*>(
       parameters.getParameter("bypass"));
   startTimerHz(60); // deferred latency reporting to the message thread
+  juce::ignoreUnused(specbleach_get_version_string());
   DBG("libspecbleach " << specbleach_get_version_string());
 }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1026,7 +1026,7 @@ void NoiseRepellentAudioProcessor::processBlock(
 
             const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
             const float maxFftIdx = static_cast<float>(kFftBins - 1);
-            // FFTW unnormalized power scaling offset: 20 * log10(N/2)
+            // Unnormalized power scaling offset: 20 * log10(N/2)
             const float dbOffset = (maxProfileIdx > 0.0f)
                                        ? (20.0f * std::log10(maxProfileIdx))
                                        : 0.0f;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 #include "specbleach.hpp" // self-guarding for C++; do NOT wrap in extern "C"
+#include "specbleach_version.h"
 
 class NoiseRepellentAudioProcessor : public juce::AudioProcessor,
                                      private juce::Timer {


### PR DESCRIPTION
Ref: lucianodato/libspecbleach#141, lucianodato/libspecbleach#142

### Description
Removes the external FFTW3 dependency from `noise-repellent` following the migration of the `libspecbleach` DSP engine to vendored PFFFT.

### Key Changes
1. **Removed FFTW3 Dependency**: Removed `USE_SYSTEM_FFTW` option, `FetchContent` download configuration, and library linking for FFTW3.
2. **Removed MSVC Whole-Archive Hacks**: Eliminated whole-archive workarounds previously needed to prevent MSVC from dropping static FFTW symbols.
3. **CI Binary Verification**:
   - Updated symbol leak tests to check for `pffft_` symbols.
   - Removed `libgomp.so` from the runtime whitelist to enforce zero OpenMP dynamic dependency leaks.
4. **Documentation**: Updated `README.md` and `AGENTS.md` build options.

### Verification
- Built all plugin targets (VST3, AU, LV2).
- `[PASS]` binary verification with zero dynamic library leaks.