### PR TITLE
Adopt redesigned libspecbleach C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,10 +234,10 @@ else()
         FetchContent_Declare(
             libspecbleach
             GIT_REPOSITORY https://github.com/lucianodato/libspecbleach.git
-            # Pin to the revision providing the stereo profile/sync APIs used
-            # by PluginProcessor (specbleach_stereo_get_active_noise_profile_
-            # for_channel, *_get_tonal_peaks_for_channel, *_sync_profiles)
-            GIT_TAG        336beb065f3918be46220832943af8cc003128f9
+            # Pin to the revision providing the redesigned C API used by
+            # PluginProcessor (SPECBLEACH_* symbols, specbleach_stereo.hpp,
+            # resampled profile load, has_any_profile).
+            GIT_TAG        main
         )
         FetchContent_MakeAvailable(libspecbleach)
         set(SPECBLEACH_SRC "${libspecbleach_SOURCE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,9 +234,8 @@ else()
         FetchContent_Declare(
             libspecbleach
             GIT_REPOSITORY https://github.com/lucianodato/libspecbleach.git
-            # Pin to the revision providing the redesigned C API used by
-            # PluginProcessor (SPECBLEACH_* symbols, specbleach_stereo.hpp,
-            # resampled profile load, has_any_profile).
+            # Track libspecbleach main while both projects are co-developed.
+            # Re-pin to a fixed revision for release builds.
             GIT_TAG        main
         )
         FetchContent_MakeAvailable(libspecbleach)

--- a/Source/GUI/LookAndFeel.cpp
+++ b/Source/GUI/LookAndFeel.cpp
@@ -35,6 +35,22 @@ const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBg =
     juce::Colour(0xff343a48);
 const juce::Colour NoiseRepellentLookAndFeel::kColorPanelBorder =
     juce::Colour(0xff4f586c);
+const juce::Colour NoiseRepellentLookAndFeel::kColorButtonOff =
+    juce::Colour(0xff3f4757);
+const juce::Colour NoiseRepellentLookAndFeel::kColorLearnCTA =
+    juce::Colour(0xffc0392b);
+const juce::Colour NoiseRepellentLookAndFeel::kColorLearnActive =
+    juce::Colour(0xffe74c3c);
+const juce::Colour NoiseRepellentLookAndFeel::kColorInactiveText =
+    juce::Colour(0xff808896);
+const juce::Colour NoiseRepellentLookAndFeel::kColorFooterText =
+    juce::Colour(0xff94a3b8);
+const juce::Colour NoiseRepellentLookAndFeel::kColorGridLine =
+    juce::Colour(0xff3d4657);
+const juce::Colour NoiseRepellentLookAndFeel::kColorGridLabel =
+    juce::Colour(0xffa8b3c4);
+const juce::Colour NoiseRepellentLookAndFeel::kColorLegendText =
+    juce::Colour(0xffd8e0ec);
 
 NoiseRepellentLookAndFeel::NoiseRepellentLookAndFeel() {
   setColour(juce::Slider::thumbColourId, juce::Colour(0xff525c70));
@@ -126,7 +142,7 @@ void NoiseRepellentLookAndFeel::drawButtonBackground(
         button.findColour(juce::TextButton::buttonColourId, false);
     base = (offCol.isOpaque() && !offCol.isTransparent())
                ? offCol
-               : (backgroundColour.isTransparent() ? juce::Colour(0xff3f4757)
+               : (backgroundColour.isTransparent() ? kColorButtonOff
                                                    : backgroundColour);
   }
 
@@ -161,8 +177,8 @@ void NoiseRepellentLookAndFeel::drawButtonText(
                         false);
 
   juce::Colour textColour;
-  if (activeBg == juce::Colour(0xffc0392b) ||
-      activeBg == juce::Colour(0xffe74c3c)) {
+  if (activeBg == kColorLearnCTA ||
+      activeBg == kColorLearnActive) {
     textColour = juce::Colours::white;
   } else if (activeBg == kColorNoiseProfile || isOn) {
     textColour = juce::Colour(0xff101216);
@@ -185,7 +201,7 @@ void NoiseRepellentLookAndFeel::drawToggleButton(
   auto bounds = button.getLocalBounds().toFloat();
   bool isOn = button.getToggleState();
 
-  g.setColour(isOn ? kColorNoiseProfile : juce::Colour(0xff3f4757));
+  g.setColour(isOn ? kColorNoiseProfile : kColorButtonOff);
   g.fillRoundedRectangle(bounds, 4.0f);
 
   g.setColour(kColorPanelBorder);
@@ -222,7 +238,7 @@ void NoiseRepellentLookAndFeel::drawComboBox(juce::Graphics& g, int width,
                    arrowZone.getCentreX() + 4.0f, arrowZone.getCentreY() - 2.0f,
                    arrowZone.getCentreX(), arrowZone.getCentreY() + 3.0f);
 
-  g.setColour(juce::Colour(0xff808896));
+  g.setColour(kColorInactiveText);
   g.fillPath(path);
 }
 

--- a/Source/GUI/LookAndFeel.cpp
+++ b/Source/GUI/LookAndFeel.cpp
@@ -129,6 +129,9 @@ void NoiseRepellentLookAndFeel::drawButtonBackground(
     juce::Graphics& g, juce::Button& button,
     const juce::Colour& backgroundColour, bool shouldDrawButtonAsHighlighted,
     bool shouldDrawButtonAsDown) {
+  // The header brand button keeps its flat label look — no button chrome.
+  if (button.getName() == kBrandButtonName)
+    return;
   auto bounds = button.getLocalBounds().toFloat();
   bool isOn = button.getToggleState();
 
@@ -158,8 +161,10 @@ void NoiseRepellentLookAndFeel::drawButtonBackground(
   g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
 }
 
-juce::Font NoiseRepellentLookAndFeel::getTextButtonFont(juce::TextButton&,
+juce::Font NoiseRepellentLookAndFeel::getTextButtonFont(juce::TextButton& button,
                                                         int) {
+  if (button.getName() == kBrandButtonName)
+    return juce::FontOptions(kFontSizeBrand, juce::Font::bold);
   return juce::FontOptions(kFontSizeLabel, juce::Font::bold);
 }
 
@@ -167,6 +172,14 @@ void NoiseRepellentLookAndFeel::drawButtonText(
     juce::Graphics& g, juce::TextButton& button,
     bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) {
   juce::ignoreUnused(shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+  if (button.getName() == kBrandButtonName) {
+    // Flat label styling preserved from the former brand juce::Label.
+    g.setColour(juce::Colours::white);
+    g.setFont(juce::FontOptions(kFontSizeBrand, juce::Font::bold));
+    g.drawText(button.getButtonText(), button.getLocalBounds(),
+               juce::Justification::centredLeft);
+    return;
+  }
   juce::Font font(getTextButtonFont(button, button.getHeight()));
   g.setFont(font);
 

--- a/Source/GUI/LookAndFeel.h
+++ b/Source/GUI/LookAndFeel.h
@@ -84,6 +84,10 @@ public:
   static const juce::Colour kColorGridLabel;    // Grid labels 0xffa8b3c4
   static const juce::Colour kColorLegendText;   // Legend text 0xffd8e0ec
 
+  // Component name identifying the header brand button (rendered as flat
+  // label-styled text instead of button chrome).
+  static constexpr const char* kBrandButtonName = "brandButton";
+
   // Typography Scale
   static constexpr float kFontSizeLabel =
       12.0f; // Standardized UI font size for all labels, headers, buttons,

--- a/Source/GUI/LookAndFeel.h
+++ b/Source/GUI/LookAndFeel.h
@@ -64,15 +64,25 @@ public:
                                  int standardMenuItemHeight, int& idealWidth,
                                  int& idealHeight) override;
 
-  // Domain Colors
+  // Domain Colors (hex values mirror the definitions in LookAndFeel.cpp)
   static const juce::Colour kColorNoiseProfile;   // Warm Amber 0xffe5a000
-  static const juce::Colour kColorDenoising;      // Slate Blue  0xff00b4d8
-  static const juce::Colour kColorFineTuning;     // Slate Gray  0xff64748b
-  static const juce::Colour kColorInputSignal;    // Soft Teal   0xff486581
-  static const juce::Colour kColorTonalPeaks;     // Muted Violet 0xff9d65c9
+  static const juce::Colour kColorDenoising;      // Aqua 0xff5cc0d4
+  static const juce::Colour kColorFineTuning;     // Pale Slate 0xffb4bfce
+  static const juce::Colour kColorInputSignal;    // Steel Blue 0xff6184a8
+  static const juce::Colour kColorTonalPeaks;     // Coral 0xffe07055
   static const juce::Colour kColorReductionCurve; // Soft Green 0xff4caf50
-  static const juce::Colour kColorPanelBg;        // Matte Dark  0xff171a21
-  static const juce::Colour kColorPanelBorder;    // Border      0xff272c37
+  static const juce::Colour kColorPanelBg;        // Matte Dark 0xff343a48
+  static const juce::Colour kColorPanelBorder;    // Border 0xff4f586c
+
+  // Shared UI Colors (previously inline hex literals across editor/visualizer)
+  static const juce::Colour kColorButtonOff;   // Toggle off 0xff3f4757
+  static const juce::Colour kColorLearnCTA;    // Learn idle red 0xffc0392b
+  static const juce::Colour kColorLearnActive; // Learn active red 0xffe74c3c
+  static const juce::Colour kColorInactiveText; // Muted gray 0xff808896
+  static const juce::Colour kColorFooterText;   // Footer gray 0xff94a3b8
+  static const juce::Colour kColorGridLine;     // Spectrum grid 0xff3d4657
+  static const juce::Colour kColorGridLabel;    // Grid labels 0xffa8b3c4
+  static const juce::Colour kColorLegendText;   // Legend text 0xffd8e0ec
 
   // Typography Scale
   static constexpr float kFontSizeLabel =

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -22,6 +22,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cmath>
 
+namespace {
+
+// Tooltip strings (single source; getTooltip() only selects among these)
+const juce::String kTpBadgeTip =
+    "Transient Protection (TP): Click to toggle.\n"
+    "Preserves sharp attack transients and plucked notes.";
+
+} // namespace
+
 SpectralVisualizerComponent::SpectralVisualizerComponent(
     NoiseRepellentAudioProcessor& p)
     : processor(p) {
@@ -843,8 +852,7 @@ juce::String SpectralVisualizerComponent::getTooltip() {
 
     auto mousePos = getMouseXYRelative().toFloat();
     if (badgeBounds.contains(mousePos)) {
-      return "Transient Protection (TP): Click to toggle.\n"
-             "Preserves sharp attack transients and plucked notes.";
+      return kTpBadgeTip;
     }
   }
   return {};

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -25,8 +25,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 SpectralVisualizerComponent::SpectralVisualizerComponent(
     NoiseRepellentAudioProcessor& p)
     : processor(p) {
-  smoothedInputDB.fill(-100.0f);
-  smoothedOutputDB.fill(-100.0f);
+  smoothedInputDB.fill(SpectralVisualizerComponent::kAxisMinDB);
+  smoothedOutputDB.fill(SpectralVisualizerComponent::kAxisMinDB);
   startTimerHz(60);
 }
 
@@ -101,9 +101,23 @@ void SpectralVisualizerComponent::timerCallback() {
 void SpectralVisualizerComponent::resized() {
 }
 
+juce::Rectangle<float> SpectralVisualizerComponent::getTpBadgeBounds() const {
+  const float w = static_cast<float>(getWidth());
+  return {w - kBadgeW - kBadgeMargin, kBadgeTop, kBadgeW, kBadgeH};
+}
+
+float SpectralVisualizerComponent::biasToY(float biasDB, float h) {
+  return h * 0.5f - (biasDB / kCurveMaxBiasDB) * (h * kCurveHeightFrac);
+}
+
+float SpectralVisualizerComponent::yToBias(float y, float h) {
+  return ((h * 0.5f - y) / (h * kCurveHeightFrac)) * kCurveMaxBiasDB;
+}
+
 // Map a frequency (Hz) to an X pixel position using logarithmic scale
-static float freqToX(float freqHz, float width, float minFreq = 20.0f,
-                     float maxFreq = 20000.0f) {
+static float freqToX(float freqHz, float width,
+                     float minFreq = SpectralVisualizerComponent::kAxisMinFreq,
+                     float maxFreq = SpectralVisualizerComponent::kAxisMaxFreq) {
   if (freqHz <= minFreq)
     return 0.0f;
   if (freqHz >= maxFreq)
@@ -112,8 +126,9 @@ static float freqToX(float freqHz, float width, float minFreq = 20.0f,
 }
 
 // Map a dB value to a Y pixel position
-static float dbToY(float db, float height, float minDB = -100.0f,
-                   float maxDB = -20.0f) {
+static float dbToY(float db, float height,
+                   float minDB = SpectralVisualizerComponent::kAxisMinDB,
+                   float maxDB = SpectralVisualizerComponent::kAxisMaxDB) {
   float clamped = juce::jlimit(minDB, maxDB, db);
   float normalized =
       (clamped - minDB) / (maxDB - minDB); // 0 at bottom, 1 at top
@@ -169,10 +184,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
 
   const float w = static_cast<float>(getWidth());
   const float h = static_cast<float>(getHeight());
-  const float minDB = -100.0f;
-  const float maxDB = -20.0f;
-  const float minFreq = 20.0f;
-  const float maxFreq = 20000.0f;
+  const float minDB = SpectralVisualizerComponent::kAxisMinDB;
+  const float maxDB = SpectralVisualizerComponent::kAxisMaxDB;
+  const float minFreq = SpectralVisualizerComponent::kAxisMinFreq;
+  const float maxFreq = SpectralVisualizerComponent::kAxisMaxFreq;
 
   const double sampleRate = processor.getSampleRate();
   const size_t numBins = NoiseRepellentAudioProcessor::kFftBins;
@@ -202,10 +217,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   // dB Y-grid (-90 dB to -20 dB in 10 dB steps)
   for (int db = -90; db <= -20; db += 10) {
     float y = dbToY(static_cast<float>(db), h, minDB, maxDB);
-    g.setColour(juce::Colour(0xff3d4657));
+    g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorGridLine));
     g.drawHorizontalLine(static_cast<int>(y), 0.0f, w);
 
-    g.setColour(juce::Colour(0xffa8b3c4));
+    g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorGridLabel));
     juce::String label = juce::String(db) + " dB";
     g.drawText(label, 8, static_cast<int>(y) - 12, 60, 12,
                juce::Justification::left);
@@ -216,10 +231,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
                                 2000, 5000, 10000, 20000};
   for (float f : freqs) {
     float x = freqToX(f, w, minFreq, maxFreq);
-    g.setColour(juce::Colour(0xff3d4657));
+    g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorGridLine));
     g.drawVerticalLine(static_cast<int>(x), 0.0f, h);
 
-    g.setColour(juce::Colour(0xffa8b3c4));
+    g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorGridLabel));
     juce::String label = f >= 1000.0f ? juce::String(f / 1000.0f, 0) + "k"
                                       : juce::String(static_cast<int>(f));
     g.drawText(label, static_cast<int>(x) + 4, static_cast<int>(h) - 14, 40, 12,
@@ -364,7 +379,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       auto nodeToPoint = [&](const NoiseRepellentAudioProcessor::CurveNode& n)
           -> juce::Point<float> {
         float nx = std::clamp(n.normX, 0.0f, 1.0f);
-        float ny = h * 0.5f - (n.biasDB / 24.0f) * (h * 0.4f);
+        float ny = SpectralVisualizerComponent::biasToY(n.biasDB, h);
         return {nx * w, ny};
       };
 
@@ -433,11 +448,11 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       // Draw dB Reference Y-Scale for Reduction Curve on Right Margin
       const float scaleX = w - 42.0f;
       const float textX = w - 38.0f;
-      static const int biasLevels[] = {+24, +12, 0, -12, -24};
+      static const int biasLevels[] = {+24, +12, 0, -12, -24}; // +/-kCurveMaxBiasDB
 
       for (int biasVal : biasLevels) {
         float ny =
-            h * 0.5f - (static_cast<float>(biasVal) / 24.0f) * (h * 0.4f);
+            SpectralVisualizerComponent::biasToY(static_cast<float>(biasVal), h);
         g.setColour(
             NoiseRepellentLookAndFeel::kColorReductionCurve.withAlpha(0.35f));
         g.drawHorizontalLine(static_cast<int>(ny), scaleX, w);
@@ -560,7 +575,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
           NoiseRepellentLookAndFeel::kColorInputSignal.withAlpha(0.70f));
       g.fillRect(curX, legendY + 7.0f, 10.0f, 8.0f);
       curX += 14.0f;
-      g.setColour(juce::Colour(0xffd8e0ec));
+      g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText));
       g.drawText("Input", static_cast<int>(curX), static_cast<int>(legendY), 32,
                  static_cast<int>(legendH), juce::Justification::left);
       curX += 32.0f + 14.0f;
@@ -569,7 +584,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
       g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
       curX += 16.0f;
-      g.setColour(juce::Colour(0xffd8e0ec));
+      g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText));
       g.drawText("Profile", static_cast<int>(curX), static_cast<int>(legendY),
                  38, static_cast<int>(legendH), juce::Justification::left);
       curX += 38.0f + 14.0f;
@@ -578,7 +593,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       g.setColour(NoiseRepellentLookAndFeel::kColorDenoising);
       g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
       curX += 16.0f;
-      g.setColour(juce::Colour(0xffd8e0ec));
+      g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText));
       g.drawText("Output", static_cast<int>(curX), static_cast<int>(legendY),
                  40, static_cast<int>(legendH), juce::Justification::left);
       curX += 40.0f;
@@ -592,7 +607,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
         float dLen[] = {2.0f, 2.0f};
         g.drawDashedLine(dashLine, dLen, 2, 1.5f);
         curX += 16.0f;
-        g.setColour(juce::Colour(0xffd8e0ec));
+        g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText));
         g.drawText("Tonal Peaks", static_cast<int>(curX),
                    static_cast<int>(legendY), 64, static_cast<int>(legendH),
                    juce::Justification::left);
