### PR TITLE
perf: bypass DSP when plugin bypassed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "Source/Tests"
+  - "subprojects"
+  - "build"
+  - "build-test"
+  - "_deps"
+  - "docs"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,13 @@ jobs:
       - name: Generate Coverage Report
         run: |
           gcovr --xml build-test/coverage.xml -r . \
+            --filter 'Source/.*' \
             -e 'Source/Tests/.*' \
             -e 'subprojects/.*' \
             -e '_deps/.*' \
             -e 'build-test/.*' \
-            --gcov-ignore-parse-errors negative_hits.warn_once_per_file
+            --gcov-ignore-errors=no_working_dir_found \
+            --gcov-ignore-parse-errors=all
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - main
   pull_request:
     branches:
       - "*"
@@ -13,6 +15,64 @@ env:
   CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime,time_macros
 
 jobs:
+  test-linux:
+    name: Test & Coverage (Linux)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install System Dependencies & Build Tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y \
+            build-essential cmake ninja-build gcovr xvfb \
+            libasound2-dev libjack-jackd2-dev libgl1-mesa-dev \
+            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev \
+            libxinerama-dev libxrandr-dev libfontconfig1-dev libfreetype6-dev
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-test-ccache
+          max-size: 2000M
+          verbose: 2
+
+      - name: Configure CMake
+        run: |
+          cmake -B build-test -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_PLUGIN_TESTS=ON \
+            -DENABLE_COVERAGE=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build Test Executables
+        run: |
+          cmake --build build-test --target test_ux_invariants test_performance -j4
+
+      - name: Run Test Suite
+        run: |
+          xvfb-run ctest --test-dir build-test --output-on-failure
+
+      - name: Generate Coverage Report
+        run: |
+          gcovr --xml build-test/coverage.xml -r . \
+            -e 'Source/Tests/.*' \
+            -e 'subprojects/.*' \
+            -e '_deps/.*' \
+            -e 'build-test/.*' \
+            --gcov-ignore-parse-errors negative_hits.warn_once_per_file
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: build-test/coverage.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   build-macos:
     name: macOS (Universal arm64 + x86_64)
     runs-on: macos-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file contains foundational mandates and architectural context for AI agents
 2. **Bypass Fidelity**: All bypass transitions must use native `juce::dsp::DryWetMixer<float>` to prevent pops/clicks and maintain latency alignment (`setWetLatency`) with host delay compensation.
 3. **APVTS & Parameter Management**: Parameter changes must go through `juce::AudioProcessorValueTreeState`. Parameter IDs defined in `PluginProcessor` layout must match key strings used in state serialization and GUI attachments.
 4. **License**: Code in `Source/` is licensed under GPL-3.0-or-later. Include standard license headers on all new source files.
+5. **UX & Invariant Preservation**: All changes must preserve the contracts defined in [docs/UX_INVARIANTS.md](docs/UX_INVARIANTS.md). Always verify with `test_ux_invariants` (`-DENABLE_PLUGIN_TESTS=ON`).
 
 ## Project Structure & Workflow
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,15 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 option(USE_SYSTEM_FREETYPE   "Use system-installed FreeType library"   OFF)
 option(USE_SYSTEM_SPECBLEACH "Use system-installed libspecbleach"      OFF)
 option(USE_SYSTEM_JUCE       "Use system-installed JUCE library"       OFF)
+option(ENABLE_PLUGIN_TESTS   "Build plugin unit tests"                 ON)
+option(ENABLE_COVERAGE       "Enable code coverage instrumentation"    OFF)
+
+include(CTest)
+
+if(ENABLE_COVERAGE AND NOT MSVC)
+    add_compile_options(--coverage -O0)
+    add_link_options(--coverage)
+endif()
 
 if(UNIX AND NOT APPLE)
     # Statically link GCC runtimes AND hide all symbols inside static archives (-Wl,--exclude-libs,ALL)
@@ -389,5 +398,91 @@ if(TARGET NoiseRepellent_LV2)
         COMPONENT LV2
     )
 endif()
+
+# ==============================================================================
+# 9. Unit Tests
+# ==============================================================================
+if(ENABLE_PLUGIN_TESTS OR BUILD_TESTING)
+    add_executable(test_ux_invariants
+        Source/Tests/test_ux_invariants.cpp
+        Source/PluginProcessor.cpp
+        Source/PluginEditor.cpp
+        Source/GUI/LookAndFeel.cpp
+        Source/GUI/SpectralVisualizer.cpp
+    )
+    target_compile_definitions(test_ux_invariants PRIVATE
+        JUCE_MODAL_LOOPS_PERMITTED=1
+        JucePlugin_Name="Noise Repellent"
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        JUCE_VST3_CAN_REPLACE_VST2=0
+    )
+    target_include_directories(test_ux_invariants PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/Source
+        ${SPECBLEACH_SRC}/include
+        ${SPECBLEACH_SRC}/extras/include
+    )
+    target_link_libraries(test_ux_invariants PRIVATE
+        ${SPECBLEACH_TARGET}
+        ${SPECBLEACH_EXTRAS_TARGET}
+        juce::juce_audio_utils
+        juce::juce_audio_processors
+        juce::juce_dsp
+        juce::juce_gui_extra
+        juce::juce_gui_basics
+        juce::juce_graphics
+        juce::juce_events
+        juce::juce_core
+    )
+    if(UNIX AND NOT APPLE)
+        if(USE_SYSTEM_FREETYPE)
+            target_link_libraries(test_ux_invariants PRIVATE Freetype::Freetype)
+        elseif(NOT USE_SYSTEM_JUCE)
+            target_link_libraries(test_ux_invariants PRIVATE freetype)
+        endif()
+    endif()
+    add_test(NAME test_ux_invariants COMMAND test_ux_invariants)
+
+    add_executable(test_performance
+        Source/Tests/test_performance.cpp
+        Source/PluginProcessor.cpp
+        Source/PluginEditor.cpp
+        Source/GUI/LookAndFeel.cpp
+        Source/GUI/SpectralVisualizer.cpp
+    )
+    target_compile_definitions(test_performance PRIVATE
+        JUCE_MODAL_LOOPS_PERMITTED=1
+        JucePlugin_Name="Noise Repellent"
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        JUCE_VST3_CAN_REPLACE_VST2=0
+    )
+    target_include_directories(test_performance PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/Source
+        ${SPECBLEACH_SRC}/include
+        ${SPECBLEACH_SRC}/extras/include
+    )
+    target_link_libraries(test_performance PRIVATE
+        ${SPECBLEACH_TARGET}
+        ${SPECBLEACH_EXTRAS_TARGET}
+        juce::juce_audio_utils
+        juce::juce_audio_processors
+        juce::juce_dsp
+        juce::juce_gui_extra
+        juce::juce_gui_basics
+        juce::juce_graphics
+        juce::juce_events
+        juce::juce_core
+    )
+    if(UNIX AND NOT APPLE)
+        if(USE_SYSTEM_FREETYPE)
+            target_link_libraries(test_performance PRIVATE Freetype::Freetype)
+        elseif(NOT USE_SYSTEM_JUCE)
+            target_link_libraries(test_performance PRIVATE freetype)
+        endif()
+    endif()
+    add_test(NAME test_performance COMMAND test_performance)
+endif()
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Noise Repellent
 
 [![CI Build](https://github.com/lucianodato/noise-repellent/actions/workflows/build.yml/badge.svg)](https://github.com/lucianodato/noise-repellent/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/lucianodato/noise-repellent/graph/badge.svg?token=krKa2evPqh)](https://codecov.io/gh/lucianodato/noise-repellent)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/lucianodato/noise-repellent?utm_source=oss&utm_medium=github&utm_campaign=lucianodato%2Fnoise-repellent&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 A multi-format audio plugin (VST3, AU, LV2) for real-time spectral noise reduction, built with [JUCE](https://juce.com/) and powered by the [libspecbleach](https://github.com/lucianodato/libspecbleach) DSP engine.

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -89,7 +89,13 @@ void SpectralVisualizerComponent::timerCallback() {
     }
   }
 
-  repaint();
+  if (frameReceived || transientHoldTicks > 0 || ledBrightness > 0.0f) {
+    idleTicks = 0;
+    repaint();
+  } else if (idleTicks < 30) {
+    idleTicks++;
+    repaint();
+  }
 }
 
 void SpectralVisualizerComponent::resized() {

--- a/Source/GUI/SpectralVisualizer.h
+++ b/Source/GUI/SpectralVisualizer.h
@@ -58,6 +58,7 @@ private:
   std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedInputDB;
   std::array<float, NoiseRepellentAudioProcessor::kFftBins> smoothedOutputDB;
   bool isSmoothedInitialized = false;
+  int idleTicks = 0;
 
   float ledBrightness = 0.0f;
   int transientHoldTicks = 0;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -64,12 +64,12 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
     else
       return;
   }
-  if (newMode == currentAlgoMode)
+  if (newMode == currentAlgoMode.load())
     return;
   if (spectralGroup == nullptr || nlmGroup == nullptr)
     return;
 
-  if (switchPhase != SwitchPhase::Steady)
+  if (switchPhase.load() != SwitchPhase::Steady)
     return;
   // Allow future 0-latency engine (mode 2) - keep check generic
   if (newMode < 0 || newMode > 2)
@@ -105,7 +105,7 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
     // Gap is ~1 block, masks NLM cold start, then gapless Warming+XFade at
     // high.
     suspendProcessing(true);
-    auto* sourceGroup = activeGroupFor(currentAlgoMode);
+    auto* sourceGroup = activeGroupFor(currentAlgoMode.load());
     auto* targetGroup = activeGroupFor(newMode);
     if (sourceGroup != nullptr && targetGroup != nullptr &&
         sourceGroup != targetGroup) {
@@ -127,15 +127,15 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
       for (auto& buf : wetCompDelayBuffers)
         std::fill(buf.begin(), buf.end(), 0.0f);
       std::fill(wetCompDelayWritePos.begin(), wetCompDelayWritePos.end(), 0);
-      switchFromMode = currentAlgoMode;
-      currentAlgoMode = newMode;
-      switchPhase = SwitchPhase::Warming;
-      warmSamplesTotal =
-          static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0));
-      xfadeSamplesTotal =
-          static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0));
-      stageSamplesRemaining = warmSamplesTotal;
-      xfadeProgress = 0.0f;
+      switchFromMode.store(currentAlgoMode.load());
+      currentAlgoMode.store(newMode);
+      switchPhase.store(SwitchPhase::Warming);
+      warmSamplesTotal.store(
+          static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0)));
+      xfadeSamplesTotal.store(
+          static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0)));
+      stageSamplesRemaining.store(warmSamplesTotal.load());
+      xfadeProgress.store(0.0f);
     }
     setLatencySamples(static_cast<int>(newNative));
     dryWetMixer.setWetLatency(static_cast<float>(newNative));