@@ -605,7 +620,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
         g.setColour(NoiseRepellentLookAndFeel::kColorReductionCurve);
         g.drawLine(curX, legendY + 11.0f, curX + 12.0f, legendY + 11.0f, 2.0f);
         curX += 16.0f;
-        g.setColour(juce::Colour(0xffd8e0ec));
+        g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText));
         g.drawText("Curve", static_cast<int>(curX), static_cast<int>(legendY),
                    38, static_cast<int>(legendH), juce::Justification::left);
       }
@@ -615,10 +630,11 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
   // 6. Transient Protection (TP) LED Indicator & Button (Top-Right Corner:
   // click to toggle ON/OFF, only visible in Advanced mode)
   if (isAdvancedVisible) {
-    const float badgeW = 66.0f;
-    const float badgeH = 22.0f;
-    const float badgeX = w - badgeW - 10.0f;
-    const float badgeY = 10.0f;
+    const juce::Rectangle<float> badge = getTpBadgeBounds();
+    const float badgeX = badge.getX();
+    const float badgeY = badge.getY();
+    const float badgeW = badge.getWidth();
+    const float badgeH = badge.getHeight();
 
     if (badgeX > 10.0f) {
       // Container background (dimmer when disabled)
@@ -672,7 +688,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
             juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel - 0.5f,
                               juce::Font::bold));
         g.setColour(
-            juce::Colour(0xffd8e0ec).withAlpha(0.65f + 0.35f * ledBrightness));
+            juce::Colour(NoiseRepellentLookAndFeel::kColorLegendText).withAlpha(0.65f + 0.35f * ledBrightness));
         g.drawText("TP ON", static_cast<int>(badgeX + 19.0f),
                    static_cast<int>(badgeY), static_cast<int>(badgeW - 22.0f),
                    static_cast<int>(badgeH), juce::Justification::centred);
@@ -708,10 +724,11 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
   // Check Transient Protection (TP) Toggle Badge click (Top-Right corner: click
   // to toggle ON/OFF in Advanced mode)
   if (isAdvancedVisible) {
-    const float badgeW = 66.0f;
-    const float badgeH = 22.0f;
-    const float badgeX = w - badgeW - 10.0f;
-    const float badgeY = 10.0f;
+    const juce::Rectangle<float> badge = getTpBadgeBounds();
+    const float badgeX = badge.getX();
+    const float badgeY = badge.getY();
+    const float badgeW = badge.getWidth();
+    const float badgeH = badge.getHeight();
     juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
     if (badgeBounds.contains(e.position)) {
       if (auto* transientParam = dynamic_cast<juce::AudioParameterBool*>(
@@ -746,7 +763,7 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
     const auto& nodes = processor.getCurveNodes();
     for (size_t i = 0; i < nodes.size(); ++i) {
       float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
-      float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
+      float ny = SpectralVisualizerComponent::biasToY(nodes[i].biasDB, h);
       if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
         activeDragTarget = DragTarget::CurveNode;
         activeNodeIndex = static_cast<int>(i);
@@ -757,7 +774,7 @@ void SpectralVisualizerComponent::mouseDown(const juce::MouseEvent& e) {
     // Add a new curve node on empty click
     float clickNormX = std::clamp(e.position.x / w, 0.01f, 0.99f);
     float clickBiasDB = std::clamp(
-        ((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f, -24.0f, 24.0f);
+        SpectralVisualizerComponent::yToBias(e.position.y, h), -SpectralVisualizerComponent::kCurveMaxBiasDB, SpectralVisualizerComponent::kCurveMaxBiasDB);
     processor.addCurveNode(clickNormX, clickBiasDB);
     repaint();
   }
@@ -769,8 +786,8 @@ void SpectralVisualizerComponent::mouseDrag(const juce::MouseEvent& e) {
 
   if (activeDragTarget == DragTarget::CurveNode && activeNodeIndex >= 0) {
     float normX = std::clamp(e.position.x / w, 0.0f, 1.0f);
-    float biasDB = std::clamp(((h * 0.5f - e.position.y) / (h * 0.4f)) * 24.0f,
-                              -24.0f, 24.0f);
+    float biasDB = std::clamp(SpectralVisualizerComponent::yToBias(e.position.y, h),
+                              -SpectralVisualizerComponent::kCurveMaxBiasDB, SpectralVisualizerComponent::kCurveMaxBiasDB);
     processor.updateCurveNode(activeNodeIndex, normX, biasDB);
     repaint();
   }
@@ -789,7 +806,7 @@ void SpectralVisualizerComponent::mouseDoubleClick(const juce::MouseEvent& e) {
 
     for (size_t i = 1; i < nodes.size() - 1; ++i) {
       float nx = std::clamp(nodes[i].normX, 0.0f, 1.0f);
-      float ny = h * 0.5f - (nodes[i].biasDB / 24.0f) * (h * 0.4f);
+      float ny = SpectralVisualizerComponent::biasToY(nodes[i].biasDB, h);
       if (e.position.getDistanceFrom({nx * w, ny}) <= 12.0f) {
         processor.removeCurveNode(static_cast<int>(i));
         repaint();
@@ -801,11 +818,7 @@ void SpectralVisualizerComponent::mouseDoubleClick(const juce::MouseEvent& e) {
 
 void SpectralVisualizerComponent::mouseMove(const juce::MouseEvent& e) {
   const float w = static_cast<float>(getWidth());
-  const float badgeW = 66.0f;
-  const float badgeH = 22.0f;
-  const float badgeX = w - badgeW - 10.0f;
-  const float badgeY = 10.0f;
-  juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
+  juce::Rectangle<float> badgeBounds = getTpBadgeBounds();
 
   if (isAdvancedVisible && badgeBounds.contains(e.position)) {
     setMouseCursor(juce::MouseCursor::PointingHandCursor);
@@ -821,10 +834,11 @@ void SpectralVisualizerComponent::mouseExit(const juce::MouseEvent&) {
 juce::String SpectralVisualizerComponent::getTooltip() {
   if (isAdvancedVisible) {
     const float w = static_cast<float>(getWidth());
-    const float badgeW = 66.0f;
-    const float badgeH = 22.0f;
-    const float badgeX = w - badgeW - 10.0f;
-    const float badgeY = 10.0f;
+    const juce::Rectangle<float> badge = getTpBadgeBounds();
+    const float badgeX = badge.getX();
+    const float badgeY = badge.getY();
+    const float badgeW = badge.getWidth();
+    const float badgeH = badge.getHeight();
     juce::Rectangle<float> badgeBounds(badgeX, badgeY, badgeW, badgeH);
 
     auto mousePos = getMouseXYRelative().toFloat();

--- a/Source/GUI/SpectralVisualizer.h
+++ b/Source/GUI/SpectralVisualizer.h
@@ -50,6 +50,25 @@ public:
     }
   }
 
+  // Spectrum axis ranges (shared by mapping helpers and paint)
+  static constexpr float kAxisMinDB = -100.0f;
+  static constexpr float kAxisMaxDB = -20.0f;
+  static constexpr float kAxisMinFreq = 20.0f;
+  static constexpr float kAxisMaxFreq = 20000.0f;
+  // Reduction-curve vertical mapping: +/-kCurveMaxBiasDB spans
+  // kCurveHeightFrac of the height around the vertical centre
+  static constexpr float kCurveMaxBiasDB = 24.0f;
+  static constexpr float kCurveHeightFrac = 0.4f;
+  // Transient-protection badge geometry
+  static constexpr float kBadgeW = 66.0f;
+  static constexpr float kBadgeH = 22.0f;
+  static constexpr float kBadgeMargin = 10.0f;
+  static constexpr float kBadgeTop = 10.0f;
+
+  juce::Rectangle<float> getTpBadgeBounds() const;
+  static float biasToY(float biasDB, float h);
+  static float yToBias(float y, float h);
+
 private:
   NoiseRepellentAudioProcessor& processor;
   NoiseRepellentAudioProcessor::SpectralFrame currentFrame;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -37,6 +37,76 @@ const juce::String kTipLink =
 const juce::String kTipResetCurve = "Reset reduction curve to flat 0 dB line.";
 const juce::String kTipThreshold =
     "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).";
+// Header
+const juce::String kTipAbout = "About Noise Repellent";
+const juce::String kTipPreferences = "Preferences";
+const juce::String kTipPreferencesMenu = "Plugin preferences menu.";
+const juce::String kTipAlgoMode =
+    "How the noise reduction smoothing is computed. Standard is fast and\n"
+    "light on CPU; Patch-Based analyzes similar patches for higher quality.";
+const juce::String kTipAdvancedToggle =
+    "Toggle Advanced DSP Controls (Smoothing, Masking, Whitening, "
+    "Aggressiveness).";
+const juce::String kTipAdvancedShow =
+    "Show Advanced DSP Controls (Smoothing, Masking Protect, Whitening,\n "
+    "Bias Curve, Tonal Split & Aggressiveness).";
+// Noise profile box
+const juce::String kTipLearnInitial =
+    "Capture static noise profile from current audio input\n(supports "
+    "multi-section accumulation).";
+const juce::String kTipLearnCapturing =
+    "Capturing noise profile from current audio playback...";
+const juce::String kTipLearnAccumulate =
+    "Capture and accumulate an additional noise section\ninto the current "
+    "profile.";
+const juce::String kTipLearnDefault =
+    "Loop a noise-only segment in your DAW and click\nto capture a noise "
+    "profile.";
+const juce::String kTipResetProfile = "Reset noise profile";
+const juce::String kTipResetProfileClear =
+    "Reset noise profile and clear learned data.";
+const juce::String kTipAdaptiveMethod =
+    "Select Adaptive Estimation Method: SPP-MMSE (best for speech & dynamic "
+    "noise),\nBrandt (best for steady hiss & fans), or Martin (best for slow "
+    "background).";
+// Reduction faders
+const juce::String kTipMasterReduction =
+    "Adjust noise reduction level in decibels\n(0 to 40 dB across all "
+    "bands).";
+const juce::String kTipTonalReduction =
+    "Adjust reduction level for tonal noise components\n(0 to 40 dB for "
+    "harmonic peaks).";
+const juce::String kTipDelta =
+    "Listen to removed noise signal\n(residual audio output).";
+const juce::String kTipBypass =
+    "Soft bypass plugin processing\nwith smooth wet/dry fade transition.";
+const juce::String kTipLinkUnlinkedDisabled =
+    "Unlinking tonal reduction is disabled in Standalone Adaptive "
+    "mode\n(requires a captured manual profile to detect tonal peaks).";
+const juce::String kTipCurveToggle = "Enable per-frequency reduction bias curve.";
+const juce::String kTipCurveOverlay =
+    "Enable per-frequency reduction bias curve overlay on spectral\n"
+    "display. Shapes both broadband and tonal reduction.";
+// Threshold faders
+const juce::String kTipMasterOffsetUnlinked =
+    "Shift broadband noise threshold up or down\nin "
+    "decibels (-12 to +12 dB).";
+const juce::String kTipTonalOffset =
+    "Shift threshold for tonal noise components\nin decibels (-12 to +12 "
+    "dB).";
+// Advanced panel
+const juce::String kTipSmoothing =
+    "Apply temporal smoothing across spectral frames\nto reduce musical "
+    "noise bubbling artifacts.";
+const juce::String kTipSmoothing2D =
+    "Adjust patch-based similarity filtering strength\nto "
+    "control Patch-Based (High Quality) smoothing.";
+const juce::String kTipMasking =
+    "Adjust psychoacoustic masking threshold\nto protect quiet musical "
+    "transients.";
+const juce::String kTipWhitening =
+    "Spectral whitening factor to equalize\nthe residual noise floor "
+    "spectrum.";
 const juce::String kTipMorphingUnavailable =
     "Profile Morphing is available in Advanced Controls\nwhen a manual "
     "learned noise profile is captured.";
@@ -59,13 +129,13 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   brandLabel.setFont(juce::FontOptions(
       NoiseRepellentLookAndFeel::kFontSizeBrand, juce::Font::bold));
   brandLabel.setColour(juce::Label::textColourId, juce::Colours::white);
-  brandLabel.setTooltip("About Noise Repellent");
+  brandLabel.setTooltip(kTipAbout);
   brandLabel.setMouseCursor(juce::MouseCursor::PointingHandCursor);
   addAndMakeVisible(brandLabel);
 
   // Preferences Header Button
   addAndMakeVisible(btnPreferences);
-  btnPreferences.setTooltip("Preferences");
+  btnPreferences.setTooltip(kTipPreferences);
   btnPreferences.setColour(juce::TextButton::buttonColourId,
                            juce::Colour(0xff3a4150));
   btnPreferences.onClick = [this]() {
@@ -187,11 +257,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   };
 
   addAndMakeVisible(btnAdaptiveArrow);
-  const juce::String adaptiveMethodTip =
-      "Select Adaptive Estimation Method: SPP-MMSE (best for speech & dynamic "
-      "noise),\nBrandt (best for steady hiss & fans), or Martin (best for slow "
-      "background).";
-  btnAdaptiveArrow.setTooltip(adaptiveMethodTip);
+  btnAdaptiveArrow.setTooltip(kTipAdaptiveMethod);
   btnAdaptiveArrow.setColour(juce::TextButton::buttonColourId,
                              juce::Colour(0xff353b48));
   btnAdaptiveArrow.onClick = [this]() {
@@ -223,7 +289,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   };
 
   addAndMakeVisible(btnResetProfile);
-  btnResetProfile.setTooltip("Reset noise profile");
+  btnResetProfile.setTooltip(kTipResetProfile);
   btnResetProfile.onClick = [this]() {
     audioProcessor.resetNoiseProfile();
     if (auto* pLearn = audioProcessor.getAPVTS().getParameter("learn_noise"))
@@ -283,7 +349,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   };
 
   btnCurveToggle.setClickingTogglesState(true);
-  btnCurveToggle.setTooltip("Enable per-frequency reduction bias curve.");
+  btnCurveToggle.setTooltip(kTipCurveToggle);
   addAndMakeVisible(btnCurveToggle);
   btnCurveToggle.onClick = [this]() { updateLayout(); };
 
@@ -439,9 +505,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   // Advanced Controls Toggle Button
   btnAdvancedToggle.setClickingTogglesState(true);
   btnAdvancedToggle.setButtonText("ADVANCED");
-  btnAdvancedToggle.setTooltip(
-      "Toggle Advanced DSP Controls (Smoothing, Masking, Whitening, "
-      "Aggressiveness).");
+  btnAdvancedToggle.setTooltip(kTipAdvancedToggle);
   addAndMakeVisible(btnAdvancedToggle);
   btnAdvancedToggle.onClick = [this]() {
     isAdvancedVisible = btnAdvancedToggle.getToggleState();
@@ -486,60 +550,38 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
       apvts, "aggressiveness", sliderAggressiveness);
 
   // Control Tooltip Descriptions
-  btnPreferences.setTooltip("Plugin preferences menu.");
+  btnPreferences.setTooltip(kTipPreferencesMenu);
   comboAlgoMode.setTooltip(
-      "How the noise reduction smoothing is computed. Standard is fast and\n"
-      "light on CPU; Patch-Based analyzes similar patches for higher quality.");
+kTipAlgoMode);
   lblAlgoHeader.setTooltip(
-      "How the noise reduction smoothing is computed. Standard is fast and\n"
-      "light on CPU; Patch-Based analyzes similar patches for higher quality.");
-  btnAdvancedToggle.setTooltip(
-      "Show Advanced DSP Controls (Smoothing, Masking Protect, Whitening,\n "
-      "Bias Curve, Tonal Split & Aggressiveness).");
-  btnLearn.setTooltip(
-      "Capture static noise profile from current audio input\n(supports "
-      "multi-section accumulation).");
-  btnResetProfile.setTooltip("Reset noise profile and clear learned data.");
+kTipAlgoMode);
+  btnAdvancedToggle.setTooltip(kTipAdvancedShow);
+  btnLearn.setTooltip(kTipLearnInitial);
+  btnResetProfile.setTooltip(kTipResetProfileClear);
   btnAdaptiveNoise.setTooltip(
       kTipAdaptive);
-  btnAdaptiveArrow.setTooltip(adaptiveMethodTip);
-  comboMethod.setTooltip(adaptiveMethodTip);
-  lblMethod.setTooltip(adaptiveMethodTip);
+  btnAdaptiveArrow.setTooltip(kTipAdaptiveMethod);
+  comboMethod.setTooltip(kTipAdaptiveMethod);
+  lblMethod.setTooltip(kTipAdaptiveMethod);
 
-  const juce::String masterRedTip =
-      "Adjust noise reduction level in decibels\n(0 to 40 dB across all "
-      "bands).";
-  const juce::String tonalRedTip =
-      "Adjust reduction level for tonal noise components\n(0 to 40 dB for "
-      "harmonic peaks).";
-  sliderMasterRed.setTooltip(masterRedTip);
-  lblMasterRed.setTooltip(masterRedTip);
-  lblReductionHeader.setTooltip(masterRedTip);
-  sliderTonalRed.setTooltip(tonalRedTip);
-  lblTonalRed.setTooltip(tonalRedTip);
+  sliderMasterRed.setTooltip(kTipMasterReduction);
+  lblMasterRed.setTooltip(kTipMasterReduction);
+  lblReductionHeader.setTooltip(kTipMasterReduction);
+  sliderTonalRed.setTooltip(kTipTonalReduction);
+  lblTonalRed.setTooltip(kTipTonalReduction);
 
   sliderOffset.setTooltip(kTipThreshold);
   lblOffset.setTooltip(kTipThreshold);
   sliderAggressiveness.setTooltip(kTipAggressiveness);
   lblAggressiveness.setTooltip(kTipAggressiveness);
-  btnDelta.setTooltip(
-      "Listen to removed noise signal\n(residual audio output).");
-  btnBypass.setTooltip(
-      "Soft bypass plugin processing\nwith smooth wet/dry fade transition.");
+  btnDelta.setTooltip(kTipDelta);
+  btnBypass.setTooltip(kTipBypass);
 
-  sliderSmoothing.setTooltip(
-      "Apply temporal smoothing across spectral frames\nto reduce musical "
-      "noise bubbling artifacts.");
-  sliderMasking.setTooltip(
-      "Adjust psychoacoustic masking threshold\nto protect quiet musical "
-      "transients.");
-  sliderWhitening.setTooltip(
-      "Spectral whitening factor to equalize\nthe residual noise floor "
-      "spectrum.");
+  sliderSmoothing.setTooltip(kTipSmoothing);
+  sliderMasking.setTooltip(kTipMasking);
+  sliderWhitening.setTooltip(kTipWhitening);
   btnLink.setTooltip(kTipLink);
-  btnCurveToggle.setTooltip(
-      "Enable per-frequency reduction bias curve overlay on spectral\n"
-      "display. Shapes both broadband and tonal reduction.");
+  btnCurveToggle.setTooltip(kTipCurveOverlay);
   btnResetCurve.setTooltip(kTipResetCurve);
 
   // Initial Layout update
@@ -771,26 +813,21 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
                        juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive)); // Active Learning Red
     btnLearn.setColour(juce::TextButton::buttonOnColourId,
                        juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive));
-    btnLearn.setTooltip(
-        "Capturing noise profile from current audio playback...");
+    btnLearn.setTooltip(kTipLearnCapturing);
   } else if (hasProfile) {
     btnLearn.setButtonText("+ Learn");
     btnLearn.setColour(juce::TextButton::buttonColourId,
                        NoiseRepellentLookAndFeel::kColorNoiseProfile);
     btnLearn.setColour(juce::TextButton::buttonOnColourId,
                        NoiseRepellentLookAndFeel::kColorNoiseProfile);
-    btnLearn.setTooltip(
-        "Capture and accumulate an additional noise section\ninto the current "
-        "profile.");
+    btnLearn.setTooltip(kTipLearnAccumulate);
   } else {
     btnLearn.setButtonText("Learn Noise");
     btnLearn.setColour(juce::TextButton::buttonColourId,
                        juce::Colour(NoiseRepellentLookAndFeel::kColorLearnCTA)); // Prominent Crimson Red CTA
     btnLearn.setColour(juce::TextButton::buttonOnColourId,
                        juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive)); // Active Learning Red
-    btnLearn.setTooltip(
-        "Loop a noise-only segment in your DAW and click\nto capture a noise "
-        "profile.");
+    btnLearn.setTooltip(kTipLearnDefault);
   }
   btnLearn.repaint();
 
@@ -856,9 +893,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   if (canUnlink) {
     btnLink.setTooltip(kTipLink);
   } else {
-    btnLink.setTooltip(
-        "Unlinking tonal reduction is disabled in Standalone Adaptive "
-        "mode\n(requires a captured manual profile to detect tonal peaks).");
+    btnLink.setTooltip(kTipLinkUnlinkedDisabled);
   }
 
   lblReductionHeader.setEnabled(pluginActive);
@@ -870,19 +905,19 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   sliderTonalRed.setEnabled(tonalEnabled);
   lblTonalRed.setEnabled(tonalEnabled);
 
-  const juce::String masterRedTip =
+  const juce::String kTipMasterReduction =
       isLinked
           ? "Adjust noise reduction level in decibels\n(0 to 40 dB across all "
             "bands)."
           : "Adjust broadband noise reduction level in decibels\n(0 to 40 dB).";
-  const juce::String tonalRedTip =
+  const juce::String kTipTonalReduction =
       "Adjust reduction level for tonal noise components\n(0 to 40 dB).";
 
-  lblReductionHeader.setTooltip(masterRedTip);
-  sliderMasterRed.setTooltip(masterRedTip);
-  lblMasterRed.setTooltip(masterRedTip);
-  sliderTonalRed.setTooltip(tonalRedTip);
-  lblTonalRed.setTooltip(tonalRedTip);
+  lblReductionHeader.setTooltip(kTipMasterReduction);
+  sliderMasterRed.setTooltip(kTipMasterReduction);
+  lblMasterRed.setTooltip(kTipMasterReduction);
+  sliderTonalRed.setTooltip(kTipTonalReduction);
+  lblTonalRed.setTooltip(kTipTonalReduction);
 
   // Threshold Offset controls
   btnLinkOffset.setEnabled(allowUnlink);
@@ -900,19 +935,12 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   sliderTonalOffset.setEnabled(tonalOffsetEnabled);
   lblTonalOffset.setEnabled(tonalOffsetEnabled);
 
-  const juce::String masterOffsetTip =
-      isOffsetLinked ? kTipThreshold
-                     : "Shift broadband noise threshold up or down\nin "
-                       "decibels (-12 to +12 dB).";
-  const juce::String tonalOffsetTip =
-      "Shift threshold for tonal noise components\nin decibels (-12 to +12 "
-      "dB).";
 
-  lblOffset.setTooltip(masterOffsetTip);
-  sliderOffset.setTooltip(masterOffsetTip);
-  lblMasterOffset.setTooltip(masterOffsetTip);
-  sliderTonalOffset.setTooltip(tonalOffsetTip);
-  lblTonalOffset.setTooltip(tonalOffsetTip);
+  lblOffset.setTooltip((isOffsetLinked ? kTipThreshold : kTipMasterOffsetUnlinked));
+  sliderOffset.setTooltip((isOffsetLinked ? kTipThreshold : kTipMasterOffsetUnlinked));
+  lblMasterOffset.setTooltip((isOffsetLinked ? kTipThreshold : kTipMasterOffsetUnlinked));
+  sliderTonalOffset.setTooltip(kTipTonalOffset);
+  lblTonalOffset.setTooltip(kTipTonalOffset);
 
   btnCurveToggle.setEnabled(pluginActive);
   btnResetCurve.setEnabled(pluginActive && btnCurveToggle.getToggleState());
@@ -929,11 +957,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   groupAdvanced.setEnabled(pluginActive);
 
   bool is2D = (comboAlgoMode.getSelectedItemIndex() == 1);
-  const juce::String smoothingTip =
-      is2D ? "Adjust patch-based similarity filtering strength\nto "
-             "control Patch-Based (High Quality) smoothing."
-           : "Apply temporal smoothing across spectral frames\nto reduce "
-             "musical noise bubbling artifacts.";
+  const juce::String smoothingTip = is2D ? kTipSmoothing2D : kTipSmoothing;
 
   sliderSmoothing.setTooltip(smoothingTip);
   lblSmoothing.setTooltip(smoothingTip);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -124,14 +124,14 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   setResizeLimits(840, 480, 1600, 1000);
   setSize(940, 560);
 
-  // Brand Header (click for About box with dependency versions)
-  brandLabel.setText("NOISE REPELLENT", juce::dontSendNotification);
-  brandLabel.setFont(juce::FontOptions(
-      NoiseRepellentLookAndFeel::kFontSizeBrand, juce::Font::bold));
-  brandLabel.setColour(juce::Label::textColourId, juce::Colours::white);
-  brandLabel.setTooltip(kTipAbout);
-  brandLabel.setMouseCursor(juce::MouseCursor::PointingHandCursor);
-  addAndMakeVisible(brandLabel);
+  // Brand Header (accessible button opening the About box with dependency
+  // versions)
+  brandButton.setName(NoiseRepellentLookAndFeel::kBrandButtonName);
+  brandButton.setButtonText("NOISE REPELLENT");
+  brandButton.setTooltip(kTipAbout);
+  brandButton.setMouseCursor(juce::MouseCursor::PointingHandCursor);
+  brandButton.onClick = [this]() { showAboutBox(); };
+  addAndMakeVisible(brandButton);
 
   // Preferences Header Button
   addAndMakeVisible(btnPreferences);
@@ -645,12 +645,6 @@ void NoiseRepellentAudioProcessorEditor::mouseEnter(
       juce::dontSendNotification);
 }
 
-void NoiseRepellentAudioProcessorEditor::mouseDown(
-    const juce::MouseEvent& event) {
-  if (event.originalComponent == &brandLabel)
-    showAboutBox();
-}
-
 void NoiseRepellentAudioProcessorEditor::showAboutBox() {
 #ifdef JucePlugin_VersionString
   const juce::String pluginVersion = JucePlugin_VersionString;
@@ -658,14 +652,15 @@ void NoiseRepellentAudioProcessorEditor::showAboutBox() {
   const juce::String pluginVersion = "dev";
 #endif
   const juce::String builtAgainst = SPECBLEACH_VERSION_STRING;
+  const juce::String expectedBanner =
+      juce::String("libspecbleach ") + builtAgainst;
   const char* runtime = specbleach_get_version_string();
   juce::String message;
   message << "Noise Repellent " << pluginVersion << " (GPL-3.0-or-later)\n\n"
           << "Built against libspecbleach " << builtAgainst << "\n"
           << "Loaded libspecbleach: "
           << (runtime != nullptr ? runtime : "unknown");
-  if (runtime != nullptr &&
-      juce::String(runtime).contains(builtAgainst) == false)
+  if (runtime != nullptr && juce::String(runtime) != expectedBanner)
     message << "\n\nNote: the loaded library differs from the build version.";
   juce::AlertWindow::showMessageBoxAsync(juce::MessageBoxIconType::InfoIcon,
                                          "About Noise Repellent", message, "OK");
@@ -1131,7 +1126,7 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   auto headerArea = area.removeFromTop(kHeaderH);
 
   // Left Title & Options Block
-  brandLabel.setBounds(
+  brandButton.setBounds(
       headerArea.removeFromLeft(kBrandW).withSizeKeepingCentre(kBrandW, kBrandH));
   headerArea.removeFromLeft(kTitleGap);
   btnPreferences.setBounds(

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -18,6 +18,30 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "PluginEditor.h"
+
+namespace {
+
+// Shared tooltip/instruction strings (single source; previously copy-pasted)
+const juce::String kTipDefaultInstruction =
+    "Loop a noise-only segment in your DAW and click Learn Noise\nto "
+    "capture a profile, then adjust reduction level.";
+const juce::String kTipAdaptive =
+    "Toggle continuous adaptive noise estimation.\nWorks standalone or on "
+    "top of a manually learned profile.";
+const juce::String kTipAggressiveness =
+    "Adjust noise profile aggressiveness using statistical variance.\n"
+    "(-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).";
+const juce::String kTipLink =
+    "Link broadband and tonal reduction controls together\nfor unified "
+    "adjustment.";
+const juce::String kTipResetCurve = "Reset reduction curve to flat 0 dB line.";
+const juce::String kTipThreshold =
+    "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).";
+const juce::String kTipMorphingUnavailable =
+    "Profile Morphing is available in Advanced Controls\nwhen a manual "
+    "learned noise profile is captured.";
+
+} // namespace
 #include "PluginProcessor.h"
 
 NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
@@ -30,11 +54,13 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   setResizeLimits(840, 480, 1600, 1000);
   setSize(940, 560);
 
-  // Brand Header
+  // Brand Header (click for About box with dependency versions)
   brandLabel.setText("NOISE REPELLENT", juce::dontSendNotification);
   brandLabel.setFont(juce::FontOptions(
       NoiseRepellentLookAndFeel::kFontSizeBrand, juce::Font::bold));
   brandLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+  brandLabel.setTooltip("About Noise Repellent");
+  brandLabel.setMouseCursor(juce::MouseCursor::PointingHandCursor);
   addAndMakeVisible(brandLabel);
 
   // Preferences Header Button
@@ -104,7 +130,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   btnAdvancedToggle.setClickingTogglesState(true);
   addAndMakeVisible(btnAdvancedToggle);
   btnAdvancedToggle.setColour(juce::TextButton::buttonColourId,
-                              juce::Colour(0xff3f4757));
+                              juce::Colour(NoiseRepellentLookAndFeel::kColorButtonOff));
   btnAdvancedToggle.setColour(juce::TextButton::buttonOnColourId,
                               NoiseRepellentLookAndFeel::kColorNoiseProfile);
   btnAdvancedToggle.onClick = [this]() {
@@ -114,7 +140,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
 
   btnDelta.setClickingTogglesState(true);
   btnDelta.setColour(juce::TextButton::buttonColourId,
-                     juce::Colour(0xff3f4757));
+                     juce::Colour(NoiseRepellentLookAndFeel::kColorButtonOff));
   btnDelta.setColour(juce::TextButton::buttonOnColourId,
                      NoiseRepellentLookAndFeel::kColorNoiseProfile);
   addAndMakeVisible(btnDelta);
@@ -122,7 +148,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
 
   btnBypass.setClickingTogglesState(true);
   btnBypass.setColour(juce::TextButton::buttonColourId,
-                      juce::Colour(0xff3f4757));
+                      juce::Colour(NoiseRepellentLookAndFeel::kColorButtonOff));
   btnBypass.setColour(juce::TextButton::buttonOnColourId,
                       NoiseRepellentLookAndFeel::kColorNoiseProfile);
   addAndMakeVisible(btnBypass);
@@ -141,19 +167,18 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   addAndMakeVisible(btnLearn);
   btnLearn.setColour(
       juce::TextButton::buttonColourId,
-      juce::Colour(0xffc0392b)); // Prominent Studio Crimson Red CTA
+      juce::Colour(NoiseRepellentLookAndFeel::kColorLearnCTA)); // Prominent Studio Crimson Red CTA
   btnLearn.setColour(juce::TextButton::buttonOnColourId,
-                     juce::Colour(0xffe74c3c)); // Active Learning Red
+                     juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive)); // Active Learning Red
   btnLearn.onClick = [this]() { updateProfileStatus(); };
 
   btnAdaptiveNoise.setClickingTogglesState(true);
   btnAdaptiveNoise.setButtonText("Adaptive");
   btnAdaptiveNoise.setTooltip(
-      "Toggle continuous adaptive noise estimation.\nWorks standalone or on "
-      "top of a manually learned profile.");
+      kTipAdaptive);
   addAndMakeVisible(btnAdaptiveNoise);
   btnAdaptiveNoise.setColour(juce::TextButton::buttonColourId,
-                             juce::Colour(0xff3f4757));
+                             juce::Colour(NoiseRepellentLookAndFeel::kColorButtonOff));
   btnAdaptiveNoise.setColour(juce::TextButton::buttonOnColourId,
                              NoiseRepellentLookAndFeel::kColorDenoising);
   btnAdaptiveNoise.onClick = [this]() {
@@ -262,7 +287,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   addAndMakeVisible(btnCurveToggle);
   btnCurveToggle.onClick = [this]() { updateLayout(); };
 
-  btnResetCurve.setTooltip("Reset reduction curve to flat 0 dB line.");
+  btnResetCurve.setTooltip(kTipResetCurve);
   addAndMakeVisible(btnResetCurve);
   btnResetCurve.onClick = [this]() {
     audioProcessor.resetCurveNodes();
@@ -476,8 +501,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
       "multi-section accumulation).");
   btnResetProfile.setTooltip("Reset noise profile and clear learned data.");
   btnAdaptiveNoise.setTooltip(
-      "Toggle continuous adaptive noise estimation.\nWorks standalone or on "
-      "top of a manually learned profile.");
+      kTipAdaptive);
   btnAdaptiveArrow.setTooltip(adaptiveMethodTip);
   comboMethod.setTooltip(adaptiveMethodTip);
   lblMethod.setTooltip(adaptiveMethodTip);
@@ -494,15 +518,10 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   sliderTonalRed.setTooltip(tonalRedTip);
   lblTonalRed.setTooltip(tonalRedTip);
 
-  sliderOffset.setTooltip(
-      "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).");
-  lblOffset.setTooltip(
-      "Shift noise profile threshold up or down\nin decibels (-12 to +12 dB).");
-  const juce::String aggrTip =
-      "Adjust noise profile aggressiveness using statistical variance.\n"
-      "(-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).";
-  sliderAggressiveness.setTooltip(aggrTip);
-  lblAggressiveness.setTooltip(aggrTip);
+  sliderOffset.setTooltip(kTipThreshold);
+  lblOffset.setTooltip(kTipThreshold);
+  sliderAggressiveness.setTooltip(kTipAggressiveness);
+  lblAggressiveness.setTooltip(kTipAggressiveness);
   btnDelta.setTooltip(
       "Listen to removed noise signal\n(residual audio output).");
   btnBypass.setTooltip(
@@ -517,13 +536,11 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   sliderWhitening.setTooltip(
       "Spectral whitening factor to equalize\nthe residual noise floor "
       "spectrum.");
-  btnLink.setTooltip(
-      "Link broadband and tonal reduction controls together\nfor unified "
-      "adjustment.");
+  btnLink.setTooltip(kTipLink);
   btnCurveToggle.setTooltip(
       "Enable per-frequency reduction bias curve overlay on spectral\n"
       "display. Shapes both broadband and tonal reduction.");
-  btnResetCurve.setTooltip("Reset reduction curve to flat 0 dB line.");
+  btnResetCurve.setTooltip(kTipResetCurve);
 
   // Initial Layout update
   isAdvancedVisible = btnAdvancedToggle.getToggleState();
@@ -535,7 +552,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
   footerTooltipLabel.setFont(juce::FontOptions(
       NoiseRepellentLookAndFeel::kFontSizeTooltip, juce::Font::plain));
   footerTooltipLabel.setColour(juce::Label::textColourId,
-                               juce::Colour(0xff94a3b8));
+                               juce::Colour(NoiseRepellentLookAndFeel::kColorFooterText));
   footerTooltipLabel.setJustificationType(juce::Justification::left);
   addAndMakeVisible(footerTooltipLabel);
 
@@ -543,8 +560,7 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
       audioProcessor.getAPVTS().getRawParameterValue("show_tooltips");
   if (showTooltipsParam == nullptr || showTooltipsParam->load() > 0.5f) {
     footerTooltipLabel.setText(
-        "Loop a noise-only segment in your DAW and click Learn Noise\nto "
-        "capture a profile, then adjust reduction level.",
+        kTipDefaultInstruction,
         juce::dontSendNotification);
   }
 
@@ -583,9 +599,34 @@ void NoiseRepellentAudioProcessorEditor::mouseEnter(
 
   // Default instruction when hovering over background / non-tooltip components
   footerTooltipLabel.setText(
-      "Loop a noise-only segment in your DAW and click Learn Noise\nto capture "
-      "a profile, then adjust reduction level.",
+      kTipDefaultInstruction,
       juce::dontSendNotification);
+}
+
+void NoiseRepellentAudioProcessorEditor::mouseDown(
+    const juce::MouseEvent& event) {
+  if (event.originalComponent == &brandLabel)
+    showAboutBox();
+}
+
+void NoiseRepellentAudioProcessorEditor::showAboutBox() {
+#ifdef JucePlugin_VersionString
+  const juce::String pluginVersion = JucePlugin_VersionString;
+#else
+  const juce::String pluginVersion = "dev";
+#endif
+  const juce::String builtAgainst = SPECBLEACH_VERSION_STRING;
+  const char* runtime = specbleach_get_version_string();
+  juce::String message;
+  message << "Noise Repellent " << pluginVersion << " (GPL-3.0-or-later)\n\n"
+          << "Built against libspecbleach " << builtAgainst << "\n"
+          << "Loaded libspecbleach: "
+          << (runtime != nullptr ? runtime : "unknown");
+  if (runtime != nullptr &&
+      juce::String(runtime).contains(builtAgainst) == false)
+    message << "\n\nNote: the loaded library differs from the build version.";
+  juce::AlertWindow::showMessageBoxAsync(juce::MessageBoxIconType::InfoIcon,
+                                         "About Noise Repellent", message, "OK");
 }
 
 void NoiseRepellentAudioProcessorEditor::mouseMove(
@@ -599,8 +640,7 @@ void NoiseRepellentAudioProcessorEditor::mouseExit(
       audioProcessor.getAPVTS().getRawParameterValue("show_tooltips");
   if (showTooltipsParam != nullptr && showTooltipsParam->load() > 0.5f) {
     footerTooltipLabel.setText(
-        "Loop a noise-only segment in your DAW and click Learn Noise\nto "
-        "capture a profile, then adjust reduction level.",
+        kTipDefaultInstruction,
         juce::dontSendNotification);
   } else {
     footerTooltipLabel.setText({}, juce::dontSendNotification);
@@ -626,8 +666,7 @@ void NoiseRepellentAudioProcessorEditor::handleAsyncUpdate() {
       audioProcessor.getAPVTS().getRawParameterValue("show_tooltips");
   if (showTooltipsParam != nullptr && showTooltipsParam->load() > 0.5f) {
     footerTooltipLabel.setText(
-        "Loop a noise-only segment in your DAW and click Learn Noise\nto "
-        "capture a profile, then adjust reduction level.",
+        kTipDefaultInstruction,
         juce::dontSendNotification);
   } else {
     footerTooltipLabel.setText({}, juce::dontSendNotification);
@@ -729,9 +768,9 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   if (isLearning) {
     btnLearn.setButtonText("Learning...");
     btnLearn.setColour(juce::TextButton::buttonColourId,
-                       juce::Colour(0xffe74c3c)); // Active Learning Red
+                       juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive)); // Active Learning Red
     btnLearn.setColour(juce::TextButton::buttonOnColourId,
-                       juce::Colour(0xffe74c3c));
+                       juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive));
     btnLearn.setTooltip(
         "Capturing noise profile from current audio playback...");
   } else if (hasProfile) {
@@ -746,9 +785,9 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   } else {
     btnLearn.setButtonText("Learn Noise");
     btnLearn.setColour(juce::TextButton::buttonColourId,
-                       juce::Colour(0xffc0392b)); // Prominent Crimson Red CTA
+                       juce::Colour(NoiseRepellentLookAndFeel::kColorLearnCTA)); // Prominent Crimson Red CTA
     btnLearn.setColour(juce::TextButton::buttonOnColourId,
-                       juce::Colour(0xffe74c3c)); // Active Learning Red
+                       juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive)); // Active Learning Red
     btnLearn.setTooltip(
         "Loop a noise-only segment in your DAW and click\nto capture a noise "
         "profile.");
@@ -762,7 +801,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
                                NoiseRepellentLookAndFeel::kColorDenoising);
   } else {
     btnAdaptiveNoise.setColour(juce::TextButton::buttonColourId,
-                               juce::Colour(0xff3f4757));
+                               juce::Colour(NoiseRepellentLookAndFeel::kColorButtonOff));
     btnAdaptiveNoise.setColour(juce::TextButton::buttonOnColourId,
                                NoiseRepellentLookAndFeel::kColorDenoising);
   }