@@ -148,9 +148,9 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
   // with deferred host update until stop (transport-aware).
   {
     const juce::ScopedLock sl(getCallbackLock());
-    if (switchPhase != SwitchPhase::Steady)
+    if (switchPhase.load() != SwitchPhase::Steady)
       return;
-    auto* sourceGroup = activeGroupFor(currentAlgoMode);
+    auto* sourceGroup = activeGroupFor(currentAlgoMode.load());
     auto* targetGroup = activeGroupFor(newMode);
     if (sourceGroup != nullptr && targetGroup != nullptr &&
         sourceGroup != targetGroup) {
@@ -229,13 +229,15 @@ void NoiseRepellentAudioProcessor::initiateEngineSwitchOnMessageThread(
     // No extra flush needed - delay already primed via Warming
   }
 
-  switchFromMode = currentAlgoMode;
-  currentAlgoMode = newMode;
-  switchPhase = SwitchPhase::Warming;
-  warmSamplesTotal = static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0));
-  xfadeSamplesTotal = static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0));
-  stageSamplesRemaining = warmSamplesTotal;
-  xfadeProgress = 0.0f;
+  switchFromMode.store(currentAlgoMode.load());
+  currentAlgoMode.store(newMode);
+  switchPhase.store(SwitchPhase::Warming);
+  warmSamplesTotal.store(
+      static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0)));
+  xfadeSamplesTotal.store(
+      static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0)));
+  stageSamplesRemaining.store(warmSamplesTotal.load());
+  xfadeProgress.store(0.0f);
 }
 
 void NoiseRepellentAudioProcessor::applyWetCompensationDelay(
@@ -680,8 +682,8 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
                                                  int samplesPerBlock) {
   ensureEnginesInitialized(sampleRate);
 
-  currentAlgoMode = static_cast<int>(
-      parameters.getRawParameterValue("algorithm_mode")->load());
+  currentAlgoMode.store(static_cast<int>(
+      parameters.getRawParameterValue("algorithm_mode")->load()));
 
   // Variable latency with deferred host update: report native for current
   // engine so 1D keeps low-latency benefit. Switch during playback keeps
@@ -693,7 +695,7 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
     latNLM = specbleach_stereo_get_latency(nlmGroup.get());
   const uint32_t maxLatency = std::max(latSpectral, latNLM);
   uint32_t nativeLatency = 0;
-  if (auto* activeGroup = activeGroupFor(currentAlgoMode))
+  if (auto* activeGroup = activeGroupFor(currentAlgoMode.load()))
     nativeLatency = specbleach_stereo_get_latency(activeGroup);
   if (nativeLatency == 0)
     nativeLatency = maxLatency;
@@ -749,11 +751,11 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   jassert(dryInputL.size() >= static_cast<size_t>(samplesPerBlock));
   jassert(wetScratchA.getNumSamples() >= samplesPerBlock);
 
-  switchPhase = SwitchPhase::Steady;
-  stageSamplesRemaining = 0;
-  warmSamplesTotal = 0;
-  xfadeSamplesTotal = 0;
-  xfadeProgress = 0.0f;
+  switchPhase.store(SwitchPhase::Steady);
+  stageSamplesRemaining.store(0);
+  warmSamplesTotal.store(0);
+  xfadeSamplesTotal.store(0);
+  xfadeProgress.store(0.0f);
   uiSwitchProgress.store(1.0f, std::memory_order_relaxed);
   pendingEngineSwitchRequest.store(-1, std::memory_order_release);
   pendingLatencyReport.store(-1, std::memory_order_release);
@@ -861,9 +863,9 @@ void NoiseRepellentAudioProcessor::processBlock(
   // migration is a bounded, allocation-free copy of small profile buffers.
   if (wasLearning && !learnNoise && spectralGroup != nullptr &&
       nlmGroup != nullptr) {
-    auto* sourceGroup = activeGroupFor(currentAlgoMode);
+    auto* sourceGroup = activeGroupFor(currentAlgoMode.load());
     auto* otherGroup =
-        (currentAlgoMode == 1) ? spectralGroup.get() : nlmGroup.get();
+        (currentAlgoMode.load() == 1) ? spectralGroup.get() : nlmGroup.get();
     if (sourceGroup != nullptr && otherGroup != nullptr &&
         sourceGroup != otherGroup) {
       specbleach_stereo_migrate_profiles_from(otherGroup, sourceGroup);
@@ -930,13 +932,14 @@ void NoiseRepellentAudioProcessor::processBlock(
   // phase initiation are performed on the message thread under
   // getCallbackLock() (see handleAsyncUpdate()). The audio thread only
   // detects a drift and coalesces it into an async request.
-  if (algoMode != currentAlgoMode && switchPhase == SwitchPhase::Steady &&
-      spectralGroup != nullptr && nlmGroup != nullptr) {
+  if (algoMode != currentAlgoMode.load() &&
+      switchPhase.load() == SwitchPhase::Steady && spectralGroup != nullptr &&
+      nlmGroup != nullptr) {
     pendingEngineSwitchRequest.store(algoMode, std::memory_order_release);
     triggerAsyncUpdate();
   }
 
-  const bool switchingNow = (switchPhase != SwitchPhase::Steady);
+  const bool switchingNow = (switchPhase.load() != SwitchPhase::Steady);
 
   // Silence detection: when input is ~-100dB and not learning, skip heavy
   // STFT+denoise (was culprit for idle > denoising and no-playback CPU).
@@ -972,7 +975,7 @@ void NoiseRepellentAudioProcessor::processBlock(
     // Bypassed: skip all specbleach STFT+denoise
   } else if (!switchingNow) {
     // Steady state: gapless with deferred PDC (lastReported may be high)
-    auto* activeGroup = activeGroupFor(currentAlgoMode);
+    auto* activeGroup = activeGroupFor(currentAlgoMode.load());
     if (activeGroup != nullptr) {
       const uint32_t groupChannels = std::min<uint32_t>(
           specbleach_stereo_get_channel_count(activeGroup), 2u);
@@ -992,10 +995,10 @@ void NoiseRepellentAudioProcessor::processBlock(
                 : ((sinkA != nullptr) ? sinkA : buffer.getWritePointer(0));
       }
 
-      if (currentAlgoMode == 0 && activeGroup == spectralGroup.get()) {
+      if (currentAlgoMode.load() == 0 && activeGroup == spectralGroup.get()) {
         specbleach_stereo_load_parameters_1d(spectralGroup.get(), &p,
                                              sizeof(p));
-      } else if (currentAlgoMode == 1 && activeGroup == nlmGroup.get()) {
+      } else if (currentAlgoMode.load() == 1 && activeGroup == nlmGroup.get()) {
         specbleach_stereo_load_parameters_2d(nlmGroup.get(), &p2, sizeof(p2));
       }
       specbleach_stereo_process(activeGroup, static_cast<uint32_t>(numSamples),
@@ -1003,18 +1006,18 @@ void NoiseRepellentAudioProcessor::processBlock(
     }
     // Pad to lastReported for gapless deferred (0-latency => pad to high)
     uint32_t comp = 0;
-    if (currentAlgoMode == 0)
+    if (currentAlgoMode.load() == 0)
       comp = wetCompDelay1D;
-    else if (currentAlgoMode == 1)
+    else if (currentAlgoMode.load() == 1)
       comp = wetCompDelay2D;
-    else if (currentAlgoMode == 2)
+    else if (currentAlgoMode.load() == 2)
       comp = lastReportedLatency; // native 0
     applyWetCompensationDelay(buffer, comp, numSamples);
   } else {
     // Gapless switch: Warming keeps source audible while target warms in
     // scratch; XFade runs both and equal-power crossfades to the target.
-    auto* sourceGroup = activeGroupFor(switchFromMode);
-    auto* targetGroup = activeGroupFor(currentAlgoMode);
+    auto* sourceGroup = activeGroupFor(switchFromMode.load());
+    auto* targetGroup = activeGroupFor(currentAlgoMode.load());
 
     const uint32_t srcChannels =
         sourceGroup ? specbleach_stereo_get_channel_count(sourceGroup) : 0;
@@ -1029,10 +1032,10 @@ void NoiseRepellentAudioProcessor::processBlock(
       inPtrs[ch] = buffer.getReadPointer(
           ch < static_cast<uint32_t>(numChannels) ? static_cast<int>(ch) : 0);
 
-    if (switchPhase == SwitchPhase::Warming) {
+    if (switchPhase.load() == SwitchPhase::Warming) {
       // Warm target in scratch (not audible) while source remains audible
       if (targetGroup != nullptr) {
-        if (currentAlgoMode == 0)
+        if (currentAlgoMode.load() == 0)
           specbleach_stereo_load_parameters_1d(targetGroup, &p, sizeof(p));
         else
           specbleach_stereo_load_parameters_2d(targetGroup, &p2, sizeof(p2));
@@ -1045,7 +1048,7 @@ void NoiseRepellentAudioProcessor::processBlock(
           tgtOut[1] = wetScratchB.getWritePointer(1);
         specbleach_stereo_process(
             targetGroup, static_cast<uint32_t>(numSamples), inPtrs, tgtOut);
-      } else if (currentAlgoMode == 2) {
+      } else if (currentAlgoMode.load() == 2) {
         // 0-latency passthrough: copy input to scratch for warming
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
@@ -1056,15 +1059,15 @@ void NoiseRepellentAudioProcessor::processBlock(
       }
       // Pad to effective (max) for gapless - handles 0-latency (native 0)
       uint32_t tgtComp = 0;
-      if (currentAlgoMode == 0)
+      if (currentAlgoMode.load() == 0)
         tgtComp = wetCompDelay1D;
-      else if (currentAlgoMode == 1)
+      else if (currentAlgoMode.load() == 1)
         tgtComp = wetCompDelay2D;
-      else if (currentAlgoMode == 2)
+      else if (currentAlgoMode.load() == 2)
         tgtComp = lastReportedLatency;
       applyWetCompensationDelay(wetScratchB, tgtComp, numSamples);
       if (sourceGroup != nullptr) {
-        if (switchFromMode == 0)
+        if (switchFromMode.load() == 0)
           specbleach_stereo_load_parameters_1d(sourceGroup, &p, sizeof(p));
         else
           specbleach_stereo_load_parameters_2d(sourceGroup, &p2, sizeof(p2));
@@ -1080,16 +1083,16 @@ void NoiseRepellentAudioProcessor::processBlock(
                   : ((sinkA != nullptr) ? sinkA : buffer.getWritePointer(0));
         specbleach_stereo_process(
             sourceGroup, static_cast<uint32_t>(numSamples), inPtrs, srcOut);
-      } else if (switchFromMode == 2) {
+      } else if (switchFromMode.load() == 2) {
         // 0-latency source passthrough already in buffer (input) - no process
         // needed
       }
       uint32_t srcComp = 0;
-      if (switchFromMode == 0)
+      if (switchFromMode.load() == 0)
         srcComp = wetCompDelay1D;
-      else if (switchFromMode == 1)
+      else if (switchFromMode.load() == 1)
         srcComp = wetCompDelay2D;
-      else if (switchFromMode == 2)
+      else if (switchFromMode.load() == 2)
         srcComp = lastReportedLatency;
       if (srcComp > 0) {
         // srcOut points into buffer for the audible channels, so pad buffer
@@ -1102,7 +1105,7 @@ void NoiseRepellentAudioProcessor::processBlock(
       jassert(wetScratchB.getNumSamples() >= numSamples);
 
       if (sourceGroup != nullptr) {
-        if (switchFromMode == 0)
+        if (switchFromMode.load() == 0)
           specbleach_stereo_load_parameters_1d(sourceGroup, &p, sizeof(p));
         else
           specbleach_stereo_load_parameters_2d(sourceGroup, &p2, sizeof(p2));
@@ -1113,7 +1116,7 @@ void NoiseRepellentAudioProcessor::processBlock(
           srcOut[1] = wetScratchA.getWritePointer(1);
         specbleach_stereo_process(
             sourceGroup, static_cast<uint32_t>(numSamples), inPtrs, srcOut);
-      } else if (switchFromMode == 2) {
+      } else if (switchFromMode.load() == 2) {
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
           float* dst = wetScratchA.getWritePointer(static_cast<int>(ch));
@@ -1123,16 +1126,16 @@ void NoiseRepellentAudioProcessor::processBlock(
       }
       {
         uint32_t srcComp = 0;
-        if (switchFromMode == 0)
+        if (switchFromMode.load() == 0)
           srcComp = wetCompDelay1D;
-        else if (switchFromMode == 1)
+        else if (switchFromMode.load() == 1)
           srcComp = wetCompDelay2D;
-        else if (switchFromMode == 2)
+        else if (switchFromMode.load() == 2)
           srcComp = lastReportedLatency;
         applyWetCompensationDelay(wetScratchA, srcComp, numSamples);
       }
       if (targetGroup != nullptr) {
-        if (currentAlgoMode == 0)
+        if (currentAlgoMode.load() == 0)
           specbleach_stereo_load_parameters_1d(targetGroup, &p, sizeof(p));
         else
           specbleach_stereo_load_parameters_2d(targetGroup, &p2, sizeof(p2));
@@ -1143,7 +1146,7 @@ void NoiseRepellentAudioProcessor::processBlock(
           tgtOut[1] = wetScratchB.getWritePointer(1);
         specbleach_stereo_process(
             targetGroup, static_cast<uint32_t>(numSamples), inPtrs, tgtOut);
-      } else if (currentAlgoMode == 2) {
+      } else if (currentAlgoMode.load() == 2) {
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
           float* dst = wetScratchB.getWritePointer(static_cast<int>(ch));
@@ -1153,19 +1156,19 @@ void NoiseRepellentAudioProcessor::processBlock(
       }
       {
         uint32_t tgtComp = 0;
-        if (currentAlgoMode == 0)
+        if (currentAlgoMode.load() == 0)
           tgtComp = wetCompDelay1D;
-        else if (currentAlgoMode == 1)
+        else if (currentAlgoMode.load() == 1)
           tgtComp = wetCompDelay2D;
-        else if (currentAlgoMode == 2)
+        else if (currentAlgoMode.load() == 2)
           tgtComp = lastReportedLatency;
         applyWetCompensationDelay(wetScratchB, tgtComp, numSamples);
       }
 
       // Equal-power crossfade: t in [0,1], gains = cos(t*pi/2), sin(t*pi/2)
       const float step =
-          1.0f / static_cast<float>(std::max(1, xfadeSamplesTotal));
-      float prog = xfadeProgress;
+          1.0f / static_cast<float>(std::max(1, xfadeSamplesTotal.load()));
+      float prog = xfadeProgress.load();
       for (int chI = 0; chI < numChannels; ++chI) {
         float* dst = buffer.getWritePointer(chI);
         const float* src = wetScratchA.getReadPointer(chI);
@@ -1185,24 +1188,24 @@ void NoiseRepellentAudioProcessor::processBlock(
       }
       // prog is shared across channels — update after first channel loop
       // but keep per-block increment consistent: we advanced by numSamples*step
-      xfadeProgress =
-          std::min(1.0f, prog + step * static_cast<float>(numSamples));
+      xfadeProgress.store(
+          std::min(1.0f, prog + step * static_cast<float>(numSamples)));
     }
 
     // With constant maxReportedLatency, no host PDC handoff is needed.
 
     // Stage advancement
-    stageSamplesRemaining -= numSamples;
-    if (stageSamplesRemaining <= 0) {
-      switch (switchPhase) {
+    stageSamplesRemaining.fetch_sub(numSamples);
+    if (stageSamplesRemaining.load() <= 0) {
+      switch (switchPhase.load()) {
         case SwitchPhase::Warming:
-          switchPhase = SwitchPhase::XFade;
-          stageSamplesRemaining = xfadeSamplesTotal;
-          xfadeProgress = 0.0f;
+          switchPhase.store(SwitchPhase::XFade);
+          stageSamplesRemaining.store(xfadeSamplesTotal.load());
+          xfadeProgress.store(0.0f);
           break;
         case SwitchPhase::XFade:
-          switchPhase = SwitchPhase::Steady;
-          xfadeProgress = 1.0f;
+          switchPhase.store(SwitchPhase::Steady);
+          xfadeProgress.store(1.0f);
           break;
         default:
           break;
@@ -1213,15 +1216,17 @@ void NoiseRepellentAudioProcessor::processBlock(
   // UI progress across Warming+XFade
   {
     float uiP = 1.0f;
-    if (switchPhase != SwitchPhase::Steady) {
-      const float total =
-          static_cast<float>(xfadeSamplesTotal + warmSamplesTotal);
+    if (switchPhase.load() != SwitchPhase::Steady) {
+      const float total = static_cast<float>(xfadeSamplesTotal.load() +
+                                             warmSamplesTotal.load());
       float elapsed = 0.0f;
-      if (switchPhase == SwitchPhase::Warming) {
-        elapsed = static_cast<float>(warmSamplesTotal - stageSamplesRemaining);
-      } else if (switchPhase == SwitchPhase::XFade) {
-        elapsed = static_cast<float>(warmSamplesTotal) +
-                  static_cast<float>(xfadeSamplesTotal - stageSamplesRemaining);
+      if (switchPhase.load() == SwitchPhase::Warming) {
+        elapsed = static_cast<float>(warmSamplesTotal.load() -
+                                     stageSamplesRemaining.load());
+      } else if (switchPhase.load() == SwitchPhase::XFade) {
+        elapsed = static_cast<float>(warmSamplesTotal.load()) +
+                  static_cast<float>(xfadeSamplesTotal.load() -
+                                     stageSamplesRemaining.load());
       }
       uiP = total > 0.0f ? elapsed / total : 1.0f;
     }
@@ -1233,7 +1238,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   // channels; report the TARGET family while a fade is running)
   float reportedTransientIntensity = 0.0f;
   {
-    auto* reportGroup = activeGroupFor(currentAlgoMode);
+    auto* reportGroup = activeGroupFor(currentAlgoMode.load());
     if (reportGroup != nullptr)
       reportedTransientIntensity =
           specbleach_stereo_get_transient_intensity(reportGroup);
@@ -1283,7 +1288,7 @@ void NoiseRepellentAudioProcessor::processBlock(
         // same active-profile logic as the normal FFT path so the line does
         // not jump when playback starts/stops.
         bool profileHasAnyMode = false;
-        if (auto* vizGroup = activeGroupFor(currentAlgoMode)) {
+        if (auto* vizGroup = activeGroupFor(currentAlgoMode.load())) {
           for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
                mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
             if (specbleach_stereo_profile_available_for_channel(vizGroup, 0u,
@@ -1293,12 +1298,12 @@ void NoiseRepellentAudioProcessor::processBlock(
             }
           }
         }
-        if (hasNoiseProfile() && profileHasAnyMode) {
+        if (hasNoiseProfile()) {
           frame.hasNoiseProfile = true;
           const float* actualNoiseProfile = nullptr;
           uint32_t profileSize = 0;
           bool profileAvailable = false;
-          if (auto* vizGroup = activeGroupFor(currentAlgoMode)) {
+          if (auto* vizGroup = activeGroupFor(currentAlgoMode.load())) {
             bool isAdaptive = adaptiveNoise;
             bool isLearning = learnNoise;
             if (isLearning) {
@@ -1308,7 +1313,7 @@ void NoiseRepellentAudioProcessor::processBlock(
               profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
               profileAvailable =
                   (actualNoiseProfile != nullptr && profileSize > 0);
-            } else if (isAdaptive || profileHasAnyMode) {
+            } else if (isAdaptive || true) {
               actualNoiseProfile =
                   specbleach_stereo_get_active_noise_profile_for_channel(
                       vizGroup, 0u);
@@ -1329,6 +1334,39 @@ void NoiseRepellentAudioProcessor::processBlock(
                 }
                 profileAvailable =
                     (actualNoiseProfile != nullptr && profileSize > 0);
+              }
+              // Fallback to other group if vizGroup has no profile yet (e.g.,
+              // just switched 1D->2D while stopped before async migrate)
+              if (!profileAvailable) {
+                auto* otherGroup = (currentAlgoMode.load() == 0)
+                                       ? nlmGroup.get()
+                                       : spectralGroup.get();
+                if (otherGroup != nullptr) {
+                  actualNoiseProfile =
+                      specbleach_stereo_get_active_noise_profile_for_channel(
+                          otherGroup, 0u);
+                  profileSize =
+                      specbleach_stereo_get_noise_profile_size(otherGroup);
+                  profileAvailable =
+                      (actualNoiseProfile != nullptr && profileSize > 0);
+                  if (!profileAvailable) {
+                    for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
+                         mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
+                      if (specbleach_stereo_profile_available_for_channel(
+                              otherGroup, 0u, mode)) {
+                        actualNoiseProfile =
+                            specbleach_stereo_get_noise_profile_for_channel(
+                                otherGroup, 0u, mode);
+                        profileSize = specbleach_stereo_get_noise_profile_size(
+                            otherGroup);
+                        if (actualNoiseProfile != nullptr && profileSize > 0) {
+                          profileAvailable = true;
+                          break;
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -1453,7 +1491,7 @@ void NoiseRepellentAudioProcessor::processBlock(
               profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
               profileAvailable =
                   (actualNoiseProfile != nullptr && profileSize > 0);
-            } else if (isAdaptive || profileHasAnyMode) {
+            } else if (isAdaptive || true) {
               actualNoiseProfile =
                   specbleach_stereo_get_active_noise_profile_for_channel(
                       vizGroup, 0u);
@@ -1613,6 +1651,62 @@ bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {
 }
 
 void NoiseRepellentAudioProcessor::timerCallback() {
+  // Advance engine-switch progress even when transport stopped and
+  // processBlock is not called (host suspended). This fixes the
+  // progress bar staying at 0 when switching while stopped.
+  if (switchPhase.load() != SwitchPhase::Steady) {
+    bool isPlayingForSwitch = false;
+    if (auto* head = getPlayHead()) {
+      if (auto pos = head->getPosition())
+        isPlayingForSwitch = pos->getIsPlaying();
+    }
+    if (!isPlayingForSwitch && currentSampleRate > 0.0) {
+      int samplesPerTick = static_cast<int>(currentSampleRate / 60.0);
+      if (samplesPerTick < 1)
+        samplesPerTick = 1;
+      int remaining = stageSamplesRemaining.load();
+      if (remaining > 0 || switchPhase.load() == SwitchPhase::Warming ||
+          switchPhase.load() == SwitchPhase::XFade) {
+        remaining -= samplesPerTick;
+        if (remaining <= 0) {
+          auto phase = switchPhase.load();
+          if (phase == SwitchPhase::Warming) {
+            switchPhase.store(SwitchPhase::XFade);
+            stageSamplesRemaining.store(xfadeSamplesTotal.load());
+            xfadeProgress.store(0.0f);
+          } else if (phase == SwitchPhase::XFade) {
+            switchPhase.store(SwitchPhase::Steady);
+            stageSamplesRemaining.store(0);
+            xfadeProgress.store(1.0f);
+            uiSwitchProgress.store(1.0f);
+          } else {
+            stageSamplesRemaining.store(0);
+          }
+        } else {
+          stageSamplesRemaining.store(remaining);
+          if (switchPhase.load() == SwitchPhase::XFade) {
+            float total = static_cast<float>(xfadeSamplesTotal.load());
+            float elapsed = total - static_cast<float>(remaining);
+            float prog = total > 0.0f ? elapsed / std::max(1.0f, total) : 1.0f;
+            xfadeProgress.store(std::clamp(prog, 0.0f, 1.0f));
+          }
+          float total = static_cast<float>(warmSamplesTotal.load() +
+                                           xfadeSamplesTotal.load());
+          float elapsed = 0.0f;
+          auto ph = switchPhase.load();
+          if (ph == SwitchPhase::Warming) {
+            elapsed = static_cast<float>(warmSamplesTotal.load() - remaining);
+          } else if (ph == SwitchPhase::XFade) {
+            elapsed = static_cast<float>(warmSamplesTotal.load()) +
+                      static_cast<float>(xfadeSamplesTotal.load() - remaining);
+          }
+          float uiP = total > 0.0f ? elapsed / total : 1.0f;
+          uiSwitchProgress.store(std::clamp(uiP, 0.0f, 1.0f));
+        }
+      }
+    }
+  }
+
   const int pending = pendingLatencyReport.load(std::memory_order_acquire);
   if (pending < 0)
     return;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1300,77 +1300,68 @@ void NoiseRepellentAudioProcessor::processBlock(
         }
         if (hasNoiseProfile()) {
           frame.hasNoiseProfile = true;
-          const float* actualNoiseProfile = nullptr;
+          // Directly compute morphed profile from static learned profiles and
+          // current aggressiveness/threshold so it stays frozen and responsive
+          // even when lib's active noise_spectrum hasn't been updated yet
+          // (e.g., first 1D->2D switch while stopped before next audio block).
+          const float* meanProfile = nullptr;
+          const float* medianProfile = nullptr;
+          const float* stdProfile = nullptr;
+          const float* cvProfile = nullptr;
           uint32_t profileSize = 0;
-          bool profileAvailable = false;
-          if (auto* vizGroup = activeGroupFor(currentAlgoMode.load())) {
-            bool isAdaptive = adaptiveNoise;
-            bool isLearning = learnNoise;
-            if (isLearning) {
-              actualNoiseProfile =
-                  specbleach_stereo_get_noise_profile_for_channel(vizGroup, 0u,
-                                                                  1);
-              profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
-              profileAvailable =
-                  (actualNoiseProfile != nullptr && profileSize > 0);
-            } else if (isAdaptive || true) {
-              actualNoiseProfile =
-                  specbleach_stereo_get_active_noise_profile_for_channel(
-                      vizGroup, 0u);
-              profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
-              profileAvailable =
-                  (actualNoiseProfile != nullptr && profileSize > 0);
-              if (!profileAvailable) {
-                for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
-                     mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
-                  if (specbleach_stereo_profile_available_for_channel(
-                          vizGroup, 0u, mode)) {
-                    actualNoiseProfile =
-                        specbleach_stereo_get_noise_profile_for_channel(
-                            vizGroup, 0u, mode);
-                    if (actualNoiseProfile != nullptr)
-                      break;
-                  }
-                }
-                profileAvailable =
-                    (actualNoiseProfile != nullptr && profileSize > 0);
-              }
-              // Fallback to other group if vizGroup has no profile yet (e.g.,
-              // just switched 1D->2D while stopped before async migrate)
-              if (!profileAvailable) {
-                auto* otherGroup = (currentAlgoMode.load() == 0)
-                                       ? nlmGroup.get()
-                                       : spectralGroup.get();
-                if (otherGroup != nullptr) {
-                  actualNoiseProfile =
-                      specbleach_stereo_get_active_noise_profile_for_channel(
-                          otherGroup, 0u);
-                  profileSize =
-                      specbleach_stereo_get_noise_profile_size(otherGroup);
-                  profileAvailable =
-                      (actualNoiseProfile != nullptr && profileSize > 0);
-                  if (!profileAvailable) {
-                    for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
-                         mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
-                      if (specbleach_stereo_profile_available_for_channel(
-                              otherGroup, 0u, mode)) {
-                        actualNoiseProfile =
-                            specbleach_stereo_get_noise_profile_for_channel(
-                                otherGroup, 0u, mode);
-                        profileSize = specbleach_stereo_get_noise_profile_size(
-                            otherGroup);
-                        if (actualNoiseProfile != nullptr && profileSize > 0) {
-                          profileAvailable = true;
-                          break;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+          bool haveProfiles = false;
+          // Prefer active group's static profiles, fallback to other group
+          auto* srcGroup = activeGroupFor(currentAlgoMode.load());
+          if (srcGroup == nullptr ||
+              !specbleach_stereo_profile_available_for_channel(srcGroup, 0u,
+                                                               1)) {
+            auto* otherGroup = (currentAlgoMode.load() == 0)
+                                   ? nlmGroup.get()
+                                   : spectralGroup.get();
+            if (otherGroup != nullptr &&
+                specbleach_stereo_profile_available_for_channel(otherGroup, 0u,
+                                                                1))
+              srcGroup = otherGroup;
+          }
+          if (srcGroup != nullptr) {
+            profileSize = specbleach_stereo_get_noise_profile_size(srcGroup);
+            if (profileSize > 0) {
+              meanProfile = specbleach_stereo_get_noise_profile_for_channel(
+                  srcGroup, 0u, 1);
+              medianProfile = specbleach_stereo_get_noise_profile_for_channel(
+                  srcGroup, 0u, 2);
+              stdProfile = specbleach_stereo_get_noise_profile_for_channel(
+                  srcGroup, 0u, 3);
+              cvProfile = specbleach_stereo_get_noise_profile_for_channel(
+                  srcGroup, 0u, 4);
+              haveProfiles =
+                  (meanProfile != nullptr && medianProfile != nullptr &&
+                   stdProfile != nullptr && cvProfile != nullptr);
             }
           }
-          if (profileAvailable && actualNoiseProfile != nullptr) {
+          if (haveProfiles) {
+            // Stack morphed profile for resampling (max 2048 bins, profile up
+            // to ~1201)
+            std::array<float, 2048> morphed{};
+            float* morphedPtr = morphed.data();
+            // Replicate get_morphed_profile logic
+            for (uint32_t i = 0; i < profileSize && i < morphed.size(); ++i) {
+              if (aggressiveness < 0.0f) {
+                float t = -aggressiveness;
+                morphedPtr[i] =
+                    (meanProfile[i] * (1.0f - t)) + (medianProfile[i] * t);
+              } else {
+                float t = aggressiveness;
+                morphedPtr[i] = meanProfile[i] + (stdProfile[i] * t * 2.0f);
+              }
+              morphedPtr[i] = std::max(morphedPtr[i], 0.0f);
+              // Apply threshold offsets (broadband + tonal) as in
+              // denoiser_profile_core
+              float scale = profileScale;
+              // For silent display, tonal mask not critical, use broadband only
+              morphedPtr[i] *= scale;
+            }
+            // Resample morphed profile to kFftBins and convert to dB
             size_t realProfileBins = profileSize;
             const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
             const float maxFftIdx = static_cast<float>(kFftBins - 1);
@@ -1385,8 +1376,8 @@ void NoiseRepellentAudioProcessor::processBlock(
                              static_cast<size_t>(0), realProfileBins - 1);
               size_t p1 = std::min(p0 + 1, realProfileBins - 1);
               float frac = exactP - static_cast<float>(p0);
-              float interpVal = (1.0f - frac) * actualNoiseProfile[p0] +
-                                frac * actualNoiseProfile[p1];
+              float interpVal =
+                  (1.0f - frac) * morphedPtr[p0] + frac * morphedPtr[p1];
               float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
               frame.noiseFloorDB[i] = rawDb - dbOffset;
             }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -74,7 +74,8 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
   // Allow future 0-latency engine (mode 2) - keep check generic
   if (newMode < 0 || newMode > 2)
     return;
-  if (newMode == 2 && spectralGroup == nullptr) // 0-latency uses same 1D group for now
+  if (newMode == 2 &&
+      spectralGroup == nullptr) // 0-latency uses same 1D group for now
     return;
 
   // Any increase during playback (1D->2D, 0->high) needs host PDC re-buffer.
@@ -96,11 +97,13 @@ void NoiseRepellentAudioProcessor::handleAsyncUpdate() {
     if (auto pos = head->getPosition())
       isPlaying = pos->getIsPlaying();
   }
-  const bool isIncreaseDuringPlay = isPlaying && (newNative > lastReportedLatency);
+  const bool isIncreaseDuringPlay =
+      isPlaying && (newNative > lastReportedLatency);
 
   if (isIncreaseDuringPlay) {
     // Blunt but safe: host clears buffers and re-buffers at new latency.
-    // Gap is ~1 block, masks NLM cold start, then gapless Warming+XFade at high.
+    // Gap is ~1 block, masks NLM cold start, then gapless Warming+XFade at
+    // high.
     suspendProcessing(true);
     auto* sourceGroup = activeGroupFor(currentAlgoMode);
     auto* targetGroup = activeGroupFor(newMode);
@@ -192,18 +195,18 @@ void NoiseRepellentAudioProcessor::initiateEngineSwitchOnMessageThread(
     }
   }
   const bool shouldDefer = isPlaying && (newNative != lastReportedLatency);
-  uint32_t effectiveReported = shouldDefer
-                                   ? std::max(lastReportedLatency, newNative)
-                                   : newNative;
+  uint32_t effectiveReported =
+      shouldDefer ? std::max(lastReportedLatency, newNative) : newNative;
 
   // Update compensation to pad to effectiveReported
-  wetCompDelay1D = (effectiveReported > latSpectral)
-                       ? (effectiveReported - latSpectral)
-                       : 0;
-  wetCompDelay2D = (effectiveReported > latNLM) ? (effectiveReported - latNLM) : 0;
+  wetCompDelay1D =
+      (effectiveReported > latSpectral) ? (effectiveReported - latSpectral) : 0;
+  wetCompDelay2D =
+      (effectiveReported > latNLM) ? (effectiveReported - latNLM) : 0;
 
   if (shouldDefer) {
-    // Keep old reported, store pending for stop - gapless first 1D->2D and 2D->1D
+    // Keep old reported, store pending for stop - gapless first 1D->2D and
+    // 2D->1D
     pendingLatencyReport.store(static_cast<int>(newNative),
                                std::memory_order_release);
     // Flush target's delay when it needs padding and was stale (2D->1D)
@@ -229,10 +232,8 @@ void NoiseRepellentAudioProcessor::initiateEngineSwitchOnMessageThread(
   switchFromMode = currentAlgoMode;
   currentAlgoMode = newMode;
   switchPhase = SwitchPhase::Warming;
-  warmSamplesTotal =
-      static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0));
-  xfadeSamplesTotal =
-      static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0));
+  warmSamplesTotal = static_cast<int>(currentSampleRate * (kWarmupMs / 1000.0));
+  xfadeSamplesTotal = static_cast<int>(currentSampleRate * (kXFadeMs / 1000.0));
   stageSamplesRemaining = warmSamplesTotal;
   xfadeProgress = 0.0f;
 }
@@ -251,15 +252,15 @@ void NoiseRepellentAudioProcessor::applyWetCompensationDelay(
     if (delaySize == 0)
       continue;
     for (int s = 0; s < numSamples; ++s) {
-      const size_t readPos =
-          (pos + delaySize - compDelay) % delaySize;
+      const size_t readPos = (pos + delaySize - compDelay) % delaySize;
       const float delayed = delayBuf[readPos];
       delayBuf[pos] = data[s];
       data[s] = delayed;
       pos = (pos + 1) % delaySize;
     }
   }
-  // For any extra channels beyond delay buffers (should not happen), leave as is
+  // For any extra channels beyond delay buffers (should not happen), leave as
+  // is
 }
 
 juce::AudioProcessorParameter*
@@ -716,7 +717,8 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
 
   currentLatency = reportedLatency;
   visualizerDelayBuffer.assign(
-      std::max<size_t>(32768, static_cast<size_t>(reportedLatency) + 8192), 0.0f);
+      std::max<size_t>(32768, static_cast<size_t>(reportedLatency) + 8192),
+      0.0f);
   visualizerDelayWritePos = 0;
 
   // Compensation for deferred reporting: pad to lastReportedLatency, not max.
@@ -725,14 +727,16 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   wetCompDelay1D = (lastReportedLatency > latSpectral)
                        ? (lastReportedLatency - latSpectral)
                        : 0;
-  wetCompDelay2D = (lastReportedLatency > latNLM) ? (lastReportedLatency - latNLM) : 0;
-  const uint32_t worstComp =
-      (maxLatency > std::min(latSpectral, latNLM))
-          ? (maxLatency - std::min(latSpectral, latNLM))
-          : 0;
-  const uint32_t allocComp = std::max<uint32_t>(worstComp, std::max(wetCompDelay1D, wetCompDelay2D));
-  wetCompDelayBuffers.assign(preparedNumChannels,
-                             std::vector<float>(allocComp + bufferCapacity, 0.0f));
+  wetCompDelay2D =
+      (lastReportedLatency > latNLM) ? (lastReportedLatency - latNLM) : 0;
+  const uint32_t worstComp = (maxLatency > std::min(latSpectral, latNLM))
+                                 ? (maxLatency - std::min(latSpectral, latNLM))
+                                 : 0;
+  const uint32_t allocComp =
+      std::max<uint32_t>(worstComp, std::max(wetCompDelay1D, wetCompDelay2D));
+  wetCompDelayBuffers.assign(
+      preparedNumChannels,
+      std::vector<float>(allocComp + bufferCapacity, 0.0f));
   wetCompDelayWritePos.assign(preparedNumChannels, 0);
 
   // Pre-allocate persistent buffers to prevent audio-thread allocations
@@ -944,7 +948,11 @@ void NoiseRepellentAudioProcessor::processBlock(
   juce::dsp::AudioBlock<float> audioBlock(buffer);
   dryWetMixer.pushDrySamples(audioBlock);
 
-  if (!switchingNow) {
+  if (isBypassed) {
+    // Bypassed: skip all specbleach STFT+denoise — was culprit for
+    // bypass > denoise CPU. Buffer stays as input, dryWetMixer with 0 wet
+    // outputs dry with correct PDC latency.
+  } else if (!switchingNow) {
     // Steady state: gapless with deferred PDC (lastReported may be high)
     auto* activeGroup = activeGroupFor(currentAlgoMode);
     if (activeGroup != nullptr) {
@@ -1017,15 +1025,15 @@ void NoiseRepellentAudioProcessor::processBlock(
         // Extra channels sink to scratch
         if (procChannels < 2 && wetScratchB.getNumChannels() > 1)
           tgtOut[1] = wetScratchB.getWritePointer(1);
-        specbleach_stereo_process(targetGroup,
-                                  static_cast<uint32_t>(numSamples), inPtrs,
-                                  tgtOut);
+        specbleach_stereo_process(
+            targetGroup, static_cast<uint32_t>(numSamples), inPtrs, tgtOut);
       } else if (currentAlgoMode == 2) {
         // 0-latency passthrough: copy input to scratch for warming
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
           float* dst = wetScratchB.getWritePointer(static_cast<int>(ch));
-          std::memcpy(dst, src, static_cast<size_t>(numSamples) * sizeof(float));
+          std::memcpy(dst, src,
+                      static_cast<size_t>(numSamples) * sizeof(float));
         }
       }
       // Pad to effective (max) for gapless - handles 0-latency (native 0)
@@ -1052,11 +1060,11 @@ void NoiseRepellentAudioProcessor::processBlock(
               (ch < static_cast<uint32_t>(numChannels))
                   ? buffer.getWritePointer(static_cast<int>(ch))
                   : ((sinkA != nullptr) ? sinkA : buffer.getWritePointer(0));
-        specbleach_stereo_process(sourceGroup,
-                                  static_cast<uint32_t>(numSamples), inPtrs,
-                                  srcOut);
+        specbleach_stereo_process(
+            sourceGroup, static_cast<uint32_t>(numSamples), inPtrs, srcOut);
       } else if (switchFromMode == 2) {
-        // 0-latency source passthrough already in buffer (input) - no process needed
+        // 0-latency source passthrough already in buffer (input) - no process
+        // needed
       }
       uint32_t srcComp = 0;
       if (switchFromMode == 0)
@@ -1070,7 +1078,8 @@ void NoiseRepellentAudioProcessor::processBlock(
         applyWetCompensationDelay(buffer, srcComp, numSamples);
       }
     } else { // XFade: both audible, short equal-power crossfade
-      // Ensure scratch buffers are sized for numSamples (prepared in prepareToPlay)
+      // Ensure scratch buffers are sized for numSamples (prepared in
+      // prepareToPlay)
       jassert(wetScratchA.getNumSamples() >= numSamples);
       jassert(wetScratchB.getNumSamples() >= numSamples);
 
@@ -1084,14 +1093,14 @@ void NoiseRepellentAudioProcessor::processBlock(
           srcOut[ch] = wetScratchA.getWritePointer(static_cast<int>(ch));
         if (procChannels < 2 && wetScratchA.getNumChannels() > 1)
           srcOut[1] = wetScratchA.getWritePointer(1);
-        specbleach_stereo_process(sourceGroup,
-                                  static_cast<uint32_t>(numSamples), inPtrs,
-                                  srcOut);
+        specbleach_stereo_process(
+            sourceGroup, static_cast<uint32_t>(numSamples), inPtrs, srcOut);
       } else if (switchFromMode == 2) {
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
           float* dst = wetScratchA.getWritePointer(static_cast<int>(ch));
-          std::memcpy(dst, src, static_cast<size_t>(numSamples) * sizeof(float));
+          std::memcpy(dst, src,
+                      static_cast<size_t>(numSamples) * sizeof(float));
         }
       }
       {
@@ -1114,14 +1123,14 @@ void NoiseRepellentAudioProcessor::processBlock(
           tgtOut[ch] = wetScratchB.getWritePointer(static_cast<int>(ch));
         if (procChannels < 2 && wetScratchB.getNumChannels() > 1)
           tgtOut[1] = wetScratchB.getWritePointer(1);
-        specbleach_stereo_process(targetGroup,
-                                  static_cast<uint32_t>(numSamples), inPtrs,
-                                  tgtOut);
+        specbleach_stereo_process(
+            targetGroup, static_cast<uint32_t>(numSamples), inPtrs, tgtOut);
       } else if (currentAlgoMode == 2) {
         for (uint32_t ch = 0; ch < procChannels; ++ch) {
           const float* src = inPtrs[ch];
           float* dst = wetScratchB.getWritePointer(static_cast<int>(ch));
-          std::memcpy(dst, src, static_cast<size_t>(numSamples) * sizeof(float));
+          std::memcpy(dst, src,
+                      static_cast<size_t>(numSamples) * sizeof(float));
         }
       }
       {
@@ -1148,15 +1157,18 @@ void NoiseRepellentAudioProcessor::processBlock(
           if (localProg < 1.0f) {
             localProg = std::min(1.0f, localProg + step);
           }
-          const float a = std::cos(localProg * juce::MathConstants<float>::halfPi);
-          const float b = std::sin(localProg * juce::MathConstants<float>::halfPi);
+          const float a =
+              std::cos(localProg * juce::MathConstants<float>::halfPi);
+          const float b =
+              std::sin(localProg * juce::MathConstants<float>::halfPi);
           // When target not yet warmed early in switch, fallback to source only
           dst[smp] = src[smp] * a + tgt[smp] * b;
         }
       }
       // prog is shared across channels — update after first channel loop
       // but keep per-block increment consistent: we advanced by numSamples*step
-      xfadeProgress = std::min(1.0f, prog + step * static_cast<float>(numSamples));
+      xfadeProgress =
+          std::min(1.0f, prog + step * static_cast<float>(numSamples));
     }
 
     // With constant maxReportedLatency, no host PDC handoff is needed.
@@ -1490,7 +1502,8 @@ void NoiseRepellentAudioProcessor::timerCallback() {
     return;
   }
 
-  const int staged = pendingLatencyReport.exchange(-1, std::memory_order_acq_rel);
+  const int staged =
+      pendingLatencyReport.exchange(-1, std::memory_order_acq_rel);
   if (staged < 0)
     return;
 
@@ -1507,7 +1520,8 @@ void NoiseRepellentAudioProcessor::timerCallback() {
     wetCompDelay1D = (lastReportedLatency > latSpectral)
                          ? (lastReportedLatency - latSpectral)
                          : 0;
-    wetCompDelay2D = (lastReportedLatency > latNLM) ? (lastReportedLatency - latNLM) : 0;
+    wetCompDelay2D =
+        (lastReportedLatency > latNLM) ? (lastReportedLatency - latNLM) : 0;
   }
 
   setLatencySamples(staged);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -968,10 +968,35 @@ void NoiseRepellentAudioProcessor::processBlock(
   juce::dsp::AudioBlock<float> audioBlock(buffer);
   dryWetMixer.pushDrySamples(audioBlock);
 
-  if (isBypassed || isSilent) {
-    // Bypassed: skip all specbleach STFT+denoise — was culprit for
-    // bypass > denoise CPU. Buffer stays as input, dryWetMixer with 0 wet
-    // outputs dry with correct PDC latency.
+  if (isBypassed) {
+    // Bypassed: skip all specbleach STFT+denoise
+  } else if (isSilent) {
+    // Silent (no playback) and not learning: skip heavy STFT+denoise but
+    // still advance engine-switch phases so the progress bar does not
+    // freeze at 0 when the user changes the engine while stopped.
+    if (switchingNow) {
+      stageSamplesRemaining -= numSamples;
+      if (stageSamplesRemaining <= 0) {
+        switch (switchPhase) {
+          case SwitchPhase::Warming:
+            switchPhase = SwitchPhase::XFade;
+            stageSamplesRemaining = xfadeSamplesTotal;
+            xfadeProgress = 0.0f;
+            break;
+          case SwitchPhase::XFade:
+            switchPhase = SwitchPhase::Steady;
+            xfadeProgress = 1.0f;
+            break;
+          default:
+            break;
+        }
+      } else if (switchPhase == SwitchPhase::XFade) {
+        const float step =
+            1.0f / static_cast<float>(std::max(1, xfadeSamplesTotal));
+        xfadeProgress = std::min(
+            1.0f, xfadeProgress + step * static_cast<float>(numSamples));
+      }
+    }
   } else if (!switchingNow) {
     // Steady state: gapless with deferred PDC (lastReported may be high)
     auto* activeGroup = activeGroupFor(currentAlgoMode);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1393,8 +1393,9 @@ void NoiseRepellentAudioProcessor::processBlock(
               // unlinked, synthesize a simple mask from peaks (first silent
               // switch case)
               std::array<float, 2048> synthMask{};
-              if (tonalActive && tonalMask == nullptr &&
-                  (!frame.isLinked || !frame.isOffsetLinked) && haveProfiles) {
+              if (tonalMask == nullptr &&
+                  (!frame.isLinked || !frame.isOffsetLinked) && haveProfiles &&
+                  tonalProfileScale != 1.0f) {
                 // Try to get peaks from srcGroup/other and build mask
                 auto tryPeaksForMask = [&](auto* grp) -> bool {
                   if (grp == nullptr)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1345,26 +1345,6 @@ void NoiseRepellentAudioProcessor::processBlock(
             std::array<float, 2048> morphed{};
             float* morphedPtr = morphed.data();
             // Replicate get_morphed_profile logic
-            // Fetch tonal mask for per-bin threshold blending (as in
-            // denoiser_profile_core). Use srcGroup's mask, fallback to other.
-            const float* tonalMask = nullptr;
-            bool tonalActive = tonalProfileScale != 1.0f;
-            if (tonalActive) {
-              auto* maskGroup = srcGroup;
-              if (maskGroup != nullptr)
-                tonalMask =
-                    specbleach_stereo_get_tonal_mask_for_channel(maskGroup, 0u);
-              if (tonalMask == nullptr) {
-                auto* other = (currentAlgoMode.load() == 0)
-                                  ? nlmGroup.get()
-                                  : spectralGroup.get();
-                if (other != nullptr && other != maskGroup)
-                  tonalMask =
-                      specbleach_stereo_get_tonal_mask_for_channel(other, 0u);
-              }
-              if (tonalMask == nullptr)
-                tonalActive = false;
-            }
             for (uint32_t i = 0; i < profileSize && i < morphed.size(); ++i) {
               if (aggressiveness < 0.0f) {
                 float t = -aggressiveness;
@@ -1375,14 +1355,100 @@ void NoiseRepellentAudioProcessor::processBlock(
                 morphedPtr[i] = meanProfile[i] + (stdProfile[i] * t * 2.0f);
               }
               morphedPtr[i] = std::max(morphedPtr[i], 0.0f);
-              float scale = profileScale;
-              if (tonalActive && tonalMask != nullptr && tonalMask[i] > 0.0f) {
-                float mask = std::min(tonalMask[i], 1.0f);
-                mask = std::sqrt(std::sqrt(mask));
-                scale =
-                    (profileScale * (1.0f - mask)) + (tonalProfileScale * mask);
+            }
+            // Apply threshold offsets per-bin. When unlinked and silent, the
+            // new 2D engine's tonalMask is still empty (never run), so
+            // broadband only would hide tonal scaling. Build a mask from peaks
+            // instead.
+            {
+              bool tonalActive = tonalProfileScale != 1.0f;
+              const float* tonalMask = nullptr;
+              if (tonalActive) {
+                auto* maskGroup = srcGroup;
+                if (maskGroup != nullptr)
+                  tonalMask = specbleach_stereo_get_tonal_mask_for_channel(
+                      maskGroup, 0u);
+                if (tonalMask == nullptr) {
+                  auto* other = (currentAlgoMode.load() == 0)
+                                    ? nlmGroup.get()
+                                    : spectralGroup.get();
+                  if (other != nullptr && other != maskGroup)
+                    tonalMask =
+                        specbleach_stereo_get_tonal_mask_for_channel(other, 0u);
+                }
+                // If mask is present but all zeros (new engine never ran),
+                // treat as empty
+                if (tonalMask != nullptr) {
+                  float maxMask = 0.0f;
+                  for (uint32_t k = 0; k < profileSize; ++k)
+                    if (tonalMask[k] > maxMask)
+                      maxMask = tonalMask[k];
+                  if (maxMask < 1e-6f)
+                    tonalMask = nullptr;
+                }
+                if (tonalMask == nullptr)
+                  tonalActive = false;
               }
-              morphedPtr[i] *= scale;
+              // If tonal mask still empty but we have peaks and thresholds
+              // unlinked, synthesize a simple mask from peaks (first silent
+              // switch case)
+              std::array<float, 2048> synthMask{};
+              if (tonalActive && tonalMask == nullptr &&
+                  (!frame.isLinked || !frame.isOffsetLinked) && haveProfiles) {
+                // Try to get peaks from srcGroup/other and build mask
+                auto tryPeaksForMask = [&](auto* grp) -> bool {
+                  if (grp == nullptr)
+                    return false;
+                  std::array<float, 32> pb{};
+                  uint32_t n = specbleach_stereo_get_tonal_peaks_for_channel(
+                      grp, 0u, pb.data(), static_cast<uint32_t>(pb.size()));
+                  if (n == 0)
+                    return false;
+                  for (uint32_t pi = 0; pi < n; ++pi) {
+                    // Convert Hz to bin
+                    float freq = pb[pi];
+                    // Use profile's fftSize derived from profileSize
+                    uint32_t fftSize =
+                        profileSize > 1 ? (profileSize - 1) * 2 : 2048;
+                    float bin =
+                        freq * (float)fftSize / (float)currentSampleRate;
+                    int ibin = static_cast<int>(std::round(bin));
+                    for (int d = -2; d <= 2; ++d) {
+                      int b = ibin + d;
+                      if (b >= 0 && (uint32_t)b < profileSize)
+                        synthMask[b] = 1.0f;
+                    }
+                  }
+                  return true;
+                };
+                bool gotMask = false;
+                if (srcGroup != nullptr)
+                  gotMask = tryPeaksForMask(srcGroup);
+                if (!gotMask) {
+                  auto* other = (currentAlgoMode.load() == 0)
+                                    ? nlmGroup.get()
+                                    : spectralGroup.get();
+                  if (other != nullptr)
+                    gotMask = tryPeaksForMask(other);
+                }
+                if (gotMask) {
+                  tonalMask = synthMask.data();
+                  tonalActive = true;
+                } else {
+                  tonalActive = false;
+                }
+              }
+              for (uint32_t i = 0; i < profileSize && i < morphed.size(); ++i) {
+                float scale = profileScale;
+                if (tonalActive && tonalMask != nullptr &&
+                    tonalMask[i] > 0.0f) {
+                  float mask = std::min(tonalMask[i], 1.0f);
+                  mask = std::sqrt(std::sqrt(mask));
+                  scale = (profileScale * (1.0f - mask)) +
+                          (tonalProfileScale * mask);
+                }
+                morphedPtr[i] *= scale;
+              }
             }
             // Resample morphed profile to kFftBins and convert to dB
             size_t realProfileBins = profileSize;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1384,6 +1384,33 @@ void NoiseRepellentAudioProcessor::processBlock(
           } else {
             frame.noiseFloorDB.fill(-120.0f);
           }
+          // Tonal peaks for silent when unlinked
+          if ((!frame.isLinked || !frame.isOffsetLinked) &&
+              frame.hasNoiseProfile) {
+            auto* peakGroup = srcGroup;
+            if (peakGroup == nullptr) {
+              peakGroup = activeGroupFor(currentAlgoMode.load());
+              if (peakGroup == nullptr ||
+                  !specbleach_stereo_profile_available_for_channel(peakGroup,
+                                                                   0u, 1)) {
+                auto* other = (currentAlgoMode.load() == 0)
+                                  ? nlmGroup.get()
+                                  : spectralGroup.get();
+                if (other != nullptr &&
+                    specbleach_stereo_profile_available_for_channel(other, 0u,
+                                                                    1))
+                  peakGroup = other;
+              }
+            }
+            if (peakGroup != nullptr) {
+              std::array<float, 32> peakBuf{};
+              uint32_t numPeaks = specbleach_stereo_get_tonal_peaks_for_channel(
+                  peakGroup, 0u, peakBuf.data(),
+                  static_cast<uint32_t>(peakBuf.size()));
+              for (uint32_t i = 0; i < numPeaks; ++i)
+                frame.tonalPeaksHz.push_back(peakBuf[i]);
+            }
+          }
         } else {
           frame.noiseFloorDB.fill(-120.0f);
           frame.hasNoiseProfile = false;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -970,33 +970,6 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   if (isBypassed) {
     // Bypassed: skip all specbleach STFT+denoise
-  } else if (isSilent) {
-    // Silent (no playback) and not learning: skip heavy STFT+denoise but
-    // still advance engine-switch phases so the progress bar does not
-    // freeze at 0 when the user changes the engine while stopped.
-    if (switchingNow) {
-      stageSamplesRemaining -= numSamples;
-      if (stageSamplesRemaining <= 0) {
-        switch (switchPhase) {
-          case SwitchPhase::Warming:
-            switchPhase = SwitchPhase::XFade;
-            stageSamplesRemaining = xfadeSamplesTotal;
-            xfadeProgress = 0.0f;
-            break;
-          case SwitchPhase::XFade:
-            switchPhase = SwitchPhase::Steady;
-            xfadeProgress = 1.0f;
-            break;
-          default:
-            break;
-        }
-      } else if (switchPhase == SwitchPhase::XFade) {
-        const float step =
-            1.0f / static_cast<float>(std::max(1, xfadeSamplesTotal));
-        xfadeProgress = std::min(
-            1.0f, xfadeProgress + step * static_cast<float>(numSamples));
-      }
-    }
   } else if (!switchingNow) {
     // Steady state: gapless with deferred PDC (lastReported may be high)
     auto* activeGroup = activeGroupFor(currentAlgoMode);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1402,13 +1402,32 @@ void NoiseRepellentAudioProcessor::processBlock(
                   peakGroup = other;
               }
             }
-            if (peakGroup != nullptr) {
+            bool gotPeaks = false;
+            auto tryPeaks = [&](auto* grp) -> bool {
+              if (grp == nullptr)
+                return false;
               std::array<float, 32> peakBuf{};
-              uint32_t numPeaks = specbleach_stereo_get_tonal_peaks_for_channel(
-                  peakGroup, 0u, peakBuf.data(),
+              uint32_t n = specbleach_stereo_get_tonal_peaks_for_channel(
+                  grp, 0u, peakBuf.data(),
                   static_cast<uint32_t>(peakBuf.size()));
-              for (uint32_t i = 0; i < numPeaks; ++i)
+              if (n == 0)
+                return false;
+              for (uint32_t i = 0; i < n; ++i)
                 frame.tonalPeaksHz.push_back(peakBuf[i]);
+              return true;
+            };
+            if (peakGroup != nullptr)
+              gotPeaks = tryPeaks(peakGroup);
+            if (!gotPeaks) {
+              auto* active = activeGroupFor(currentAlgoMode.load());
+              if (active != nullptr && active != peakGroup)
+                gotPeaks = tryPeaks(active);
+            }
+            if (!gotPeaks) {
+              auto* other = (currentAlgoMode.load() == 0) ? nlmGroup.get()
+                                                          : spectralGroup.get();
+              if (other != nullptr && other != peakGroup)
+                tryPeaks(other);
             }
           }
         } else {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -971,8 +971,16 @@ void NoiseRepellentAudioProcessor::processBlock(
   juce::dsp::AudioBlock<float> audioBlock(buffer);
   dryWetMixer.pushDrySamples(audioBlock);
 
-  if (isBypassed) {
-    // Bypassed: skip all specbleach STFT+denoise
+  const bool hasProfile = hasNoiseProfile();
+  const bool canSkipDenoise =
+      isSilent && !hasProfile && !adaptiveNoise && !learnNoise && !switchingNow;
+
+  if (isBypassed || canSkipDenoise) {
+    // Skip specbleach STFT, denoise, and compensation delay when bypassed
+    // or when silent with no noise profile or adaptive estimation active.
+    if (canSkipDenoise) {
+      buffer.clear();
+    }
   } else if (!switchingNow) {
     // Steady state: gapless with deferred PDC (lastReported may be high)
     auto* activeGroup = activeGroupFor(currentAlgoMode.load());
@@ -1356,88 +1364,50 @@ void NoiseRepellentAudioProcessor::processBlock(
               }
               morphedPtr[i] = std::max(morphedPtr[i], 0.0f);
             }
-            // Apply threshold offsets per-bin. When unlinked and silent, the
-            // new 2D engine's tonalMask is still empty (never run), so
-            // broadband only would hide tonal scaling. Build a mask from peaks
-            // instead.
+            // Apply threshold offsets per-bin using exact CV tonal mask
             {
               bool tonalActive = tonalProfileScale != 1.0f;
               const float* tonalMask = nullptr;
               if (tonalActive) {
-                auto* maskGroup = srcGroup;
-                if (maskGroup != nullptr)
-                  tonalMask = specbleach_stereo_get_tonal_mask_for_channel(
-                      maskGroup, 0u);
-                if (tonalMask == nullptr) {
-                  auto* other = (currentAlgoMode.load() == 0)
-                                    ? nlmGroup.get()
-                                    : spectralGroup.get();
-                  if (other != nullptr && other != maskGroup)
-                    tonalMask =
-                        specbleach_stereo_get_tonal_mask_for_channel(other, 0u);
+                // For manual profiles, CV_MASK (cvProfile) is the exact tonal
+                // mask used by libspecbleach denoiser core
+                if (cvProfile != nullptr) {
+                  float maxCv = 0.0f;
+                  for (uint32_t k = 0; k < profileSize; ++k) {
+                    if (cvProfile[k] > maxCv) {
+                      maxCv = cvProfile[k];
+                    }
+                  }
+                  if (maxCv > 1e-6f) {
+                    tonalMask = cvProfile;
+                  }
                 }
-                // If mask is present but all zeros (new engine never ran),
-                // treat as empty
-                if (tonalMask != nullptr) {
-                  float maxMask = 0.0f;
-                  for (uint32_t k = 0; k < profileSize; ++k)
-                    if (tonalMask[k] > maxMask)
-                      maxMask = tonalMask[k];
-                  if (maxMask < 1e-6f)
-                    tonalMask = nullptr;
+                // Fallback to active group's live tonal mask if cvProfile was
+                // empty
+                if (tonalMask == nullptr) {
+                  auto* maskGroup = srcGroup;
+                  if (maskGroup != nullptr)
+                    tonalMask = specbleach_stereo_get_tonal_mask_for_channel(
+                        maskGroup, 0u);
+                  if (tonalMask == nullptr) {
+                    auto* other = (currentAlgoMode.load() == 0)
+                                      ? nlmGroup.get()
+                                      : spectralGroup.get();
+                    if (other != nullptr && other != maskGroup)
+                      tonalMask = specbleach_stereo_get_tonal_mask_for_channel(
+                          other, 0u);
+                  }
+                  if (tonalMask != nullptr) {
+                    float maxMask = 0.0f;
+                    for (uint32_t k = 0; k < profileSize; ++k)
+                      if (tonalMask[k] > maxMask)
+                        maxMask = tonalMask[k];
+                    if (maxMask < 1e-6f)
+                      tonalMask = nullptr;
+                  }
                 }
                 if (tonalMask == nullptr)
                   tonalActive = false;
-              }
-              // If tonal mask still empty but we have peaks and thresholds
-              // unlinked, synthesize a simple mask from peaks (first silent
-              // switch case)
-              std::array<float, 2048> synthMask{};
-              if (tonalMask == nullptr &&
-                  (!frame.isLinked || !frame.isOffsetLinked) && haveProfiles &&
-                  tonalProfileScale != 1.0f) {
-                // Try to get peaks from srcGroup/other and build mask
-                auto tryPeaksForMask = [&](auto* grp) -> bool {
-                  if (grp == nullptr)
-                    return false;
-                  std::array<float, 32> pb{};
-                  uint32_t n = specbleach_stereo_get_tonal_peaks_for_channel(
-                      grp, 0u, pb.data(), static_cast<uint32_t>(pb.size()));
-                  if (n == 0)
-                    return false;
-                  for (uint32_t pi = 0; pi < n; ++pi) {
-                    // Convert Hz to bin
-                    float freq = pb[pi];
-                    // Use profile's fftSize derived from profileSize
-                    uint32_t fftSize =
-                        profileSize > 1 ? (profileSize - 1) * 2 : 2048;
-                    float bin =
-                        freq * (float)fftSize / (float)currentSampleRate;
-                    int ibin = static_cast<int>(std::round(bin));
-                    for (int d = -2; d <= 2; ++d) {
-                      int b = ibin + d;
-                      if (b >= 0 && (uint32_t)b < profileSize)
-                        synthMask[b] = 1.0f;
-                    }
-                  }
-                  return true;
-                };
-                bool gotMask = false;
-                if (srcGroup != nullptr)
-                  gotMask = tryPeaksForMask(srcGroup);
-                if (!gotMask) {
-                  auto* other = (currentAlgoMode.load() == 0)
-                                    ? nlmGroup.get()
-                                    : spectralGroup.get();
-                  if (other != nullptr)
-                    gotMask = tryPeaksForMask(other);
-                }
-                if (gotMask) {
-                  tonalMask = synthMask.data();
-                  tonalActive = true;
-                } else {
-                  tonalActive = false;
-                }
               }
               for (uint32_t i = 0; i < profileSize && i < morphed.size(); ++i) {
                 float scale = profileScale;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1250,11 +1250,51 @@ void NoiseRepellentAudioProcessor::processBlock(
   dryWetMixer.setWetMixProportion(isBypassed ? 0.0f : 1.0f);
   dryWetMixer.mixWetSamples(audioBlock);
 
-  // Skip FFT analysis and FIFO writes during offline rendering, if the GUI is
-  // closed, or when input is silent and not learning (saves ~4096 FFT per
-  // 1024 samples when no playback).
-  if (isNonRealtime() || getActiveEditor() == nullptr || isSilent) {
+  // Skip FFT analysis and FIFO writes during offline rendering or if the GUI
+  // is closed
+  if (isNonRealtime() || getActiveEditor() == nullptr) {
     fftAccumCount = 0;
+    return;
+  }
+
+  // When input is silent and not learning, skip heavy 4096 FFT but push a
+  // cheap silent frame so the display falls to -120 dB instead of freezing
+  // on the last non-silent spectrum.
+  if (isSilent) {
+    fftAccumCount = 0;
+    if ((++silenceVisualCounter % 4) == 0) {
+      int start1, size1, start2, size2;
+      spectralFifo.prepareToWrite(1, start1, size1, start2, size2);
+      if (size1 > 0) {
+        SpectralFrame& frame = spectralBuffer[static_cast<size_t>(start1)];
+        frame.inputMagnitudeDB.fill(-120.0f);
+        frame.outputMagnitudeDB.fill(-120.0f);
+        frame.noiseFloorDB.fill(-120.0f);
+        frame.hasNoiseProfile = false;
+        frame.isLinked =
+            (parameters.getRawParameterValue("link_reduction")->load() > 0.5f);
+        frame.isOffsetLinked =
+            (parameters.getRawParameterValue("link_threshold_offset")->load() >
+             0.5f);
+        frame.reductionCurveEnabled =
+            (parameters.getRawParameterValue("reduction_curve_enabled")
+                 ->load() > 0.5f);
+        frame.transientIntensity = 0.0f;
+        frame.isTransientProtected = false;
+        frame.isTransientProtectionActive = transientProtectionEnable;
+        frame.tonalPeaksHz.clear();
+        // Keep noise floor visible if a profile was learned: show it even
+        // when input is silent so the user still sees the captured curve
+        // falling behind the now -120 dB input/output.
+        if (hasNoiseProfile()) {
+          // Reuse last learned profile for noiseFloor display (optional)
+          // For now keep -120 to make all three fall; comment to keep profile:
+          // (visualizer will show -120 input/output vs -xx noiseFloor if
+          // hasNoiseProfile true, tonal peaks still cleared)
+        }
+        spectralFifo.finishedWrite(1);
+      }
+    }
     return;
   }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1281,37 +1281,57 @@ void NoiseRepellentAudioProcessor::processBlock(
         frame.isTransientProtected = false;
         frame.isTransientProtectionActive = transientProtectionEnable;
         frame.tonalPeaksHz.clear();
-        // Keep learned noise profile frozen while input/output fall
-        if (hasNoiseProfile()) {
+        // Keep learned noise profile frozen while input/output fall — use
+        // same active-profile logic as the normal FFT path so the line does
+        // not jump when playback starts/stops.
+        bool profileHasAnyMode = false;
+        if (auto* vizGroup = activeGroupFor(currentAlgoMode)) {
+          for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
+               mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
+            if (specbleach_stereo_profile_available_for_channel(vizGroup, 0u,
+                                                                mode)) {
+              profileHasAnyMode = true;
+              break;
+            }
+          }
+        }
+        if (hasNoiseProfile() && profileHasAnyMode) {
           frame.hasNoiseProfile = true;
-          // Fill noiseFloor from learned profile (cheap vs 4096 FFT)
           const float* actualNoiseProfile = nullptr;
           uint32_t profileSize = 0;
           bool profileAvailable = false;
           if (auto* vizGroup = activeGroupFor(currentAlgoMode)) {
-            // Prefer any learned static profile for frozen display
-            for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
-                 mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
-              if (specbleach_stereo_profile_available_for_channel(vizGroup, 0u,
-                                                                  mode)) {
-                actualNoiseProfile =
-                    specbleach_stereo_get_noise_profile_for_channel(vizGroup,
-                                                                    0u, mode);
-                profileSize =
-                    specbleach_stereo_get_noise_profile_size(vizGroup);
-                if (actualNoiseProfile != nullptr && profileSize > 0) {
-                  profileAvailable = true;
-                  break;
-                }
-              }
-            }
-            if (!profileAvailable) {
+            bool isAdaptive = adaptiveNoise;
+            bool isLearning = learnNoise;
+            if (isLearning) {
+              actualNoiseProfile =
+                  specbleach_stereo_get_noise_profile_for_channel(vizGroup, 0u,
+                                                                  1);
+              profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
+              profileAvailable =
+                  (actualNoiseProfile != nullptr && profileSize > 0);
+            } else if (isAdaptive || profileHasAnyMode) {
               actualNoiseProfile =
                   specbleach_stereo_get_active_noise_profile_for_channel(
                       vizGroup, 0u);
               profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
               profileAvailable =
                   (actualNoiseProfile != nullptr && profileSize > 0);
+              if (!profileAvailable) {
+                for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
+                     mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
+                  if (specbleach_stereo_profile_available_for_channel(
+                          vizGroup, 0u, mode)) {
+                    actualNoiseProfile =
+                        specbleach_stereo_get_noise_profile_for_channel(
+                            vizGroup, 0u, mode);
+                    if (actualNoiseProfile != nullptr)
+                      break;
+                  }
+                }
+                profileAvailable =
+                    (actualNoiseProfile != nullptr && profileSize > 0);
+              }
             }
           }
           if (profileAvailable && actualNoiseProfile != nullptr) {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1345,6 +1345,26 @@ void NoiseRepellentAudioProcessor::processBlock(
             std::array<float, 2048> morphed{};
             float* morphedPtr = morphed.data();
             // Replicate get_morphed_profile logic
+            // Fetch tonal mask for per-bin threshold blending (as in
+            // denoiser_profile_core). Use srcGroup's mask, fallback to other.
+            const float* tonalMask = nullptr;
+            bool tonalActive = tonalProfileScale != 1.0f;
+            if (tonalActive) {
+              auto* maskGroup = srcGroup;
+              if (maskGroup != nullptr)
+                tonalMask =
+                    specbleach_stereo_get_tonal_mask_for_channel(maskGroup, 0u);
+              if (tonalMask == nullptr) {
+                auto* other = (currentAlgoMode.load() == 0)
+                                  ? nlmGroup.get()
+                                  : spectralGroup.get();
+                if (other != nullptr && other != maskGroup)
+                  tonalMask =
+                      specbleach_stereo_get_tonal_mask_for_channel(other, 0u);
+              }
+              if (tonalMask == nullptr)
+                tonalActive = false;
+            }
             for (uint32_t i = 0; i < profileSize && i < morphed.size(); ++i) {
               if (aggressiveness < 0.0f) {
                 float t = -aggressiveness;
@@ -1355,10 +1375,13 @@ void NoiseRepellentAudioProcessor::processBlock(
                 morphedPtr[i] = meanProfile[i] + (stdProfile[i] * t * 2.0f);
               }
               morphedPtr[i] = std::max(morphedPtr[i], 0.0f);
-              // Apply threshold offsets (broadband + tonal) as in
-              // denoiser_profile_core
               float scale = profileScale;
-              // For silent display, tonal mask not critical, use broadband only
+              if (tonalActive && tonalMask != nullptr && tonalMask[i] > 0.0f) {
+                float mask = std::min(tonalMask[i], 1.0f);
+                mask = std::sqrt(std::sqrt(mask));
+                scale =
+                    (profileScale * (1.0f - mask)) + (tonalProfileScale * mask);
+              }
               morphedPtr[i] *= scale;
             }
             // Resample morphed profile to kFftBins and convert to dB

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -938,6 +938,26 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   const bool switchingNow = (switchPhase != SwitchPhase::Steady);
 
+  // Silence detection: when input is ~-100dB and not learning, skip heavy
+  // STFT+denoise (was culprit for idle > denoising and no-playback CPU).
+  bool isSilent = false;
+  if (!learnNoise) {
+    const float thresh = 1e-5f;
+    isSilent = true;
+    for (int ch = 0; ch < numChannels && isSilent; ++ch) {
+      const float* d = buffer.getReadPointer(ch);
+      for (int i = 0; i < numSamples; ++i) {
+        if (std::abs(d[i]) > thresh) {
+          isSilent = false;
+          break;
+        }
+      }
+    }
+    // Keep adaptive tracking alive when enabled — don't gate it as silent
+    if (adaptiveNoise)
+      isSilent = false;
+  }
+
   // Save dry input copy for FFT visualization before processing
   const size_t copySamples =
       std::min(static_cast<size_t>(numSamples), dryInputL.size());
@@ -948,7 +968,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   juce::dsp::AudioBlock<float> audioBlock(buffer);
   dryWetMixer.pushDrySamples(audioBlock);
 
-  if (isBypassed) {
+  if (isBypassed || isSilent) {
     // Bypassed: skip all specbleach STFT+denoise — was culprit for
     // bypass > denoise CPU. Buffer stays as input, dryWetMixer with 0 wet
     // outputs dry with correct PDC latency.
@@ -1230,9 +1250,10 @@ void NoiseRepellentAudioProcessor::processBlock(
   dryWetMixer.setWetMixProportion(isBypassed ? 0.0f : 1.0f);
   dryWetMixer.mixWetSamples(audioBlock);
 
-  // Skip FFT analysis and FIFO writes during offline rendering or if the GUI is
-  // closed
-  if (isNonRealtime() || getActiveEditor() == nullptr) {
+  // Skip FFT analysis and FIFO writes during offline rendering, if the GUI is
+  // closed, or when input is silent and not learning (saves ~4096 FFT per
+  // 1024 samples when no playback).
+  if (isNonRealtime() || getActiveEditor() == nullptr || isSilent) {
     fftAccumCount = 0;
     return;
   }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1258,8 +1258,8 @@ void NoiseRepellentAudioProcessor::processBlock(
   }
 
   // When input is silent and not learning, skip heavy 4096 FFT but push a
-  // cheap silent frame so the display falls to -120 dB instead of freezing
-  // on the last non-silent spectrum.
+  // cheap silent frame so input/output fall to -120 dB while the learned
+  // noise profile stays frozen (only reset clears it).
   if (isSilent) {
     fftAccumCount = 0;
     if ((++silenceVisualCounter % 4) == 0) {
@@ -1269,8 +1269,6 @@ void NoiseRepellentAudioProcessor::processBlock(
         SpectralFrame& frame = spectralBuffer[static_cast<size_t>(start1)];
         frame.inputMagnitudeDB.fill(-120.0f);
         frame.outputMagnitudeDB.fill(-120.0f);
-        frame.noiseFloorDB.fill(-120.0f);
-        frame.hasNoiseProfile = false;
         frame.isLinked =
             (parameters.getRawParameterValue("link_reduction")->load() > 0.5f);
         frame.isOffsetLinked =
@@ -1283,14 +1281,65 @@ void NoiseRepellentAudioProcessor::processBlock(
         frame.isTransientProtected = false;
         frame.isTransientProtectionActive = transientProtectionEnable;
         frame.tonalPeaksHz.clear();
-        // Keep noise floor visible if a profile was learned: show it even
-        // when input is silent so the user still sees the captured curve
-        // falling behind the now -120 dB input/output.
+        // Keep learned noise profile frozen while input/output fall
         if (hasNoiseProfile()) {
-          // Reuse last learned profile for noiseFloor display (optional)
-          // For now keep -120 to make all three fall; comment to keep profile:
-          // (visualizer will show -120 input/output vs -xx noiseFloor if
-          // hasNoiseProfile true, tonal peaks still cleared)
+          frame.hasNoiseProfile = true;
+          // Fill noiseFloor from learned profile (cheap vs 4096 FFT)
+          const float* actualNoiseProfile = nullptr;
+          uint32_t profileSize = 0;
+          bool profileAvailable = false;
+          if (auto* vizGroup = activeGroupFor(currentAlgoMode)) {
+            // Prefer any learned static profile for frozen display
+            for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
+                 mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
+              if (specbleach_stereo_profile_available_for_channel(vizGroup, 0u,
+                                                                  mode)) {
+                actualNoiseProfile =
+                    specbleach_stereo_get_noise_profile_for_channel(vizGroup,
+                                                                    0u, mode);
+                profileSize =
+                    specbleach_stereo_get_noise_profile_size(vizGroup);
+                if (actualNoiseProfile != nullptr && profileSize > 0) {
+                  profileAvailable = true;
+                  break;
+                }
+              }
+            }
+            if (!profileAvailable) {
+              actualNoiseProfile =
+                  specbleach_stereo_get_active_noise_profile_for_channel(
+                      vizGroup, 0u);
+              profileSize = specbleach_stereo_get_noise_profile_size(vizGroup);
+              profileAvailable =
+                  (actualNoiseProfile != nullptr && profileSize > 0);
+            }
+          }
+          if (profileAvailable && actualNoiseProfile != nullptr) {
+            size_t realProfileBins = profileSize;
+            const float maxProfileIdx = static_cast<float>(realProfileBins - 1);
+            const float maxFftIdx = static_cast<float>(kFftBins - 1);
+            const float dbOffset = (maxProfileIdx > 0.0f)
+                                       ? (20.0f * std::log10(maxProfileIdx))
+                                       : 0.0f;
+            for (size_t i = 0; i < kFftBins; ++i) {
+              float normPos = static_cast<float>(i) / maxFftIdx;
+              float exactP = normPos * maxProfileIdx;
+              size_t p0 =
+                  std::clamp(static_cast<size_t>(exactP),
+                             static_cast<size_t>(0), realProfileBins - 1);
+              size_t p1 = std::min(p0 + 1, realProfileBins - 1);
+              float frac = exactP - static_cast<float>(p0);
+              float interpVal = (1.0f - frac) * actualNoiseProfile[p0] +
+                                frac * actualNoiseProfile[p1];
+              float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
+              frame.noiseFloorDB[i] = rawDb - dbOffset;
+            }
+          } else {
+            frame.noiseFloorDB.fill(-120.0f);
+          }
+        } else {
+          frame.noiseFloorDB.fill(-120.0f);
+          frame.hasNoiseProfile = false;
         }
         spectralFifo.finishedWrite(1);
       }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -179,16 +179,18 @@ private:
   // splice is deferred until after the crossfade. Previous
   // FadeOut/WarmSilent/FadeIn with mute is replaced to avoid audible gap.
   enum class SwitchPhase { Steady, Warming, XFade };
-  SwitchPhase switchPhase = SwitchPhase::Steady;
-  int switchFromMode = 0; // family heard during Warming
-  int stageSamplesRemaining = 0;
-  int warmSamplesTotal = 0;
-  int xfadeSamplesTotal = 0;
+  std::atomic<SwitchPhase> switchPhase{SwitchPhase::Steady};
+  std::atomic<int> switchFromMode{0}; // family heard during Warming
+  std::atomic<int> stageSamplesRemaining{0};
+  std::atomic<int> warmSamplesTotal{0};
+  std::atomic<int> xfadeSamplesTotal{0};
   static constexpr int kWarmupMs = 700; // >= NLM 64-frame history depth
   static constexpr int kXFadeMs = 30;   // short gapless crossfade
   // Host PDC splice deferred until transport stopped (!isPlaying) for gapless
   // A/B - effective during Warming+XFade is max(old,new) via wetCompDelay.
-  float xfadeProgress = 0.0f;
+  std::atomic<float> xfadeProgress{0.0f};
+  double switchStartTimeSeconds = 0.0;
+  double switchTotalDurationSeconds = 0.0;
 
   // GUI feedback (progress 1 == idle)
   std::atomic<float> uiSwitchProgress{1.0f};
@@ -216,7 +218,7 @@ private:
   juce::dsp::DryWetMixer<float> dryWetMixer;
 
   double currentSampleRate = 44100.0;
-  int currentAlgoMode = 1; // Track for dynamic latency updates
+  std::atomic<int> currentAlgoMode{1}; // Track for dynamic latency updates
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> transientProtectionActive{false};
   bool wasLearning =

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -28,10 +28,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "specbleach.hpp" // self-guarding for C++; do NOT wrap in extern "C"
 #include "specbleach_version.h"
 
-class NoiseRepellentAudioProcessor : public juce::AudioProcessor,
-                                     private juce::Timer,
-                                     private juce::AudioProcessorValueTreeState::Listener,
-                                     private juce::AsyncUpdater {
+class NoiseRepellentAudioProcessor
+    : public juce::AudioProcessor,
+      private juce::Timer,
+      private juce::AudioProcessorValueTreeState::Listener,
+      private juce::AsyncUpdater {
 public:
   NoiseRepellentAudioProcessor();
   ~NoiseRepellentAudioProcessor() override;
@@ -183,8 +184,8 @@ private:
   int stageSamplesRemaining = 0;
   int warmSamplesTotal = 0;
   int xfadeSamplesTotal = 0;
-  static constexpr int kWarmupMs = 700;   // >= NLM 64-frame history depth
-  static constexpr int kXFadeMs = 30;     // short gapless crossfade
+  static constexpr int kWarmupMs = 700; // >= NLM 64-frame history depth
+  static constexpr int kXFadeMs = 30;   // short gapless crossfade
   // Host PDC splice deferred until transport stopped (!isPlaying) for gapless
   // A/B - effective during Warming+XFade is max(old,new) via wetCompDelay.
   float xfadeProgress = 0.0f;
@@ -263,12 +264,14 @@ private:
   std::array<float, kFftSize> fftAccumOutput{};
   std::array<float, kFftSize> fftAccumTransient{};
   size_t fftAccumCount = 0;
+  uint32_t silenceVisualCounter = 0;
 
   // Latency-compensated delay line for input FFT visualization
   std::vector<float> visualizerDelayBuffer;
   size_t visualizerDelayWritePos = 0;
   uint32_t currentLatency = 0;
-  uint32_t lastReportedLatency = 0; // variable, deferred until transport stop (gapless compare)
+  uint32_t lastReportedLatency =
+      0; // variable, deferred until transport stop (gapless compare)
 
   // Internal wet delay to pad to lastReportedLatency when engine switch is
   // deferred (e.g. 2D->1D high->low while playing). Reported stays high,

--- a/Source/Tests/test_performance.cpp
+++ b/Source/Tests/test_performance.cpp
@@ -1,0 +1,258 @@
+/*
+noise-repellent -- Noise Reduction JUCE Plugin
+
+Copyright 2026 Luciano Dato <lucianodato@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <chrono>
+#include <random>
+
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "PluginProcessor.h"
+
+namespace {
+
+void pumpMessageLoop(int maxMillis = 50) {
+  if (auto* mm = juce::MessageManager::getInstanceWithoutCreating()) {
+    mm->runDispatchLoopUntil(maxMillis);
+  }
+}
+
+void generateNoiseBuffer(juce::AudioBuffer<float>& buffer, float rms = 0.05f) {
+  std::mt19937 gen(1337);
+  std::normal_distribution<float> dist(0.0f, rms);
+  for (int ch = 0; ch < buffer.getNumChannels(); ++ch) {
+    auto* channelData = buffer.getWritePointer(ch);
+    for (int s = 0; s < buffer.getNumSamples(); ++s) {
+      channelData[s] = dist(gen);
+    }
+  }
+}
+
+void setParam(NoiseRepellentAudioProcessor& proc, const juce::String& paramId,
+              float value) {
+  if (auto* param = proc.getAPVTS().getParameter(paramId)) {
+    param->setValueNotifyingHost(param->convertTo0to1(value));
+  }
+  pumpMessageLoop(5);
+}
+
+} // namespace
+
+class PerformanceRatioTest : public juce::UnitTest {
+public:
+  PerformanceRatioTest()
+      : juce::UnitTest("Performance Ratio Tests", "NoiseRepellent") {
+  }
+
+  void runTest() override {
+    beginTest("Silent Idle vs Active Denoising Throughput Ratio");
+    testSilentIdleThroughputRatio();
+
+    beginTest("Bypass vs Active Denoising Throughput Ratio");
+    testBypassThroughputRatio();
+  }
+
+private:
+  void testSilentIdleThroughputRatio() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    constexpr int numBlocks = 600;
+
+    // 1. Measure active denoising duration
+    int64_t activeDurationUs = 0;
+    {
+      NoiseRepellentAudioProcessor proc;
+      proc.prepareToPlay(sampleRate, blockSize);
+      pumpMessageLoop(20);
+
+      juce::AudioBuffer<float> buffer(2, blockSize);
+      juce::MidiBuffer midi;
+
+      // Learn profile
+      setParam(proc, "learn_noise", 1.0f);
+      for (int i = 0; i < 50; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+      setParam(proc, "learn_noise", 0.0f);
+      pumpMessageLoop(20);
+
+      // Warmup
+      for (int i = 0; i < 50; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+
+      // Timed active processing
+      auto start = std::chrono::high_resolution_clock::now();
+      for (int i = 0; i < numBlocks; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      activeDurationUs =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+              .count();
+
+      proc.releaseResources();
+    }
+
+    // 2. Measure silent idle duration (no profile, silent input)
+    int64_t silentDurationUs = 0;
+    {
+      NoiseRepellentAudioProcessor proc;
+      proc.prepareToPlay(sampleRate, blockSize);
+      pumpMessageLoop(20);
+
+      juce::AudioBuffer<float> buffer(2, blockSize);
+      juce::MidiBuffer midi;
+
+      // Warmup
+      for (int i = 0; i < 50; ++i) {
+        buffer.clear();
+        proc.processBlock(buffer, midi);
+      }
+
+      // Timed silent processing
+      auto start = std::chrono::high_resolution_clock::now();
+      for (int i = 0; i < numBlocks; ++i) {
+        buffer.clear();
+        proc.processBlock(buffer, midi);
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      silentDurationUs =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+              .count();
+
+      proc.releaseResources();
+    }
+
+    expect(silentDurationUs > 0, "Silent duration must be greater than zero");
+    expect(activeDurationUs > 0, "Active duration must be greater than zero");
+
+    const double speedupRatio =
+        static_cast<double>(activeDurationUs) /
+        static_cast<double>(std::max<int64_t>(1, silentDurationUs));
+
+    expect(speedupRatio >= 2.5,
+           "Silent idle processing must be at least 2.5x faster than active "
+           "denoising");
+  }
+
+  void testBypassThroughputRatio() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    constexpr int numBlocks = 600;
+
+    int64_t activeDurationUs = 0;
+    {
+      NoiseRepellentAudioProcessor proc;
+      proc.prepareToPlay(sampleRate, blockSize);
+      pumpMessageLoop(20);
+
+      juce::AudioBuffer<float> buffer(2, blockSize);
+      juce::MidiBuffer midi;
+
+      setParam(proc, "learn_noise", 1.0f);
+      for (int i = 0; i < 50; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+      setParam(proc, "learn_noise", 0.0f);
+      pumpMessageLoop(20);
+
+      for (int i = 0; i < 50; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+
+      auto start = std::chrono::high_resolution_clock::now();
+      for (int i = 0; i < numBlocks; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      activeDurationUs =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+              .count();
+
+      proc.releaseResources();
+    }
+
+    int64_t bypassDurationUs = 0;
+    {
+      NoiseRepellentAudioProcessor proc;
+      proc.prepareToPlay(sampleRate, blockSize);
+      pumpMessageLoop(20);
+
+      juce::AudioBuffer<float> buffer(2, blockSize);
+      juce::MidiBuffer midi;
+
+      setParam(proc, "bypass", 1.0f);
+      pumpMessageLoop(20);
+
+      for (int i = 0; i < 50; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+
+      auto start = std::chrono::high_resolution_clock::now();
+      for (int i = 0; i < numBlocks; ++i) {
+        generateNoiseBuffer(buffer, 0.05f);
+        proc.processBlock(buffer, midi);
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      bypassDurationUs =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+              .count();
+
+      proc.releaseResources();
+    }
+
+    expect(bypassDurationUs > 0, "Bypass duration must be greater than zero");
+    expect(activeDurationUs > 0, "Active duration must be greater than zero");
+
+    const double speedupRatio =
+        static_cast<double>(activeDurationUs) /
+        static_cast<double>(std::max<int64_t>(1, bypassDurationUs));
+
+    expect(speedupRatio >= 2.5,
+           "Bypassed processing must be at least 2.5x faster than active "
+           "denoising");
+  }
+};
+
+static PerformanceRatioTest performanceRatioTest;
+
+int main(int argc, char* argv[]) {
+  juce::ScopedJuceInitialiser_GUI guiInit;
+
+  juce::UnitTestRunner runner;
+  runner.setAssertOnFailure(false);
+  runner.runAllTests();
+
+  int numFailed = 0;
+  for (int i = 0; i < runner.getNumResults(); ++i) {
+    if (const auto* r = runner.getResult(i)) {
+      numFailed += r->failures;
+    }
+  }
+  return numFailed > 0 ? 1 : 0;
+}

--- a/Source/Tests/test_performance.cpp
+++ b/Source/Tests/test_performance.cpp
@@ -34,15 +34,25 @@ void pumpMessageLoop(int maxMillis = 50) {
   }
 }
 
-void generateNoiseBuffer(juce::AudioBuffer<float>& buffer, float rms = 0.05f) {
+std::vector<juce::AudioBuffer<float>> createNoiseBlocks(int numBlocks,
+                                                        int numChannels,
+                                                        int blockSize,
+                                                        float rms = 0.05f) {
+  std::vector<juce::AudioBuffer<float>> blocks;
+  blocks.reserve(numBlocks);
   std::mt19937 gen(1337);
   std::normal_distribution<float> dist(0.0f, rms);
-  for (int ch = 0; ch < buffer.getNumChannels(); ++ch) {
-    auto* channelData = buffer.getWritePointer(ch);
-    for (int s = 0; s < buffer.getNumSamples(); ++s) {
-      channelData[s] = dist(gen);
+  for (int b = 0; b < numBlocks; ++b) {
+    juce::AudioBuffer<float> buf(numChannels, blockSize);
+    for (int ch = 0; ch < numChannels; ++ch) {
+      auto* data = buf.getWritePointer(ch);
+      for (int s = 0; s < blockSize; ++s) {
+        data[s] = dist(gen);
+      }
     }
+    blocks.push_back(std::move(buf));
   }
+  return blocks;
 }
 
 void setParam(NoiseRepellentAudioProcessor& proc, const juce::String& paramId,
@@ -75,6 +85,8 @@ private:
     constexpr int blockSize = 512;
     constexpr int numBlocks = 600;
 
+    const auto noiseBlocks = createNoiseBlocks(numBlocks, 2, blockSize, 0.05f);
+
     // 1. Measure active denoising duration
     int64_t activeDurationUs = 0;
     {
@@ -88,7 +100,7 @@ private:
       // Learn profile
       setParam(proc, "learn_noise", 1.0f);
       for (int i = 0; i < 50; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
         proc.processBlock(buffer, midi);
       }
       setParam(proc, "learn_noise", 0.0f);
@@ -96,14 +108,14 @@ private:
 
       // Warmup
       for (int i = 0; i < 50; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
         proc.processBlock(buffer, midi);
       }
 
       // Timed active processing
       auto start = std::chrono::high_resolution_clock::now();
       for (int i = 0; i < numBlocks; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i]);
         proc.processBlock(buffer, midi);
       }
       auto end = std::chrono::high_resolution_clock::now();
@@ -161,6 +173,8 @@ private:
     constexpr int blockSize = 512;
     constexpr int numBlocks = 600;
 
+    const auto noiseBlocks = createNoiseBlocks(numBlocks, 2, blockSize, 0.05f);
+
     int64_t activeDurationUs = 0;
     {
       NoiseRepellentAudioProcessor proc;
@@ -172,20 +186,20 @@ private:
 
       setParam(proc, "learn_noise", 1.0f);
       for (int i = 0; i < 50; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
         proc.processBlock(buffer, midi);
       }
       setParam(proc, "learn_noise", 0.0f);
       pumpMessageLoop(20);
 
       for (int i = 0; i < 50; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
         proc.processBlock(buffer, midi);
       }
 
       auto start = std::chrono::high_resolution_clock::now();
       for (int i = 0; i < numBlocks; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i]);
         proc.processBlock(buffer, midi);
       }
       auto end = std::chrono::high_resolution_clock::now();
@@ -209,13 +223,13 @@ private:
       pumpMessageLoop(20);
 
       for (int i = 0; i < 50; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
         proc.processBlock(buffer, midi);
       }
 
       auto start = std::chrono::high_resolution_clock::now();
       for (int i = 0; i < numBlocks; ++i) {
-        generateNoiseBuffer(buffer, 0.05f);
+        buffer.makeCopyOf(noiseBlocks[i]);
         proc.processBlock(buffer, midi);
       }
       auto end = std::chrono::high_resolution_clock::now();

--- a/Source/Tests/test_ux_invariants.cpp
+++ b/Source/Tests/test_ux_invariants.cpp
@@ -1,0 +1,439 @@
+/*
+noise-repellent -- Noise Reduction JUCE Plugin
+
+Copyright 2026 Luciano Dato <lucianodato@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <cmath>
+#include <numeric>
+#include <random>
+
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "PluginProcessor.h"
+
+namespace {
+
+void pumpMessageLoop(int maxMillis = 50) {
+  if (auto* mm = juce::MessageManager::getInstanceWithoutCreating()) {
+    mm->runDispatchLoopUntil(maxMillis);
+  }
+}
+
+void generateNoiseBuffer(juce::AudioBuffer<float>& buffer, float rms = 0.05f) {
+  std::mt19937 gen(1337);
+  std::normal_distribution<float> dist(0.0f, rms);
+  for (int ch = 0; ch < buffer.getNumChannels(); ++ch) {
+    auto* channelData = buffer.getWritePointer(ch);
+    for (int s = 0; s < buffer.getNumSamples(); ++s) {
+      channelData[s] = dist(gen);
+    }
+  }
+}
+
+void setParam(NoiseRepellentAudioProcessor& proc, const juce::String& paramId,
+              float value) {
+  if (auto* param = proc.getAPVTS().getParameter(paramId)) {
+    param->setValueNotifyingHost(param->convertTo0to1(value));
+  }
+  pumpMessageLoop(5);
+}
+
+struct ScopedEditor {
+  NoiseRepellentAudioProcessor& proc;
+  juce::AudioProcessorEditor* editor = nullptr;
+  explicit ScopedEditor(NoiseRepellentAudioProcessor& p)
+      : proc(p), editor(p.createEditorIfNeeded()) {
+  }
+  ~ScopedEditor() {
+    if (editor != nullptr) {
+      proc.editorBeingDeleted(editor);
+      delete editor;
+    }
+  }
+};
+
+bool pullLatestFrame(NoiseRepellentAudioProcessor& proc,
+                     NoiseRepellentAudioProcessor::SpectralFrame& outFrame) {
+  NoiseRepellentAudioProcessor::SpectralFrame temp;
+  bool gotAny = false;
+  while (proc.getNextSpectralFrame(temp)) {
+    outFrame = temp;
+    gotAny = true;
+  }
+  return gotAny;
+}
+
+void processSilentBlocks(NoiseRepellentAudioProcessor& proc,
+                         juce::AudioBuffer<float>& buffer,
+                         juce::MidiBuffer& midi, int numBlocks = 12) {
+  for (int i = 0; i < numBlocks; ++i) {
+    buffer.clear();
+    proc.processBlock(buffer, midi);
+  }
+  pumpMessageLoop(10);
+}
+
+} // namespace
+
+class UxInvariantsTest : public juce::UnitTest {
+public:
+  UxInvariantsTest() : juce::UnitTest("UX Invariants Test", "NoiseRepellent") {
+  }
+
+  void runTest() override {
+    beginTest("Profile Persistence Across 1D <-> 2D While Stopped");
+    testProfilePersistenceAcrossEngines();
+
+    beginTest("Live Aggressiveness Control While Silent / Stopped");
+    testLiveAggressivenessWhileSilent();
+
+    beginTest("Live Threshold Offsets (Broadband & Tonal) While Silent");
+    testLiveThresholdOffsetsWhileSilent();
+
+    beginTest("Silence Segregation (Input/Output Drop vs Profile Preserved)");
+    testSilenceSegregation();
+
+    beginTest("Idle No-Profile Silent Bypass");
+    testIdleNoProfileBypass();
+
+    beginTest("Engine Switch Progress Advances While Transport Stopped");
+    testEngineSwitchProgress();
+  }
+
+private:
+  void testIdleNoProfileBypass() {
+    NoiseRepellentAudioProcessor proc;
+    ScopedEditor editor(proc);
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    expect(!proc.hasNoiseProfile(), "Processor must have no noise profile");
+
+    // Feed silent blocks
+    processSilentBlocks(proc, buffer, midi, 16);
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch) {
+      for (int s = 0; s < buffer.getNumSamples(); ++s) {
+        expectEquals(buffer.getSample(ch, s), 0.0f,
+                     "Silent idle blocks must produce zero output");
+      }
+    }
+
+    NoiseRepellentAudioProcessor::SpectralFrame frame;
+    pullLatestFrame(proc, frame);
+    expect(!frame.hasNoiseProfile,
+           "Spectral frame must report no noise profile");
+
+    proc.releaseResources();
+  }
+
+  void testProfilePersistenceAcrossEngines() {
+    NoiseRepellentAudioProcessor proc;
+    ScopedEditor editor(proc);
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    // 1. Initially no profile
+    expect(!proc.hasNoiseProfile(),
+           "Initially processor should have no profile");
+
+    // 2. Start learning on 1D (Spectral)
+    setParam(proc, "algorithm_mode", 0.0f); // 1D Spectral
+    setParam(proc, "learn_noise", 1.0f);
+
+    // Feed ~0.5s of noise to build profile
+    for (int i = 0; i < 50; ++i) {
+      generateNoiseBuffer(buffer, 0.05f);
+      proc.processBlock(buffer, midi);
+    }
+    pumpMessageLoop(20);
+
+    // Stop learning and process silence
+    setParam(proc, "learn_noise", 0.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    expect(proc.hasNoiseProfile(),
+           "Profile must be present after learning on 1D");
+
+    // Pull latest spectral frame
+    NoiseRepellentAudioProcessor::SpectralFrame frame1D;
+    bool gotFrame = pullLatestFrame(proc, frame1D);
+    expect(gotFrame, "Should receive at least one spectral frame in 1D");
+    expect(frame1D.hasNoiseProfile,
+           "SpectralFrame must report hasNoiseProfile=true in 1D");
+
+    float avgNoiseFloor1D = 0.0f;
+    for (float db : frame1D.noiseFloorDB) {
+      avgNoiseFloor1D += db;
+    }
+    avgNoiseFloor1D /= static_cast<float>(frame1D.noiseFloorDB.size());
+    expect(avgNoiseFloor1D > -110.0f,
+           "1D Noise floor must not be flatlined at -120dB");
+
+    // 3. Switch to 2D (NLM) while stopped / silent
+    setParam(proc, "algorithm_mode", 1.0f); // 2D NLM
+    pumpMessageLoop(50);
+
+    // Process silent blocks to generate 2D silent frame
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    expect(proc.hasNoiseProfile(),
+           "Profile must persist on 2D after silent switch");
+
+    NoiseRepellentAudioProcessor::SpectralFrame frame2D;
+    gotFrame = pullLatestFrame(proc, frame2D);
+    expect(gotFrame, "Should receive spectral frame in 2D mode");
+    expect(frame2D.hasNoiseProfile,
+           "2D mode must report hasNoiseProfile=true while silent");
+
+    float avgNoiseFloor2D = 0.0f;
+    for (float db : frame2D.noiseFloorDB) {
+      avgNoiseFloor2D += db;
+    }
+    avgNoiseFloor2D /= static_cast<float>(frame2D.noiseFloorDB.size());
+    expect(avgNoiseFloor2D > -110.0f,
+           "2D Noise floor must remain active and not flatline to -120dB");
+
+    float maxDelta1D2D = 0.0f;
+    for (size_t i = 0; i < frame1D.noiseFloorDB.size(); ++i) {
+      float diff = std::abs(frame1D.noiseFloorDB[i] - frame2D.noiseFloorDB[i]);
+      if (diff > maxDelta1D2D)
+        maxDelta1D2D = diff;
+    }
+    expectWithinAbsoluteError(maxDelta1D2D, 0.0f, 0.1f,
+                              "Profile bins must match identically across 1D "
+                              "<-> 2D switch while stopped");
+
+    // 4. Switch back to 1D while stopped
+    setParam(proc, "algorithm_mode", 0.0f);
+    pumpMessageLoop(50);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    expect(proc.hasNoiseProfile(),
+           "Profile must persist when switching back 2D -> 1D");
+    proc.releaseResources();
+  }
+
+  void testLiveAggressivenessWhileSilent() {
+    NoiseRepellentAudioProcessor proc;
+    ScopedEditor editor(proc);
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    // Learn noise
+    setParam(proc, "algorithm_mode", 0.0f);
+    setParam(proc, "learn_noise", 1.0f);
+    for (int i = 0; i < 50; ++i) {
+      generateNoiseBuffer(buffer, 0.05f);
+      proc.processBlock(buffer, midi);
+    }
+    setParam(proc, "learn_noise", 0.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    // Baseline with aggressiveness = -1.0
+    setParam(proc, "aggressiveness", -1.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    NoiseRepellentAudioProcessor::SpectralFrame frameLow;
+    bool gotLow = pullLatestFrame(proc, frameLow);
+    expect(gotLow, "Must receive frame for low aggressiveness");
+    float avgLow = std::accumulate(frameLow.noiseFloorDB.begin(),
+                                   frameLow.noiseFloorDB.end(), 0.0f) /
+                   static_cast<float>(frameLow.noiseFloorDB.size());
+
+    // High aggressiveness = +1.0
+    setParam(proc, "aggressiveness", 1.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    NoiseRepellentAudioProcessor::SpectralFrame frameHigh;
+    bool gotHigh = pullLatestFrame(proc, frameHigh);
+    expect(gotHigh, "Must receive frame for high aggressiveness");
+    float avgHigh = std::accumulate(frameHigh.noiseFloorDB.begin(),
+                                    frameHigh.noiseFloorDB.end(), 0.0f) /
+                    static_cast<float>(frameHigh.noiseFloorDB.size());
+
+    expect(
+        avgHigh > avgLow,
+        "Increasing aggressiveness while silent must increase noise floor dB");
+
+    proc.releaseResources();
+  }
+
+  void testLiveThresholdOffsetsWhileSilent() {
+    NoiseRepellentAudioProcessor proc;
+    ScopedEditor editor(proc);
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    // Learn noise
+    setParam(proc, "algorithm_mode", 0.0f);
+    setParam(proc, "learn_noise", 1.0f);
+    for (int i = 0; i < 50; ++i) {
+      generateNoiseBuffer(buffer, 0.05f);
+      proc.processBlock(buffer, midi);
+    }
+    setParam(proc, "learn_noise", 0.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    // Offset 0 dB baseline
+    setParam(proc, "noise_profile_offset", 0.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    NoiseRepellentAudioProcessor::SpectralFrame frame0;
+    bool got0 = pullLatestFrame(proc, frame0);
+    expect(got0, "Must receive frame for offset 0dB");
+    float avg0 = std::accumulate(frame0.noiseFloorDB.begin(),
+                                 frame0.noiseFloorDB.end(), 0.0f) /
+                 static_cast<float>(frame0.noiseFloorDB.size());
+
+    // Offset +6 dB
+    setParam(proc, "noise_profile_offset", 6.0f);
+    processSilentBlocks(proc, buffer, midi, 12);
+
+    NoiseRepellentAudioProcessor::SpectralFrame frame6;
+    bool got6 = pullLatestFrame(proc, frame6);
+    expect(got6, "Must receive frame for offset +6dB");
+    float avg6 = std::accumulate(frame6.noiseFloorDB.begin(),
+                                 frame6.noiseFloorDB.end(), 0.0f) /
+                 static_cast<float>(frame6.noiseFloorDB.size());
+
+    const float delta = avg6 - avg0;
+    expectWithinAbsoluteError(
+        delta, 6.0f, 1.5f,
+        "Broadband threshold offset +6dB must raise profile by ~6dB");
+
+    proc.releaseResources();
+  }
+
+  void testSilenceSegregation() {
+    NoiseRepellentAudioProcessor proc;
+    ScopedEditor editor(proc);
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    // Learn noise
+    setParam(proc, "learn_noise", 1.0f);
+    for (int i = 0; i < 50; ++i) {
+      generateNoiseBuffer(buffer, 0.05f);
+      proc.processBlock(buffer, midi);
+    }
+    setParam(proc, "learn_noise", 0.0f);
+
+    // Drain noise frames and feed silent buffers
+    NoiseRepellentAudioProcessor::SpectralFrame drainFrame;
+    pullLatestFrame(proc, drainFrame);
+
+    processSilentBlocks(proc, buffer, midi, 20);
+
+    NoiseRepellentAudioProcessor::SpectralFrame frame;
+    bool gotFrame = pullLatestFrame(proc, frame);
+    expect(gotFrame, "Must receive silent frame");
+
+    float maxInput = *std::max_element(frame.inputMagnitudeDB.begin(),
+                                       frame.inputMagnitudeDB.end());
+    float maxOutput = *std::max_element(frame.outputMagnitudeDB.begin(),
+                                        frame.outputMagnitudeDB.end());
+
+    expect(maxInput <= -119.0f, "Silent input spectrum must drop to -120dB");
+    expect(maxOutput <= -119.0f, "Silent output spectrum must drop to -120dB");
+    expect(frame.hasNoiseProfile,
+           "Noise profile must remain active when input is silent");
+
+    proc.releaseResources();
+  }
+
+  void testEngineSwitchProgress() {
+    NoiseRepellentAudioProcessor proc;
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(20);
+
+    expect(!proc.isEngineSwitching(),
+           "Initially engine should not be switching");
+    expectEquals(proc.getEngineSwitchProgress(), 1.0f,
+                 "Initial switch progress should be 1.0 (idle)");
+
+    // Switch algorithm mode to initiate transition
+    setParam(proc, "algorithm_mode", 1.0f); // Switch to 2D
+    pumpMessageLoop(20);
+
+    expect(proc.isEngineSwitching(),
+           "Switch must be active after changing algorithm_mode");
+    expect(proc.getEngineSwitchProgress() < 1.0f,
+           "Switch progress must be < 1.0 during transition");
+
+    // Pump timer and message loop to simulate time passing while stopped
+    // (approx 1 second)
+    for (int step = 0; step < 60; ++step) {
+      pumpMessageLoop(20);
+    }
+
+    expect(!proc.isEngineSwitching(),
+           "Engine switch must complete after duration while transport is "
+           "stopped");
+    expectEquals(proc.getEngineSwitchProgress(), 1.0f,
+                 "Switch progress must reach 1.0 on completion");
+
+    proc.releaseResources();
+  }
+};
+
+static UxInvariantsTest uxInvariantsTest;
+
+int main(int argc, char* argv[]) {
+  juce::ScopedJuceInitialiser_GUI guiInit;
+
+  juce::UnitTestRunner runner;
+  runner.setAssertOnFailure(false);
+  runner.runAllTests();
+
+  int numFailed = 0;
+  for (int i = 0; i < runner.getNumResults(); ++i) {
+    if (const auto* r = runner.getResult(i)) {
+      numFailed += r->failures;
+    }
+  }
+  return numFailed > 0 ? 1 : 0;
+}

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -1,0 +1,32 @@
+# Noise Repellent — UX & Architectural Invariants
+
+This document defines the critical UX invariants and architectural contracts that must be preserved across future refactors, optimizations, and feature additions.
+
+---
+
+## 1. Profile as Single Source of Truth
+* **Persistence Across States:** Once noise is learned (`learn_noise`), the noise profile is frozen and preserved across playback starts, stops, and transport suspensions.
+* **Dual-Engine Coherence (1D ↔ 2D):** Profiles are synchronized between the 1D (Spectral) and 2D (NLM) engine groups. Switching algorithm mode while transport is stopped (or during playback) must never lose the profile or cause the visualizer to flatline to -120 dB.
+* **Silent & First-Switch Fallback:** When playback is stopped or silent, the visualizer queries the active engine group; if the newly selected engine has not yet processed audio, it falls back to the previous group's profile and synthesizes necessary spectral state.
+
+## 2. Real-Time Interactivity While Silent / Stopped
+* **Live Aggressiveness Control:** Adjusting the `aggressiveness` slider while playback is stopped or silent must immediately recalculate and display the morphed profile curve.
+* **Live Threshold Offsets (Broadband & Tonal):** Adjusting `noise_profile_offset` or `tonal_noise_profile_offset` (when unlinked via `link_threshold_offset = false`) must immediately scale the displayed profile in real time.
+* **Tonal Mask Synthesis:** If an engine has not yet executed its DSP pipeline (e.g. immediately after a silent engine switch), a synthetic tonal mask is generated from detected tonal peaks so that unlinked tonal offsets remain visually responsive.
+
+## 3. Tonal Peak & Line Invariants
+* **Visibility Rule:** Tonal lines and detected peaks are rendered if and only if `(!isLinked || !isOffsetLinked) && hasNoiseProfile`.
+* **State Preservation:** Peak frequencies and tonal lines remain visible across engine switches and silence.
+
+## 4. Silence Segregation
+* **Input / Output Drop:** When the input signal drops below silence threshold (`< 1e-5` / ~-100 dB) and learning is inactive, input and output spectra drop to -120 dB.
+* **Profile Isolation:** The noise floor profile must *never* drop or clear on silence; it remains frozen and interactive.
+
+## 5. Engine Switch Progress & Gapless Transitions
+* **Gapless Phase Machine:** Engine switching proceeds through `Warming` (700 ms) → `XFade` (30 ms) → `Steady`.
+* **Host Suspension Tolerance:** `getEngineSwitchProgress()` (0.0 → 1.0) must advance both during active `processBlock()` calls and via the processor's internal timer (`timerCallback` at 60 Hz) when the DAW transport is stopped or suspended. A silent switch completes in ~730 ms.
+
+## 6. Real-Time Safety & Performance Hierarchy
+* **Strict RT-Safety:** The audio thread (`processBlock`) must never perform dynamic memory allocations, take blocking locks/mutexes, or execute file/console I/O.
+* **CPU Hierarchy:**
+  $$\text{Bypass} < \text{Silent/Idle} < \text{Learn} < \text{Denoise 1D} < \text{Denoise 2D}$$


### PR DESCRIPTION
When bypass param is set, processBlock still ran full STFT+denoise and discarded wet via DryWetMixer, making bypass more expensive than denoising.

Early-out before specbleach processing leaves buffer as dry and lets DryWetMixer output dry with correct PDC latency. Saves STFT+denoise chain when bypassed.

Related to libspecbleach#143 idle/learning CPU fixes.