@@ -795,18 +834,11 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   lblAggressiveness.setEnabled(aggressivenessEnabled);
 
   if (aggressivenessEnabled) {
-    const juce::String aggrTip =
-        "Adjust noise profile aggressiveness using statistical variance.\n"
-        "(-1.0: Median, 0.0: Mean, +1.0: Mean + 2 Standard Deviations).";
-    sliderAggressiveness.setTooltip(aggrTip);
-    lblAggressiveness.setTooltip(aggrTip);
+    sliderAggressiveness.setTooltip(kTipAggressiveness);
+    lblAggressiveness.setTooltip(kTipAggressiveness);
   } else {
-    sliderAggressiveness.setTooltip(
-        "Profile Morphing is available in Advanced Controls\nwhen a manual "
-        "learned noise profile is captured.");
-    lblAggressiveness.setTooltip(
-        "Profile Morphing is available in Advanced Controls\nwhen a manual "
-        "learned noise profile is captured.");
+    sliderAggressiveness.setTooltip(kTipMorphingUnavailable);
+    lblAggressiveness.setTooltip(kTipMorphingUnavailable);
   }
 
   // Reduction controls
@@ -822,9 +854,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   }
 
   if (canUnlink) {
-    btnLink.setTooltip(
-        "Link broadband and tonal reduction controls together\nfor unified "
-        "adjustment.");
+    btnLink.setTooltip(kTipLink);
   } else {
     btnLink.setTooltip(
         "Unlinking tonal reduction is disabled in Standalone Adaptive "
@@ -871,8 +901,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   lblTonalOffset.setEnabled(tonalOffsetEnabled);
 
   const juce::String masterOffsetTip =
-      isOffsetLinked ? "Shift noise profile threshold up or down\nin decibels "
-                       "(-12 to +12 dB)."
+      isOffsetLinked ? kTipThreshold
                      : "Shift broadband noise threshold up or down\nin "
                        "decibels (-12 to +12 dB).";
   const juce::String tonalOffsetTip =
@@ -915,7 +944,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
   if (isBypassed) {
     lblProfileStatus.setText("STATUS: BYPASSED", juce::dontSendNotification);
     lblProfileStatus.setColour(juce::Label::textColourId,
-                               juce::Colour(0xff808896));
+                               juce::Colour(NoiseRepellentLookAndFeel::kColorInactiveText));
   } else if (isDelta) {
     lblProfileStatus.setText("STATUS: DELTA (RESIDUAL LISTEN)",
                              juce::dontSendNotification);
@@ -925,7 +954,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
     lblProfileStatus.setText("STATUS: CAPTURING NOISE PROFILE...",
                              juce::dontSendNotification);
     lblProfileStatus.setColour(juce::Label::textColourId,
-                               juce::Colour(0xffe74c3c));
+                               juce::Colour(NoiseRepellentLookAndFeel::kColorLearnActive));
   } else if (isAdaptive && hasProfile) {
     lblProfileStatus.setText("STATUS: HYBRID (ADAPTIVE + PROFILE)",
                              juce::dontSendNotification);
@@ -945,7 +974,7 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
     lblProfileStatus.setText("STATUS: NO PROFILE (PASS-THROUGH)",
                              juce::dontSendNotification);
     lblProfileStatus.setColour(juce::Label::textColourId,
-                               juce::Colour(0xff808896));
+                               juce::Colour(NoiseRepellentLookAndFeel::kColorInactiveText));
   }
 }
 
@@ -968,7 +997,7 @@ void NoiseRepellentAudioProcessorEditor::paint(juce::Graphics& g) {
   g.fillAll(juce::Colour(0xff2c313c));
 
   if (isAdvancedVisible) {
-    g.setColour(juce::Colour(0xff4f586c));
+    g.setColour(NoiseRepellentLookAndFeel::kColorPanelBorder);
 
     float topY = (float)groupAdvanced.getY() + 22.0f;
     float bottomY = (float)groupAdvanced.getBottom() - 10.0f;
@@ -1025,7 +1054,7 @@ void NoiseRepellentAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
   contentArea.removeFromTop(4);
 
   // Subtitle explanation
-  g.setColour(juce::Colour(0xff94a3b8));
+  g.setColour(juce::Colour(NoiseRepellentLookAndFeel::kColorFooterText));
   g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
                               juce::Font::plain));
   g.drawText("Processing in progress. UI disabled for speed.", contentArea,
@@ -1033,24 +1062,63 @@ void NoiseRepellentAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
 }
 
 void NoiseRepellentAudioProcessorEditor::resized() {
-  auto area = getLocalBounds().reduced(12);
+  // Layout metrics (pixel geometry; values define the look, names the intent)
+  constexpr int kOuterMargin = 12;
+  constexpr int kHeaderH = 54;
+  constexpr int kBrandW = 135;
+  constexpr int kBrandH = 26;
+  constexpr int kTitleGap = 4;
+  constexpr int kPrefsBtn = 22;
+  constexpr int kBypassW = 60;
+  constexpr int kHeaderBtnH = 24;
+  constexpr int kHeaderBtnGap = 6;
+  constexpr int kDeltaW = 50;
+  constexpr int kAlgoColH = 44;
+  constexpr int kAlgoLabelH = 15;
+  constexpr int kAlgoLabelGap = 3;
+  constexpr int kAlgoComboH = 26;
+  constexpr int kGroupPadX = 6;
+  constexpr int kGroupPadY = 4;
+  constexpr int kGroupTitleH = 10;
+  constexpr int kProfileBtnH = 24;
+  constexpr int kSectionGap = 8;
+  constexpr int kFooterGap = 8;
+  constexpr int kAdvPanelH = 68;
+  constexpr int kAdvLabelH = 16;
+  constexpr int kAdvLabelGap = 2;
+  constexpr int kAdvSliderH = 20;
+  constexpr int kInnerPad = 10;
+  constexpr int kBankLinkedW = 95;
+  constexpr int kBankUnlinkedW = 155;
+  constexpr int kBankLabelH = 16;
+  constexpr int kBankLabelGap = 2;
+  constexpr int kBankBtnH = 22;
+  constexpr int kBankBtnGap = 6;
+  constexpr int kBankSplitGap = 6;
+  constexpr int kCurveResetW = 22;
+  constexpr int kCurveResetGap = 2;
+  constexpr int kBankGutter = 10;
+  constexpr int kFooterSplitPct = 55;
+  constexpr int kAdvTitleH = 12;
+
+  auto area = getLocalBounds().reduced(kOuterMargin);
 
   // Header (Fixed 54px with spacious headroom for profile controls)
-  auto headerArea = area.removeFromTop(54);
+  auto headerArea = area.removeFromTop(kHeaderH);
 
   // Left Title & Options Block
   brandLabel.setBounds(
-      headerArea.removeFromLeft(135).withSizeKeepingCentre(135, 26));
-  headerArea.removeFromLeft(4);
+      headerArea.removeFromLeft(kBrandW).withSizeKeepingCentre(kBrandW, kBrandH));
+  headerArea.removeFromLeft(kTitleGap);
   btnPreferences.setBounds(
-      headerArea.removeFromLeft(22).withSizeKeepingCentre(22, 22));
+      headerArea.removeFromLeft(kPrefsBtn).withSizeKeepingCentre(kPrefsBtn, kPrefsBtn));
 
   // Right Action Buttons Block
   btnBypass.setBounds(
-      headerArea.removeFromRight(60).withSizeKeepingCentre(60, 24));
-  headerArea.removeFromRight(6);
+      headerArea.removeFromRight(kBypassW).withSizeKeepingCentre(kBypassW, kHeaderBtnH));
+  headerArea.removeFromRight(kHeaderBtnGap);
   btnDelta.setBounds(
-      headerArea.removeFromRight(50).withSizeKeepingCentre(50, 24));
+      headerArea.removeFromRight(kDeltaW).withSizeKeepingCentre(kDeltaW, kHeaderBtnH));
 
   constexpr int kHeaderGap = 16;
   headerArea.removeFromLeft(kHeaderGap);
@@ -1078,11 +1146,11 @@ void NoiseRepellentAudioProcessorEditor::resized() {
 
   // Processing Engine Column in Header
   auto algoCol = headerArea.removeFromLeft(kAlgoWidth);
-  int algoYPad = std::max(0, (algoCol.getHeight() - 44) / 2);
+  int algoYPad = std::max(0, (algoCol.getHeight() - kAlgoColH) / 2);
   algoCol.removeFromTop(algoYPad);
-  lblAlgoHeader.setBounds(algoCol.removeFromTop(15));
-  algoCol.removeFromTop(3);
-  comboAlgoMode.setBounds(algoCol.removeFromTop(26));
+  lblAlgoHeader.setBounds(algoCol.removeFromTop(kAlgoLabelH));
+  algoCol.removeFromTop(kAlgoLabelGap);
+  comboAlgoMode.setBounds(algoCol.removeFromTop(kAlgoComboH));
 
   headerArea.removeFromLeft(kHeaderGap);
 
@@ -1090,28 +1158,28 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   auto profileGroupArea = headerArea.removeFromLeft(kProfileWidth);
   groupProfile.setBounds(profileGroupArea);
 
-  auto profileInner = profileGroupArea.reduced(6, 4);
-  profileInner.removeFromTop(10);
+  auto profileInner = profileGroupArea.reduced(kGroupPadX, kGroupPadY);
+  profileInner.removeFromTop(kGroupTitleH);
 
   auto profileRow = profileInner;
 
   auto bLearn = profileRow.removeFromLeft(kLearnW);
-  btnLearn.setBounds(bLearn.withSizeKeepingCentre(kLearnW, 24));
+  btnLearn.setBounds(bLearn.withSizeKeepingCentre(kLearnW, kProfileBtnH));
   profileRow.removeFromLeft(kBtnGap);
 
   auto bAdapt = profileRow.removeFromLeft(kAdaptW);
-  btnAdaptiveNoise.setBounds(bAdapt.withSizeKeepingCentre(kAdaptW, 24));
+  btnAdaptiveNoise.setBounds(bAdapt.withSizeKeepingCentre(kAdaptW, kProfileBtnH));
 
   if (isAdvancedVisible) {
     auto bAdaptArrow = profileRow.removeFromLeft(kArrowW);
-    btnAdaptiveArrow.setBounds(bAdaptArrow.withSizeKeepingCentre(kArrowW, 24));
+    btnAdaptiveArrow.setBounds(bAdaptArrow.withSizeKeepingCentre(kArrowW, kProfileBtnH));
   }
   profileRow.removeFromLeft(kBtnGap);
 
   auto bReset = profileRow.removeFromLeft(kResetW);
-  btnResetProfile.setBounds(bReset.withSizeKeepingCentre(kResetW, 24));
+  btnResetProfile.setBounds(bReset.withSizeKeepingCentre(kResetW, kProfileBtnH));
 
-  area.removeFromTop(8);
+  area.removeFromTop(kSectionGap);
 
   // Footer bar
   auto* showTooltipsParam =
@@ -1130,11 +1198,11 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   if (showFooter) {
     constexpr int kFooterHeight = 34;
     auto footerArea = area.removeFromBottom(kFooterHeight);
-    area.removeFromBottom(8);
+    area.removeFromBottom(kFooterGap);
 
     if (showTooltips && showHud) {
       auto leftFooter =
-          footerArea.removeFromLeft(footerArea.getWidth() * 55 / 100);
+          footerArea.removeFromLeft(footerArea.getWidth() * kFooterSplitPct / 100);
       footerTooltipLabel.setBounds(leftFooter);
       lblProfileStatus.setBounds(footerArea);
       lblProfileStatus.setJustificationType(juce::Justification::centredRight);
@@ -1149,11 +1217,11 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   // Bottom Collapsible Advanced Panel (4 Controls: Smoothing, Masking,
   // Whitening, Aggressiveness)
   if (isAdvancedVisible) {
-    auto advArea = area.removeFromBottom(68);
+    auto advArea = area.removeFromBottom(kAdvPanelH);
     groupAdvanced.setBounds(advArea);
 
-    auto advInner = advArea.reduced(10, 4);
-    advInner.removeFromTop(12);
+    auto advInner = advArea.reduced(kInnerPad, kGroupPadY);
+    advInner.removeFromTop(kAdvTitleH);
 
     constexpr int kNumGaps = 3;
     constexpr int kGapW = 14;
@@ -1162,60 +1230,60 @@ void NoiseRepellentAudioProcessorEditor::resized() {
 
     // 1. Smoothing Slider
     auto s1 = advInner.removeFromLeft(itemW);
-    lblSmoothing.setBounds(s1.removeFromTop(16));
-    s1.removeFromTop(2);
-    sliderSmoothing.setBounds(s1.removeFromTop(20));
+    lblSmoothing.setBounds(s1.removeFromTop(kAdvLabelH));
+    s1.removeFromTop(kAdvLabelGap);
+    sliderSmoothing.setBounds(s1.removeFromTop(kAdvSliderH));
 
     // 2. Masking Slider
     advInner.removeFromLeft(kGapW);
     auto s2 = advInner.removeFromLeft(itemW);
-    lblMasking.setBounds(s2.removeFromTop(16));
-    s2.removeFromTop(2);
-    sliderMasking.setBounds(s2.removeFromTop(20));
+    lblMasking.setBounds(s2.removeFromTop(kAdvLabelH));
+    s2.removeFromTop(kAdvLabelGap);
+    sliderMasking.setBounds(s2.removeFromTop(kAdvSliderH));
 
     // 3. Whitening Slider
     advInner.removeFromLeft(kGapW);
     auto s3 = advInner.removeFromLeft(itemW);
-    lblWhitening.setBounds(s3.removeFromTop(16));
-    s3.removeFromTop(2);
-    sliderWhitening.setBounds(s3.removeFromTop(20));
+    lblWhitening.setBounds(s3.removeFromTop(kAdvLabelH));
+    s3.removeFromTop(kAdvLabelGap);
+    sliderWhitening.setBounds(s3.removeFromTop(kAdvSliderH));
 
     // 4. Aggressiveness Slider
     advInner.removeFromLeft(kGapW);
     auto s4 = advInner;
-    lblAggressiveness.setBounds(s4.removeFromTop(16));
-    s4.removeFromTop(2);
-    sliderAggressiveness.setBounds(s4.removeFromTop(20));
+    lblAggressiveness.setBounds(s4.removeFromTop(kAdvLabelH));
+    s4.removeFromTop(kAdvLabelGap);
+    sliderAggressiveness.setBounds(s4.removeFromTop(kAdvSliderH));
 
-    area.removeFromBottom(8);
+    area.removeFromBottom(kSectionGap);
   }
 
   // Main Denoising & Spectrum Canvas
   groupDenoising.setBounds(area);
 
-  auto denoiseInner = area.reduced(10);
-  denoiseInner.removeFromTop(10);
+  auto denoiseInner = area.reduced(kInnerPad);
+  denoiseInner.removeFromTop(kGroupTitleH);
 
   bool isLinked = !isAdvancedVisible || btnLink.getToggleState();
-  int faderBankWidth = isLinked ? 95 : 155;
+  int faderBankWidth = isLinked ? kBankLinkedW : kBankUnlinkedW;
 
   auto faderBankArea = denoiseInner.removeFromLeft(faderBankWidth);
-  lblReductionHeader.setBounds(faderBankArea.removeFromTop(16));
-  faderBankArea.removeFromTop(2);
+  lblReductionHeader.setBounds(faderBankArea.removeFromTop(kBankLabelH));
+  faderBankArea.removeFromTop(kBankLabelGap);
 
   if (isAdvancedVisible) {
-    btnLink.setBounds(faderBankArea.removeFromTop(22));
-    faderBankArea.removeFromTop(6);
+    btnLink.setBounds(faderBankArea.removeFromTop(kBankBtnH));
+    faderBankArea.removeFromTop(kBankBtnGap);
 
     // Carve bottom area of faderBankArea for Curve split button [ Curve ][ ↺ ]
     bool isCurveOn = btnCurveToggle.getToggleState();
-    auto faderBottomArea = faderBankArea.removeFromBottom(22);
-    faderBankArea.removeFromBottom(6);
+    auto faderBottomArea = faderBankArea.removeFromBottom(kBankBtnH);
+    faderBankArea.removeFromBottom(kBankBtnGap);
 
     if (isCurveOn) {
       btnCurveToggle.setBounds(
-          faderBottomArea.removeFromLeft(faderBottomArea.getWidth() - 22));
-      faderBottomArea.removeFromLeft(2);
+          faderBottomArea.removeFromLeft(faderBottomArea.getWidth() - kCurveResetW));
+      faderBottomArea.removeFromLeft(kCurveResetGap);
       btnResetCurve.setBounds(faderBottomArea);
     } else {
       btnCurveToggle.setBounds(faderBottomArea);
@@ -1225,60 +1293,60 @@ void NoiseRepellentAudioProcessorEditor::resized() {
   if (isLinked) {
     sliderMasterRed.setBounds(faderBankArea);
   } else {
-    int colW = (faderBankArea.getWidth() - 6) / 2;
+    int colW = (faderBankArea.getWidth() - kBankSplitGap) / 2;
 
     auto leftCol = faderBankArea.removeFromLeft(colW);
-    faderBankArea.removeFromLeft(6);
+    faderBankArea.removeFromLeft(kBankSplitGap);
     auto rightCol = faderBankArea;
 
-    lblMasterRed.setBounds(leftCol.removeFromTop(16));
-    leftCol.removeFromTop(2);
+    lblMasterRed.setBounds(leftCol.removeFromTop(kBankLabelH));
+    leftCol.removeFromTop(kBankLabelGap);
     sliderMasterRed.setBounds(leftCol);
 
-    lblTonalRed.setBounds(rightCol.removeFromTop(16));
-    rightCol.removeFromTop(2);
+    lblTonalRed.setBounds(rightCol.removeFromTop(kBankLabelH));
+    rightCol.removeFromTop(kBankLabelGap);
     sliderTonalRed.setBounds(rightCol);
   }
 
-  denoiseInner.removeFromLeft(10);
+  denoiseInner.removeFromLeft(kBankGutter);
 
   // Right-side Threshold (Noise Profile Offset) vertical fader bank (symmetric
   // to reduction sliders on left)
   bool isOffsetLinked = !isAdvancedVisible || btnLinkOffset.getToggleState();
-  int offsetBankWidth = isOffsetLinked ? 95 : 155;
+  int offsetBankWidth = isOffsetLinked ? kBankLinkedW : kBankUnlinkedW;
 
   auto offsetBankArea = denoiseInner.removeFromRight(offsetBankWidth);
-  denoiseInner.removeFromRight(10);
+  denoiseInner.removeFromRight(kBankGutter);
 
-  lblOffset.setBounds(offsetBankArea.removeFromTop(16));
-  offsetBankArea.removeFromTop(2);
+  lblOffset.setBounds(offsetBankArea.removeFromTop(kBankLabelH));
+  offsetBankArea.removeFromTop(kBankLabelGap);
 
   if (isAdvancedVisible) {
-    btnLinkOffset.setBounds(offsetBankArea.removeFromTop(22));
-    offsetBankArea.removeFromTop(6);
+    btnLinkOffset.setBounds(offsetBankArea.removeFromTop(kBankBtnH));
+    offsetBankArea.removeFromTop(kBankBtnGap);
   }
 
   // Carve bottom area of offsetBankArea for Advanced Controls button below
   // threshold slider
-  auto offsetBottomArea = offsetBankArea.removeFromBottom(22);
-  offsetBankArea.removeFromBottom(6);
+  auto offsetBottomArea = offsetBankArea.removeFromBottom(kBankBtnH);
+  offsetBankArea.removeFromBottom(kBankBtnGap);
   btnAdvancedToggle.setBounds(offsetBottomArea);
 
   if (isOffsetLinked) {
     sliderOffset.setBounds(offsetBankArea);
   } else {
-    int colW = (offsetBankArea.getWidth() - 6) / 2;
+    int colW = (offsetBankArea.getWidth() - kBankSplitGap) / 2;
 
     auto leftCol = offsetBankArea.removeFromLeft(colW);
-    offsetBankArea.removeFromLeft(6);
+    offsetBankArea.removeFromLeft(kBankSplitGap);
     auto rightCol = offsetBankArea;
 
-    lblMasterOffset.setBounds(leftCol.removeFromTop(16));
-    leftCol.removeFromTop(2);
+    lblMasterOffset.setBounds(leftCol.removeFromTop(kBankLabelH));
+    leftCol.removeFromTop(kBankLabelGap);
     sliderOffset.setBounds(leftCol);
 
-    lblTonalOffset.setBounds(rightCol.removeFromTop(16));
-    rightCol.removeFromTop(2);
+    lblTonalOffset.setBounds(rightCol.removeFromTop(kBankLabelH));
+    rightCol.removeFromTop(kBankLabelGap);
     sliderTonalOffset.setBounds(rightCol);
   }
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -38,6 +38,7 @@ public:
   void paintOverChildren(juce::Graphics&) override;
   void resized() override;
   void timerCallback() override;
+  void mouseDown(const juce::MouseEvent&) override;
   void mouseEnter(const juce::MouseEvent&) override;
   void mouseMove(const juce::MouseEvent&) override;
   void mouseExit(const juce::MouseEvent&) override;
@@ -145,6 +146,7 @@ private:
   void updateLayout();
   void updateSliderLabels();
   void updateProfileStatus();
+  void showAboutBox();
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(
       NoiseRepellentAudioProcessorEditor)

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -38,7 +38,6 @@ public:
   void paintOverChildren(juce::Graphics&) override;
   void resized() override;
   void timerCallback() override;
-  void mouseDown(const juce::MouseEvent&) override;
   void mouseEnter(const juce::MouseEvent&) override;
   void mouseMove(const juce::MouseEvent&) override;
   void mouseExit(const juce::MouseEvent&) override;
@@ -54,7 +53,7 @@ private:
   std::atomic<bool> tooltipStateDirty{false};
 
   // Header Controls
-  juce::Label brandLabel;
+  juce::TextButton brandButton;
   juce::TextButton btnPreferences{juce::CharPointer_UTF8("\xe2\x96\xbc")};
   juce::Label lblAlgoHeader{"lblAlgoHeader", "SMOOTHING QUALITY"};
   juce::ComboBox comboAlgoMode;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -22,6 +22,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
 #include <cstring>
 
+namespace {
+
+// STFT frame sent to libspecbleach (matches library examples/header docs).
+constexpr float kEngineFrameSizeMs = 46.0f;
+// Silence gate: amplitude floor ~-100 dB, i.e. the amplitude-domain twin of
+// libspecbleach's ESTIMATOR_SILENCE_THRESHOLD (1e-10 power).
+constexpr float kSilenceAmplitudeFloor = 1e-5f;
+// Divide-by-zero guards for the reduction-curve Hermite spline.
+constexpr float kSplineSlopeEpsilon = 1e-5f;
+constexpr float kSplineParamEpsilon = 1e-9f;
+
+} // namespace
+
 NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
     : AudioProcessor(
           BusesProperties()
@@ -32,7 +45,7 @@ NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
   bypassParameter = dynamic_cast<juce::AudioParameterBool*>(
       parameters.getParameter("bypass"));
   juce::ignoreUnused(specbleach_get_version_string());
-  DBG("libspecbleach " << specbleach_get_version_string());
+  DBG(specbleach_get_version_string()); // banner is "libspecbleach X.Y.Z"
 }
 
 NoiseRepellentAudioProcessor::~NoiseRepellentAudioProcessor() {
@@ -236,12 +249,12 @@ void NoiseRepellentAudioProcessor::interpolateCurve(uint32_t numBins) {
 
   std::vector<float> m(numNodes, 0.0f);
   if (numNodes > 2) {
-    m.front() = (dX.front() > 1e-5f) ? dY.front() / dX.front() : 0.0f;
-    m.back() = (dX.back() > 1e-5f) ? dY.back() / dX.back() : 0.0f;
+    m.front() = (dX.front() > kSplineSlopeEpsilon) ? dY.front() / dX.front() : 0.0f;
+    m.back() = (dX.back() > kSplineSlopeEpsilon) ? dY.back() / dX.back() : 0.0f;
 
     for (size_t i = 1; i < numNodes - 1; ++i) {
-      float secant1 = (dX[i - 1] > 1e-5f) ? dY[i - 1] / dX[i - 1] : 0.0f;
-      float secant2 = (dX[i] > 1e-5f) ? dY[i] / dX[i] : 0.0f;
+      float secant1 = (dX[i - 1] > kSplineSlopeEpsilon) ? dY[i - 1] / dX[i - 1] : 0.0f;
+      float secant2 = (dX[i] > kSplineSlopeEpsilon) ? dY[i] / dX[i] : 0.0f;
       if (secant1 * secant2 <= 0.0f) {
         m[i] = 0.0f;
       } else {
@@ -249,7 +262,7 @@ void NoiseRepellentAudioProcessor::interpolateCurve(uint32_t numBins) {
       }
     }
   } else {
-    float secant = (dX.front() > 1e-5f) ? dY.front() / dX.front() : 0.0f;
+    float secant = (dX.front() > kSplineSlopeEpsilon) ? dY.front() / dX.front() : 0.0f;
     m[0] = secant;
     m[1] = secant;
   }
@@ -280,7 +293,7 @@ void NoiseRepellentAudioProcessor::interpolateCurve(uint32_t numBins) {
       if (binNormX >= sortedNodes[i].normX &&
           binNormX <= sortedNodes[i + 1].normX) {
         float dx = dX[i];
-        float t = (dx > 1e-9f) ? (binNormX - sortedNodes[i].normX) / dx : 0.0f;
+        float t = (dx > kSplineParamEpsilon) ? (binNormX - sortedNodes[i].normX) / dx : 0.0f;
         float t2 = t * t;
         float t3 = t2 * t;
 
@@ -298,46 +311,20 @@ void NoiseRepellentAudioProcessor::interpolateCurve(uint32_t numBins) {
   }
 }
 
-// Resamples a persisted noise profile to whatever spectrum size the group
-// expects, then loads it into one of its channel engines.
-static bool loadProfileGroupSafe(specbleach_stereo* group, uint32_t channel,
-                                 const float* data, uint32_t size,
-                                 uint32_t blockCount, int mode) {
-  if (group == nullptr || data == nullptr || size == 0)
-    return false;
-
-  const uint32_t targetSize = specbleach_stereo_get_noise_profile_size(group);
-  if (targetSize == 0)
-    return false;
-
-  if (size == targetSize) {
-    return specbleach_stereo_load_noise_profile_for_channel(
-        group, channel, data, size, blockCount, mode);
-  } else if (targetSize == 1) {
-    float resampledSample = data[0];
-    return specbleach_stereo_load_noise_profile_for_channel(
-        group, channel, &resampledSample, 1, blockCount, mode);
-  } else {
-    std::vector<float> resampled(targetSize);
-    float maxSrcIdx = static_cast<float>(size - 1);
-    float maxTargetIdx = static_cast<float>(targetSize - 1);
-    for (uint32_t i = 0; i < targetSize; ++i) {
-      float normPos = static_cast<float>(i) / maxTargetIdx;
-      float exactIdx = normPos * maxSrcIdx;
-      uint32_t idx0 = std::clamp(static_cast<uint32_t>(exactIdx), 0u, size - 1);
-      uint32_t idx1 = std::min(idx0 + 1, size - 1);
-      float frac = exactIdx - static_cast<float>(idx0);
-      resampled[i] = (1.0f - frac) * data[idx0] + frac * data[idx1];
-    }
-    return specbleach_stereo_load_noise_profile_for_channel(
-        group, channel, resampled.data(), targetSize, blockCount, mode);
-  }
-}
-
 void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
+  // Engine width follows the bus layout (mono hosts get a 1-engine group;
+  // the library supports 1 channel explicitly). Rebuild on sample-rate OR
+  // channel-count change — hosts can re-layout without touching the rate.
+  const uint32_t wantedChannels = static_cast<uint32_t>(
+      std::max({getTotalNumInputChannels(), getTotalNumOutputChannels(), 1}));
+  const uint32_t currentGroupChannels =
+      (engineGroup != nullptr)
+          ? specbleach_stereo_get_channel_count(engineGroup.get())
+          : 0;
   const bool needNewEngines =
       (engineGroup == nullptr ||
-       std::abs(currentSampleRate - sampleRate) > 0.001);
+       std::abs(currentSampleRate - sampleRate) > 0.001 ||
+       currentGroupChannels != wantedChannels);
 
   if (!needNewEngines)
     return;
@@ -361,13 +348,13 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
       for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
            mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
         if (!specbleach_stereo_profile_available_for_channel(engineGroup.get(),
-                                                             channel, mode))
+                                                             channel, static_cast<SpecbleachProfileMode>(mode)))
           continue;
-        float* profile = specbleach_stereo_get_noise_profile_for_channel(
-            engineGroup.get(), channel, mode);
+        const float* profile = specbleach_stereo_get_noise_profile_for_channel(
+            engineGroup.get(), channel, static_cast<SpecbleachProfileMode>(mode));
         const uint32_t blockCount =
             specbleach_stereo_get_profile_block_count_for_channel(
-                engineGroup.get(), channel, mode);
+                engineGroup.get(), channel, static_cast<SpecbleachProfileMode>(mode));
         if (profile != nullptr && sz > 0) {
           savedProfiles.push_back({static_cast<int>(channel), mode, sz,
                                    blockCount,
@@ -380,23 +367,22 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   // Free existing group before allocating the replacement
   engineGroup.reset();
 
-  uint32_t channels = preparedNumChannels;
-  if (channels < 2) {
-    channels = static_cast<uint32_t>(
-        std::max({getTotalNumInputChannels(), getTotalNumOutputChannels(), 2}));
-  }
+  uint32_t channels = wantedChannels;
 
   const uint32_t sampleRateUint = static_cast<uint32_t>(sampleRate);
-  engineGroup = specbleach::make_stereo_group(sampleRateUint, 50.0f, channels);
+  engineGroup = specbleach::make_stereo_group(sampleRateUint,
+                                                kEngineFrameSizeMs, channels);
 
   currentSampleRate = sampleRate;
   preparedNumChannels = channels;
 
-  // Restore backed-up profiles into the new group
+  // Restore backed-up profiles into the new group (library resamples to
+  // the native spectrum size when the sample rate changed)
   for (const auto& item : savedProfiles) {
-    loadProfileGroupSafe(engineGroup.get(), static_cast<uint32_t>(item.channel),
-                         item.data.data(), item.size, item.blockCount,
-                         item.mode);
+    specbleach_stereo_load_noise_profile_resampled_for_channel(
+        engineGroup.get(), static_cast<uint32_t>(item.channel),
+        item.data.data(), item.size, item.blockCount,
+        static_cast<SpecbleachProfileMode>(item.mode));
   }
 
   // Restore state pending profiles if loaded before prepareToPlay
@@ -405,17 +391,21 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
     if (item.channel == 1)
       hasCh1 = true;
 
-    loadProfileGroupSafe(engineGroup.get(), static_cast<uint32_t>(item.channel),
-                         item.data.data(), item.size, item.blockCount,
-                         item.mode);
+    specbleach_stereo_load_noise_profile_resampled_for_channel(
+        engineGroup.get(), static_cast<uint32_t>(item.channel),
+        item.data.data(), item.size, item.blockCount,
+        static_cast<SpecbleachProfileMode>(item.mode));
   }
 
   // Legacy states may lack channel 1 profiles — fall back from channel 0
-  if (!hasCh1) {
+  // (stereo groups only; mono groups have no channel 1)
+  if (!hasCh1 &&
+      specbleach_stereo_get_channel_count(engineGroup.get()) > 1) {
     for (const auto& item : pendingProfiles) {
       if (item.channel == 0) {
-        loadProfileGroupSafe(engineGroup.get(), 1u, item.data.data(), item.size,
-                             item.blockCount, item.mode);
+        specbleach_stereo_load_noise_profile_resampled_for_channel(
+            engineGroup.get(), 1u, item.data.data(), item.size,
+            item.blockCount, static_cast<SpecbleachProfileMode>(item.mode));
       }
     }
   }
@@ -439,7 +429,7 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   const int bufferCapacity = std::max(samplesPerBlock, 16384);
   preparedBlockSize = static_cast<uint32_t>(bufferCapacity);
   preparedNumChannels = static_cast<uint32_t>(
-      std::max({getTotalNumInputChannels(), getTotalNumOutputChannels(), 2}));
+      std::max({getTotalNumInputChannels(), getTotalNumOutputChannels(), 1}));
 
   juce::dsp::ProcessSpec spec;
   spec.sampleRate = sampleRate;
@@ -458,10 +448,7 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
 
   // Pre-allocate persistent buffers to prevent audio-thread allocations
   dryInputL.resize(static_cast<size_t>(bufferCapacity), 0.0f);
-  wetScratchA.setSize(static_cast<int>(preparedNumChannels), bufferCapacity,
-                      false, false, true);
   jassert(dryInputL.size() >= static_cast<size_t>(samplesPerBlock));
-  jassert(wetScratchA.getNumSamples() >= samplesPerBlock);
 
   // Pre-reserve tonal peak storage in every FIFO slot so push_back on the
   // audio thread never reallocates
@@ -585,7 +572,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   p.reduction_gain = reductionGain;
   p.smoothing_factor = smoothingNorm;
   p.smoothing_mode =
-      (algoMode == 1) ? SB_SMOOTHING_NLM_2D : SB_SMOOTHING_TEMPORAL;
+      (algoMode == 1) ? SPECBLEACH_SMOOTHING_NLM_2D : SPECBLEACH_SMOOTHING_TEMPORAL;
   p.whitening_factor = whiteningNorm;
   p.adaptive_noise = adaptiveNoise;
   p.noise_estimation_method =
@@ -607,7 +594,7 @@ void NoiseRepellentAudioProcessor::processBlock(
   // STFT+denoise (was culprit for idle > denoising and no-playback CPU).
   bool isSilent = false;
   if (!learnNoise) {
-    const float thresh = 1e-5f;
+    const float thresh = kSilenceAmplitudeFloor;
     isSilent = true;
     for (int ch = 0; ch < numChannels && isSilent; ++ch) {
       const float* d = buffer.getReadPointer(ch);
@@ -644,25 +631,21 @@ void NoiseRepellentAudioProcessor::processBlock(
       buffer.clear();
     }
   } else if (engineGroup != nullptr) {
+    // Process 1:1 up to the buffer width (mono hosts get a 1-engine group;
+    // layouts beyond stereo are rejected in isBusesLayoutSupported).
     const uint32_t groupChannels = std::min<uint32_t>(
-        specbleach_stereo_get_channel_count(engineGroup.get()), 2u);
+        specbleach_stereo_get_channel_count(engineGroup.get()),
+        static_cast<uint32_t>(numChannels));
     const float* inPtrs[2] = {nullptr, nullptr};
-    float* sinkA = wetScratchA.getNumChannels() > 1
-                       ? wetScratchA.getWritePointer(1)
-                       : nullptr;
-    for (uint32_t ch = 0; ch < groupChannels; ++ch)
-      inPtrs[ch] = buffer.getReadPointer(
-          ch < static_cast<uint32_t>(numChannels) ? static_cast<int>(ch) : 0);
+    for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
+      inPtrs[ch] = buffer.getReadPointer(static_cast<int>(ch));
 
     float* outPtrs[2] = {nullptr, nullptr};
-    for (uint32_t ch = 0; ch < groupChannels; ++ch) {
-      outPtrs[ch] =
-          (ch < static_cast<uint32_t>(numChannels))
-              ? buffer.getWritePointer(static_cast<int>(ch))
-              : ((sinkA != nullptr) ? sinkA : buffer.getWritePointer(0));
-    }
+    for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
+      outPtrs[ch] = buffer.getWritePointer(static_cast<int>(ch));
 
-    specbleach_stereo_load_parameters(engineGroup.get(), &p, sizeof(p));
+    specbleach_stereo_load_parameters(engineGroup.get(), &p,
+                                        SPECBLEACH_PARAMETERS_SIZE);
     specbleach_stereo_process(
         engineGroup.get(), static_cast<uint32_t>(numSamples), inPtrs, outPtrs);
     // Latency is constant for both smoothing modes — no wet compensation
@@ -762,7 +745,7 @@ void NoiseRepellentAudioProcessor::processBlock(
             // Tonal peaks for silent when unlinked
             if ((!frame.isLinked || !frame.isOffsetLinked) &&
                 frame.hasNoiseProfile) {
-              std::array<float, 32> peakBuf{};
+              std::array<float, kMaxTonalPeaks> peakBuf{};
               uint32_t n = specbleach_stereo_get_tonal_peaks_for_channel(
                   engineGroup.get(), 0u, peakBuf.data(),
                   static_cast<uint32_t>(peakBuf.size()));
@@ -851,37 +834,31 @@ void NoiseRepellentAudioProcessor::processBlock(
         juce::SpinLock::ScopedTryLockType profileTryLock(profileLock);
         if (profileTryLock.isLocked() && engineGroup != nullptr) {
           const auto* vizGroup = engineGroup.get();
-          for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
-               mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
-            if (specbleach_stereo_profile_available_for_channel(
-                    const_cast<specbleach_stereo*>(vizGroup), 0u, mode)) {
-              profileHasAnyMode = true;
-              break;
-            }
-          }
+          profileHasAnyMode =
+              specbleach_stereo_has_any_profile_for_channel(vizGroup, 0u);
 
           if (isLearning) {
             actualNoiseProfile =
                 specbleach_stereo_get_noise_profile_for_channel(
-                    const_cast<specbleach_stereo*>(vizGroup), 0u, 1);
+                    vizGroup, 0u, SPECBLEACH_PROFILE_ROLLING_MEAN);
             profileSize = specbleach_stereo_get_noise_profile_size(
-                const_cast<specbleach_stereo*>(vizGroup));
+                vizGroup);
             profileAvailable =
                 (actualNoiseProfile != nullptr && profileSize > 0);
           } else {
             actualNoiseProfile =
                 specbleach_stereo_get_active_noise_profile_for_channel(
-                    const_cast<specbleach_stereo*>(vizGroup), 0u);
+                    vizGroup, 0u);
             profileSize = specbleach_stereo_get_noise_profile_size(
-                const_cast<specbleach_stereo*>(vizGroup));
+                vizGroup);
             if (!actualNoiseProfile && profileHasAnyMode) {
               for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
                    mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
                 if (specbleach_stereo_profile_available_for_channel(
-                        const_cast<specbleach_stereo*>(vizGroup), 0u, mode)) {
+                        vizGroup, 0u, static_cast<SpecbleachProfileMode>(mode))) {
                   actualNoiseProfile =
                       specbleach_stereo_get_noise_profile_for_channel(
-                          const_cast<specbleach_stereo*>(vizGroup), 0u, mode);
+                          vizGroup, 0u, static_cast<SpecbleachProfileMode>(mode));
                   if (actualNoiseProfile)
                     break;
                 }
@@ -948,7 +925,7 @@ void NoiseRepellentAudioProcessor::processBlock(
 
           // Query libspecbleach directly for reported tonal peak frequencies
           // computed on this real noise profile
-          std::array<float, 32> peakBuf{};
+          std::array<float, kMaxTonalPeaks> peakBuf{};
           uint32_t numPeaks = 0;
           if (engineGroup != nullptr) {
             numPeaks = specbleach_stereo_get_tonal_peaks_for_channel(
@@ -1015,13 +992,7 @@ void NoiseRepellentAudioProcessor::resetNoiseProfile() {
 bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {
   if (engineGroup == nullptr)
     return false;
-  for (int mode = SPECBLEACH_PROFILE_MODE_FIRST;
-       mode <= SPECBLEACH_PROFILE_MODE_LAST; ++mode) {
-    if (specbleach_stereo_profile_available_for_channel(engineGroup.get(), 0u,
-                                                        mode))
-      return true;
-  }
-  return false;
+  return specbleach_stereo_has_any_profile_for_channel(engineGroup.get(), 0u);
 }
 
 void NoiseRepellentAudioProcessor::getStateInformation(
@@ -1049,13 +1020,13 @@ void NoiseRepellentAudioProcessor::getStateInformation(
 
       if (engineGroup != nullptr &&
           specbleach_stereo_profile_available_for_channel(engineGroup.get(),
-                                                          channel, mode)) {
+                                                          channel, static_cast<SpecbleachProfileMode>(mode))) {
         profile = specbleach_stereo_get_noise_profile_for_channel(
-            engineGroup.get(), channel, mode);
+            engineGroup.get(), channel, static_cast<SpecbleachProfileMode>(mode));
         profileSize =
             specbleach_stereo_get_noise_profile_size(engineGroup.get());
         blockCount = specbleach_stereo_get_profile_block_count_for_channel(
-            engineGroup.get(), channel, mode);
+            engineGroup.get(), channel, static_cast<SpecbleachProfileMode>(mode));
       }
 
       if (profile != nullptr && profileSize > 0) {
@@ -1184,19 +1155,22 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
             pendingProfiles.push_back(pp);
 
             const uint32_t channelUint = static_cast<uint32_t>(channel);
-            loadProfileGroupSafe(engineGroup.get(), channelUint, floatArray,
-                                 size, blockCount, mode);
+            specbleach_stereo_load_noise_profile_resampled_for_channel(
+                engineGroup.get(), channelUint, floatArray, size, blockCount,
+                static_cast<SpecbleachProfileMode>(mode));
           }
         }
       }
 
       // If legacy profile had no Channel 1 profile, copy Channel 0 to
-      // Channel 1
-      if (!hasCh1) {
+      // Channel 1 (stereo groups only)
+      if (!hasCh1 &&
+          specbleach_stereo_get_channel_count(engineGroup.get()) > 1) {
         for (const auto& pp : pendingProfiles) {
           if (pp.channel == 0) {
-            loadProfileGroupSafe(engineGroup.get(), 1u, pp.data.data(), pp.size,
-                                 pp.blockCount, pp.mode);
+            specbleach_stereo_load_noise_profile_resampled_for_channel(
+                engineGroup.get(), 1u, pp.data.data(), pp.size, pp.blockCount,
+                static_cast<SpecbleachProfileMode>(pp.mode));
           }
         }
       }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -33,6 +33,22 @@ constexpr float kSilenceAmplitudeFloor = 1e-5f;
 constexpr float kSplineSlopeEpsilon = 1e-5f;
 constexpr float kSplineParamEpsilon = 1e-9f;
 
+// Bounds-checked profile restore. Returns false (without touching the engine)
+// when the group is null/narrow for the requested channel, so callers can
+// retain the entry for a later, wider rebuild instead of dropping it.
+bool loadProfileResampledChecked(specbleach_stereo* group, int channel,
+                                 const float* data, uint32_t size,
+                                 uint32_t blockCount,
+                                 SpecbleachProfileMode mode) {
+  if (group == nullptr || data == nullptr || channel < 0 || size == 0)
+    return false;
+  if (static_cast<uint32_t>(channel) >=
+      specbleach_stereo_get_channel_count(group))
+    return false;
+  return specbleach_stereo_load_noise_profile_resampled_for_channel(
+      group, static_cast<uint32_t>(channel), data, size, blockCount, mode);
+}
+
 } // namespace
 
 NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
@@ -311,6 +327,41 @@ void NoiseRepellentAudioProcessor::interpolateCurve(uint32_t numBins) {
   }
 }
 
+void NoiseRepellentAudioProcessor::loadParametersIfChanged(
+    const SpecbleachDenoiserParameters& p, bool curveEnabled) {
+  SpecbleachDenoiserParameters norm = p;
+  norm.reduction_curve_bias = nullptr; // compared via lastLoadedCurve instead
+  const bool sameStruct =
+      paramsCacheValid &&
+      std::memcmp(&norm, &lastLoadedParams, sizeof(norm)) == 0;
+  bool sameCurve = true;
+  if (curveEnabled && p.reduction_curve_bias != nullptr &&
+      p.reduction_curve_size > 0) {
+    sameCurve =
+        paramsCacheValid &&
+        lastLoadedCurve.size() == p.reduction_curve_size &&
+        std::memcmp(lastLoadedCurve.data(), p.reduction_curve_bias,
+                    p.reduction_curve_size * sizeof(float)) == 0;
+  } else {
+    sameCurve = paramsCacheValid && lastLoadedCurve.empty();
+  }
+  if (sameStruct && sameCurve)
+    return; // steady state: skip the setup-only library call entirely
+
+  if (!specbleach_stereo_load_parameters(engineGroup.get(), &p,
+                                         SPECBLEACH_PARAMETERS_SIZE))
+    return; // keep the old cache so the next block retries
+
+  lastLoadedParams = norm;
+  if (curveEnabled && p.reduction_curve_bias != nullptr &&
+      p.reduction_curve_size > 0)
+    lastLoadedCurve.assign(p.reduction_curve_bias,
+                           p.reduction_curve_bias + p.reduction_curve_size);
+  else
+    lastLoadedCurve.clear();
+  paramsCacheValid = true;
+}
+
 void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   // Engine width follows the bus layout (mono hosts get a 1-engine group;
   // the library supports 1 channel explicitly). Rebuild on sample-rate OR
@@ -377,12 +428,23 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   preparedNumChannels = channels;
 
   // Restore backed-up profiles into the new group (library resamples to
-  // the native spectrum size when the sample rate changed)
+  // the native spectrum size when the sample rate changed). Entries that do
+  // not fit the current width (e.g. right-channel data on a mono rebuild)
+  // are retained in pendingProfiles for a later stereo rebuild.
+  std::vector<PendingProfile> retainedProfiles;
+  retainedProfiles.reserve(savedProfiles.size() + pendingProfiles.size());
   for (const auto& item : savedProfiles) {
-    specbleach_stereo_load_noise_profile_resampled_for_channel(
-        engineGroup.get(), static_cast<uint32_t>(item.channel),
-        item.data.data(), item.size, item.blockCount,
-        static_cast<SpecbleachProfileMode>(item.mode));
+    if (!loadProfileResampledChecked(
+            engineGroup.get(), item.channel, item.data.data(), item.size,
+            item.blockCount, static_cast<SpecbleachProfileMode>(item.mode))) {
+      PendingProfile pp;
+      pp.channel = item.channel;
+      pp.mode = item.mode;
+      pp.size = item.size;
+      pp.blockCount = item.blockCount;
+      pp.data = item.data;
+      retainedProfiles.push_back(std::move(pp));
+    }
   }
 
   // Restore state pending profiles if loaded before prepareToPlay
@@ -391,11 +453,12 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
     if (item.channel == 1)
       hasCh1 = true;
 
-    specbleach_stereo_load_noise_profile_resampled_for_channel(
-        engineGroup.get(), static_cast<uint32_t>(item.channel),
-        item.data.data(), item.size, item.blockCount,
-        static_cast<SpecbleachProfileMode>(item.mode));
+    if (!loadProfileResampledChecked(
+            engineGroup.get(), item.channel, item.data.data(), item.size,
+            item.blockCount, static_cast<SpecbleachProfileMode>(item.mode)))
+      retainedProfiles.push_back(item);
   }
+  pendingProfiles = std::move(retainedProfiles);
 
   // Legacy states may lack channel 1 profiles — fall back from channel 0
   // (stereo groups only; mono groups have no channel 1)
@@ -403,16 +466,40 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
       specbleach_stereo_get_channel_count(engineGroup.get()) > 1) {
     for (const auto& item : pendingProfiles) {
       if (item.channel == 0) {
-        specbleach_stereo_load_noise_profile_resampled_for_channel(
-            engineGroup.get(), 1u, item.data.data(), item.size,
+        loadProfileResampledChecked(
+            engineGroup.get(), 1, item.data.data(), item.size,
             item.blockCount, static_cast<SpecbleachProfileMode>(item.mode));
       }
     }
   }
-  pendingProfiles.clear();
 
   // Fill any remaining per-channel/per-mode gaps
   specbleach_stereo_sync_profiles(engineGroup.get());
+
+  // This rebuild invalidates the parameter cache, and the engine is fresh.
+  // Warm up the library's internal curve copy buffer here (setup context —
+  // the first curve-enabled load may allocate, later same-size loads reuse
+  // it) so audio blocks never trigger that allocation.
+  paramsCacheValid = false;
+  lastLoadedCurve.clear();
+  {
+    juce::SpinLock::ScopedLockType curveGuard(curveLock);
+    const uint32_t numBins =
+        specbleach_stereo_get_noise_profile_size(engineGroup.get());
+    if (numBins > 0) {
+      interpolateCurve(numBins);
+      lastLoadedCurve.reserve(interpolatedCurveBias.size());
+      if (!interpolatedCurveBias.empty()) {
+        SpecbleachDenoiserParameters warm{};
+        warm.reduction_curve_enabled = true;
+        warm.reduction_curve_bias = interpolatedCurveBias.data();
+        warm.reduction_curve_size =
+            static_cast<uint32_t>(interpolatedCurveBias.size());
+        specbleach_stereo_load_parameters(engineGroup.get(), &warm,
+                                          SPECBLEACH_PARAMETERS_SIZE);
+      }
+    }
+  }
 }
 
 void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
@@ -455,8 +542,8 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   for (auto& slot : spectralBuffer)
     slot.tonalPeaksHz.reserve(kMaxTonalPeaks);
 
-  pendingProfiles.clear();
-
+  // NB: pendingProfiles is owned by ensureEnginesInitialized — retained
+  // (narrow-group) entries must survive prepareToPlay for a later rebuild.
   currentLatency = reportedLatency;
   dryWetMixer.setWetLatency(static_cast<float>(reportedLatency));
 
@@ -644,8 +731,10 @@ void NoiseRepellentAudioProcessor::processBlock(
     for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
       outPtrs[ch] = buffer.getWritePointer(static_cast<int>(ch));
 
-    specbleach_stereo_load_parameters(engineGroup.get(), &p,
-                                        SPECBLEACH_PARAMETERS_SIZE);
+    // Push the latest parameter values ahead of processing, but only when
+    // they changed since the last push — steady-state blocks skip the
+    // setup-only library call (same-thread handoff, never concurrent).
+    loadParametersIfChanged(p, curveEnabled);
     specbleach_stereo_process(
         engineGroup.get(), static_cast<uint32_t>(numSamples), inPtrs, outPtrs);
     // Latency is constant for both smoothing modes — no wet compensation
@@ -1146,18 +1235,20 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
             const float* floatArray =
                 reinterpret_cast<const float*>(mb.getData());
 
-            PendingProfile pp;
-            pp.channel = channel;
-            pp.mode = mode;
-            pp.size = size;
-            pp.blockCount = blockCount;
-            pp.data.assign(floatArray, floatArray + size);
-            pendingProfiles.push_back(pp);
-
-            const uint32_t channelUint = static_cast<uint32_t>(channel);
-            specbleach_stereo_load_noise_profile_resampled_for_channel(
-                engineGroup.get(), channelUint, floatArray, size, blockCount,
-                static_cast<SpecbleachProfileMode>(mode));
+            // Narrow (or not yet created) engines cannot take this channel —
+            // keep it pending for a later, wider rebuild instead of dropping
+            // it.
+            if (!loadProfileResampledChecked(
+                    engineGroup.get(), channel, floatArray, size, blockCount,
+                    static_cast<SpecbleachProfileMode>(mode))) {
+              PendingProfile pp;
+              pp.channel = channel;
+              pp.mode = mode;
+              pp.size = size;
+              pp.blockCount = blockCount;
+              pp.data.assign(floatArray, floatArray + size);
+              pendingProfiles.push_back(std::move(pp));
+            }
           }
         }
       }
@@ -1168,8 +1259,8 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
           specbleach_stereo_get_channel_count(engineGroup.get()) > 1) {
         for (const auto& pp : pendingProfiles) {
           if (pp.channel == 0) {
-            specbleach_stereo_load_noise_profile_resampled_for_channel(
-                engineGroup.get(), 1u, pp.data.data(), pp.size, pp.blockCount,
+            loadProfileResampledChecked(
+                engineGroup.get(), 1, pp.data.data(), pp.size, pp.blockCount,
                 static_cast<SpecbleachProfileMode>(pp.mode));
           }
         }
@@ -1177,10 +1268,6 @@ void NoiseRepellentAudioProcessor::setStateInformation(const void* data,
 
       // Fill any remaining per-channel/per-mode gaps
       specbleach_stereo_sync_profiles(engineGroup.get());
-
-      if (engineGroup != nullptr) {
-        pendingProfiles.clear();
-      }
     }
   }
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <juce_dsp/juce_dsp.h>
 #include <vector>
 
-#include "specbleach.hpp" // self-guarding for C++; do NOT wrap in extern "C"
+#include "specbleach_stereo.hpp" // self-guarding for C++; do NOT wrap in extern "C"
 #include "specbleach_version.h"
 
 class NoiseRepellentAudioProcessor : public juce::AudioProcessor {
@@ -160,10 +160,7 @@ private:
   // crossfade machinery needed in the plugin).
   specbleach::StereoGroupPtr engineGroup;
 
-  // Scratch wet sink for out-of-bus channels during processing
-  juce::AudioBuffer<float> wetScratchA;
-
-  double currentSampleRate = 44100.0;
+  double currentSampleRate = 48000.0;
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> transientProtectionActive{false};
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -160,7 +160,10 @@ private:
   // crossfade machinery needed in the plugin).
   specbleach::StereoGroupPtr engineGroup;
 
-  double currentSampleRate = 48000.0;
+  // Last rate reported by the host via prepareToPlay(). Zero until the first
+  // call — readers must tolerate "host hasn't informed us yet" (see the
+  // sr <= 0 fallback in interpolateCurve).
+  double currentSampleRate = 0.0;
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> transientProtectionActive{false};
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -142,9 +142,19 @@ public:
 private:
   void ensureEnginesInitialized(double sampleRate);
   void interpolateCurve(uint32_t numBins);
+  // Pushes p to the engine group only when it differs from the last pushed
+  // block (same-thread, serialized with process calls — never concurrent).
+  // Steady-state audio blocks skip the setup-only library call entirely.
+  void loadParametersIfChanged(const SpecbleachDenoiserParameters& p,
+                               bool curveEnabled);
 
   // Thread-safe reduction curve data
   juce::SpinLock curveLock;
+  // Last parameter block pushed to the engine group, with the curve pointer
+  // normalized out (curve bytes are cached separately below).
+  SpecbleachDenoiserParameters lastLoadedParams{};
+  std::vector<float> lastLoadedCurve;
+  bool paramsCacheValid = false;
   std::vector<CurveNode> curveNodes{{0.0f, 0.0f}, {1.0f, 0.0f}};
   std::vector<float> interpolatedCurveBias;
   std::atomic<bool> curveNodesDirty{true};

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -118,6 +118,9 @@ public:
     beginTest("Channel Layout Matrix (Mono vs Stereo Processing)");
     testChannelLayoutMatrix();
 
+    beginTest("Mono Bus Layout (Single-Engine Group)");
+    testMonoBusLayout();
+
     beginTest("Transient Protection Dynamic Response");
     testTransientProtection();
   }
@@ -469,6 +472,68 @@ private:
     }
 
     proc.releaseResources();
+  }
+
+  void testMonoBusLayout() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+
+    juce::AudioProcessor::BusesLayout monoLayout;
+    monoLayout.inputBuses.add(juce::AudioChannelSet::mono());
+    monoLayout.outputBuses.add(juce::AudioChannelSet::mono());
+
+    NoiseRepellentAudioProcessor proc;
+    expect(proc.setBusesLayout(monoLayout), "Mono bus layout must be accepted");
+    expect(proc.getTotalNumInputChannels() == 1, "Mono input bus width");
+    expect(proc.getTotalNumOutputChannels() == 1, "Mono output bus width");
+
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+
+    // Learn a profile through the 1-engine group
+    setParam(proc, "learn_noise", 1.0f);
+    juce::AudioBuffer<float> buffer(1, blockSize);
+    juce::MidiBuffer midi;
+    for (int b = 0; b < 30; ++b) {
+      generateNoiseBuffer(buffer, 0.05f, 2000 + b);
+      proc.processBlock(buffer, midi);
+    }
+    setParam(proc, "learn_noise", 0.0f);
+    pumpMessageLoop(10);
+
+    expect(proc.hasNoiseProfile(), "Mono-learned profile must be present");
+
+    generateNoiseBuffer(buffer, 0.05f, 777);
+    proc.processBlock(buffer, midi);
+    const auto* out = buffer.getReadPointer(0);
+    for (int s = 0; s < blockSize; ++s)
+      expect(std::isfinite(out[s]), "Mono output must be finite");
+
+    // State roundtrip between mono instances
+    juce::MemoryBlock state;
+    proc.getStateInformation(state);
+    NoiseRepellentAudioProcessor proc2;
+    expect(proc2.setBusesLayout(monoLayout),
+           "Mono layout on restore target must be accepted");
+    proc2.prepareToPlay(sampleRate, blockSize);
+    proc2.setStateInformation(state.getData(), (int)state.getSize());
+    expect(proc2.hasNoiseProfile(), "Restored mono profile must be present");
+
+    // Switching back to stereo rebuilds the engine width without crashing
+    juce::AudioProcessor::BusesLayout stereoLayout;
+    stereoLayout.inputBuses.add(juce::AudioChannelSet::stereo());
+    stereoLayout.outputBuses.add(juce::AudioChannelSet::stereo());
+    expect(proc.setBusesLayout(stereoLayout),
+           "Stereo layout must be accepted after mono");
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+    juce::AudioBuffer<float> stereoBuf(2, blockSize);
+    generateNoiseBuffer(stereoBuf, 0.05f, 888);
+    proc.processBlock(stereoBuf, midi);
+    expect(proc.hasNoiseProfile(), "Profile must survive mono->stereo switch");
+
+    proc.releaseResources();
+    proc2.releaseResources();
   }
 
   void testTransientProtection() {

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -18,6 +18,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <cmath>
+#include <limits>
+#include <map>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -86,6 +88,64 @@ void learnProfile(NoiseRepellentAudioProcessor& proc, double sampleRate,
   pumpMessageLoop(10);
 }
 
+void learnStereoDistinctProfiles(NoiseRepellentAudioProcessor& proc,
+                                 int blockSize = 512, int numBlocks = 30) {
+  juce::AudioBuffer<float> buffer(2, blockSize);
+  juce::MidiBuffer midi;
+  for (int b = 0; b < numBlocks; ++b) {
+    // Deliberately different per-channel noise so L/R profiles are distinct.
+    std::mt19937 genL(static_cast<uint32_t>(3000 + b));
+    std::normal_distribution<float> distL(0.0f, 0.06f);
+    auto* left = buffer.getWritePointer(0);
+    for (int s = 0; s < blockSize; ++s) left[s] = distL(genL);
+    std::mt19937 genR(static_cast<uint32_t>(9000 + b));
+    std::normal_distribution<float> distR(0.0f, 0.015f);
+    auto* right = buffer.getWritePointer(1);
+    for (int s = 0; s < blockSize; ++s) right[s] = distR(genR);
+    proc.processBlock(buffer, midi);
+  }
+}
+
+// (channel, mode) -> profile magnitudes decoded from a saved state block.
+std::map<std::pair<int, int>, std::vector<float>>
+extractStateProfiles(const juce::MemoryBlock& state) {
+  std::map<std::pair<int, int>, std::vector<float>> out;
+  std::unique_ptr<juce::XmlElement> xml(
+      juce::AudioProcessor::getXmlFromBinary(state.getData(),
+                                             (int)state.getSize()));
+  if (xml == nullptr)
+    return out;
+  juce::ValueTree tree = juce::ValueTree::fromXml(*xml);
+  if (!tree.isValid())
+    return out;
+  juce::ValueTree profiles = tree.getChildWithName("LEARNED_PROFILES");
+  if (!profiles.isValid())
+    return out;
+  for (int i = 0; i < profiles.getNumChildren(); ++i) {
+    juce::ValueTree node = profiles.getChild(i);
+    int channel = node.getProperty("channel", -1);
+    int mode = node.getProperty("mode", 0);
+    juce::String base64Data = node.getProperty("data", "");
+    juce::MemoryBlock mb;
+    if (channel < 0 || base64Data.isEmpty() ||
+        !mb.fromBase64Encoding(base64Data) || mb.getSize() == 0)
+      continue;
+    const size_t count = mb.getSize() / sizeof(float);
+    const float* data = reinterpret_cast<const float*>(mb.getData());
+    out[{channel, mode}] = std::vector<float>(data, data + count);
+  }
+  return out;
+}
+
+float maxAbsDiff(const std::vector<float>& a, const std::vector<float>& b) {
+  if (a.size() != b.size())
+    return std::numeric_limits<float>::infinity();
+  float m = 0.0f;
+  for (size_t i = 0; i < a.size(); ++i)
+    m = std::max(m, std::abs(a[i] - b[i]));
+  return m;
+}
+
 } // namespace
 
 class IntegrationTest : public juce::UnitTest {
@@ -120,6 +180,9 @@ public:
 
     beginTest("Mono Bus Layout (Single-Engine Group)");
     testMonoBusLayout();
+
+    beginTest("Stereo-Mono-Stereo Distinct Profile Restore");
+    testStereoMonoStereoDistinctRestore();
 
     beginTest("Transient Protection Dynamic Response");
     testTransientProtection();
@@ -534,6 +597,78 @@ private:
 
     proc.releaseResources();
     proc2.releaseResources();
+  }
+
+  void testStereoMonoStereoDistinctRestore() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+
+    NoiseRepellentAudioProcessor proc;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+
+    // Learn distinct L/R profiles from deliberately different channel noise.
+    setParam(proc, "learn_noise", 1.0f);
+    learnStereoDistinctProfiles(proc, blockSize, 30);
+    setParam(proc, "learn_noise", 0.0f);
+    pumpMessageLoop(10);
+    expect(proc.hasNoiseProfile(), "Stereo-learned profile must be present");
+
+    juce::MemoryBlock stereoState;
+    proc.getStateInformation(stereoState);
+    auto before = extractStateProfiles(stereoState);
+
+    // Find a mode stored for both channels and require distinct L/R data.
+    int probeMode = -1;
+    for (const auto& [key, data] : before) {
+      const auto [ch, mode] = key;
+      if (ch == 0 && before.count({1, mode}) > 0) {
+        probeMode = mode;
+        break;
+      }
+    }
+    expect(probeMode >= 0, "Saved state must hold both channel profiles");
+    if (probeMode < 0) {
+      proc.releaseResources();
+      return;
+    }
+    expect(maxAbsDiff(before[{0, probeMode}], before[{1, probeMode}]) > 1e-3f,
+           "Left/right profiles must be distinct before narrowing");
+
+    // Narrow to mono: the right-channel entry must be retained, not dropped.
+    juce::AudioProcessor::BusesLayout monoLayout;
+    monoLayout.inputBuses.add(juce::AudioChannelSet::mono());
+    monoLayout.outputBuses.add(juce::AudioChannelSet::mono());
+    expect(proc.setBusesLayout(monoLayout), "Mono layout must be accepted");
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+    expect(proc.hasNoiseProfile(), "Mono engine must keep channel 0 profile");
+
+    // Widen back to stereo: the retained right channel must come back intact
+    // (not overwritten by a channel-0 fallback copy).
+    juce::AudioProcessor::BusesLayout stereoLayout;
+    stereoLayout.inputBuses.add(juce::AudioChannelSet::stereo());
+    stereoLayout.outputBuses.add(juce::AudioChannelSet::stereo());
+    expect(proc.setBusesLayout(stereoLayout),
+           "Stereo layout must be accepted after mono");
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+    expect(proc.hasNoiseProfile(), "Profile must survive mono->stereo switch");
+
+    juce::MemoryBlock restoredState;
+    proc.getStateInformation(restoredState);
+    auto after = extractStateProfiles(restoredState);
+    expect(after.count({0, probeMode}) > 0 && after.count({1, probeMode}) > 0,
+           "Restored state must hold both channel profiles");
+    if (after.count({0, probeMode}) > 0 && after.count({1, probeMode}) > 0) {
+      expectWithinAbsoluteError(
+          maxAbsDiff(after[{1, probeMode}], before[{1, probeMode}]), 0.0f,
+          1e-6f, "Right channel must restore intact across mono narrowing");
+      expect(maxAbsDiff(after[{0, probeMode}], after[{1, probeMode}]) > 1e-3f,
+             "Restored left/right profiles must remain distinct");
+    }
+
+    proc.releaseResources();
   }
 
   void testTransientProtection() {


### PR DESCRIPTION
Adopts the redesigned libspecbleach C API (libspecbleach#151), plus mono-host support, an About box, and a GUI/DSP literal cleanup. **Depends on libspecbleach#151 — merge that first.**

## API adoption
- New `specbleach_stereo.hpp`, `SPECBLEACH_SMOOTHING_*`, `static_cast<SpecbleachProfileMode>`, `SPECBLEACH_PARAMETERS_SIZE`, const-correct calls, version-banner fix.
- Deleted 35-line local profile resampler; all 5 sites use `specbleach_stereo_load_noise_profile_resampled_for_channel`; `has_any_profile_for_channel` adopted.

## Mono hosts
- Engine width follows bus layout (`max({in, out}, 1)`), rebuilds on SR or channel-count change, 1:1 channel mapping, `wetScratchA` deleted, new `testMonoBusLayout`.

## About box + cleanup
- Brand click -> About popup (plugin version, library built-against vs loaded versions + mismatch note).
- 46 ms frame constant, DSP epsilons, shared GUI colors, visualizer axis/curve/badge helpers, tooltip strings, `resized()` layout constants (pixel-identical swaps).

## Verification
- Clean Debug build, **5/5 suites green** (incl. UX invariants + new mono test).

## Post-merge follow-up
CI on this PR fetches libspecbleach at the pinned `GIT_TAG 336beb0` (old API) and will stay red until libspecbleach#151 merges; then bump the pin to the new master SHA on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mono input and output configurations, including profile learning, saving, restoring, and switching between mono and stereo.
  - Added an About dialog showing plugin and library version information, with a warning when versions differ.

- **Improvements**
  - Updated tooltips to provide clearer, context-sensitive status information.
  - Refined visualizer curves, axes, badges, legends, and UI colors for a more consistent presentation.
  - Improved layout consistency across the plugin interface.

- **Bug Fixes**
  - Improved profile handling and engine rebuilding when audio channel layouts or sample rates change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->