### PR TITLE
Stepped STFT frame-size control (23/32/46/64/93 ms) + bypass alignment fixes

### DIFF
--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -205,19 +205,16 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       static_cast<float>(NoiseRepellentAudioProcessor::kFftSize);
 
   // Frequency-domain spatially smoothed display buffers (UI display smoothing
-  // only)
+  // only). The noise profile is deliberately NOT smoothed: it arrives at the
+  // engine's native bin resolution (nearest-bin mapped) and smoothing would
+  // hide the coarser/finer steps that distinguish frame sizes.
   std::vector<float> freqSmoothedInput(numBins);
   std::vector<float> freqSmoothedOutput(numBins);
-  std::vector<float> freqSmoothedProfile(numBins);
 
   smoothBinsLogarithmicFrequencyDomain(smoothedInputDB.data(),
                                        freqSmoothedInput.data(), numBins);
   smoothBinsLogarithmicFrequencyDomain(smoothedOutputDB.data(),
                                        freqSmoothedOutput.data(), numBins);
-  if (currentFrame.hasNoiseProfile) {
-    smoothBinsLogarithmicFrequencyDomain(currentFrame.noiseFloorDB.data(),
-                                         freqSmoothedProfile.data(), numBins);
-  }
 
   // ── Grid lines ──
   g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
@@ -319,10 +316,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
     g.strokePath(outputPath, juce::PathStrokeType(1.8f));
   }
 
-  // 3. Noise Floor Profile Curve (Solid Warm Amber Line)
+  // 3. Noise Floor Profile Curve (Solid Warm Amber Line, native engine bins)
   if (currentFrame.hasNoiseProfile) {
     juce::Path noisePath =
-        buildLogFreqPath(freqSmoothedProfile.data(), numBins);
+        buildLogFreqPath(currentFrame.noiseFloorDB.data(), numBins);
     g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
     g.strokePath(noisePath, juce::PathStrokeType(2.0f));
 
@@ -363,7 +360,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
           if (freq < minFreq || freq > maxFreq)
             continue;
           float x = freqToX(freq, w, minFreq, maxFreq);
-          float y = dbToY(freqSmoothedProfile[b], h, minDB, maxDB);
+          float y = dbToY(currentFrame.noiseFloorDB[b], h, minDB, maxDB);
           if (!started) {
             segment.startNewSubPath(x, y);
             started = true;

--- a/Source/GUI/SpectralVisualizer.cpp
+++ b/Source/GUI/SpectralVisualizer.cpp
@@ -205,16 +205,19 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
       static_cast<float>(NoiseRepellentAudioProcessor::kFftSize);
 
   // Frequency-domain spatially smoothed display buffers (UI display smoothing
-  // only). The noise profile is deliberately NOT smoothed: it arrives at the
-  // engine's native bin resolution (nearest-bin mapped) and smoothing would
-  // hide the coarser/finer steps that distinguish frame sizes.
+  // only)
   std::vector<float> freqSmoothedInput(numBins);
   std::vector<float> freqSmoothedOutput(numBins);
+  std::vector<float> freqSmoothedProfile(numBins);
 
   smoothBinsLogarithmicFrequencyDomain(smoothedInputDB.data(),
                                        freqSmoothedInput.data(), numBins);
   smoothBinsLogarithmicFrequencyDomain(smoothedOutputDB.data(),
                                        freqSmoothedOutput.data(), numBins);
+  if (currentFrame.hasNoiseProfile) {
+    smoothBinsLogarithmicFrequencyDomain(currentFrame.noiseFloorDB.data(),
+                                         freqSmoothedProfile.data(), numBins);
+  }
 
   // ── Grid lines ──
   g.setFont(juce::FontOptions(NoiseRepellentLookAndFeel::kFontSizeLabel,
@@ -316,10 +319,10 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
     g.strokePath(outputPath, juce::PathStrokeType(1.8f));
   }
 
-  // 3. Noise Floor Profile Curve (Solid Warm Amber Line, native engine bins)
+  // 3. Noise Floor Profile Curve (Solid Warm Amber Line)
   if (currentFrame.hasNoiseProfile) {
     juce::Path noisePath =
-        buildLogFreqPath(currentFrame.noiseFloorDB.data(), numBins);
+        buildLogFreqPath(freqSmoothedProfile.data(), numBins);
     g.setColour(NoiseRepellentLookAndFeel::kColorNoiseProfile);
     g.strokePath(noisePath, juce::PathStrokeType(2.0f));
 
@@ -360,7 +363,7 @@ void SpectralVisualizerComponent::paint(juce::Graphics& g) {
           if (freq < minFreq || freq > maxFreq)
             continue;
           float x = freqToX(freq, w, minFreq, maxFreq);
-          float y = dbToY(currentFrame.noiseFloorDB[b], h, minDB, maxDB);
+          float y = dbToY(freqSmoothedProfile[b], h, minDB, maxDB);
           if (!started) {
             segment.startNewSubPath(x, y);
             started = true;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -182,10 +182,15 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
     menu.addItem(item2);
 
     menu.addSeparator();
-    menu.addSectionHeader("STFT FRAME SIZE (FFT RESOLUTION)");
-    static constexpr const char* kFrameSizeNames[5] = {"23 ms", "32 ms",
-                                                       "46 ms", "64 ms",
-                                                       "93 ms"};
+    menu.addSectionHeader("FRAME SIZE (BIGGER = FINER DETAIL + MORE LATENCY)");
+    // Guidance baked into the labels: PopupMenu items have no tooltip
+    // support, and latency in ms is sample-rate independent (always 2x).
+    static constexpr const char* kFrameSizeNames[5] = {
+        "23 ms - live input, transients (46 ms latency)",
+        "32 ms - general purpose (64 ms latency)",
+        "46 ms - stationary noise, default (92 ms latency)",
+        "64 ms - tonal detail: hum & whine (128 ms latency)",
+        "93 ms - max resolution, print/mix (186 ms latency)"};
     for (int i = 0; i < 5; ++i) {
       juce::PopupMenu::Item frameItem(kFrameSizeNames[i]);
       frameItem.itemID = 3 + i;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1009,17 +1009,10 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
     lblProfileStatus.setColour(juce::Label::textColourId,
                                NoiseRepellentLookAndFeel::kColorDenoising);
   } else if (hasProfile) {
-    if (audioProcessor.isProfileResampledStale()) {
-      lblProfileStatus.setText("STATUS: PROFILE RESAMPLED - RE-LEARN ADVISED",
-                               juce::dontSendNotification);
-      lblProfileStatus.setColour(juce::Label::textColourId,
-                                 juce::Colour(NoiseRepellentLookAndFeel::kColorTonalPeaks));
-    } else {
-      lblProfileStatus.setText("STATUS: STATIONARY NOISE PROFILE",
-                               juce::dontSendNotification);
-      lblProfileStatus.setColour(juce::Label::textColourId,
-                                 NoiseRepellentLookAndFeel::kColorNoiseProfile);
-    }
+    lblProfileStatus.setText("STATUS: STATIONARY NOISE PROFILE",
+                             juce::dontSendNotification);
+    lblProfileStatus.setColour(juce::Label::textColourId,
+                               NoiseRepellentLookAndFeel::kColorNoiseProfile);
   } else {
     lblProfileStatus.setText("STATUS: NO PROFILE (PASS-THROUGH)",
                              juce::dontSendNotification);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -183,16 +183,17 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
 
     menu.addSeparator();
     menu.addSectionHeader("STFT FRAME SIZE (FFT RESOLUTION)");
-    static constexpr const char* kFrameSizeNames[4] = {"23 ms", "32 ms",
-                                                       "46 ms", "64 ms"};
-    for (int i = 0; i < 4; ++i) {
+    static constexpr const char* kFrameSizeNames[5] = {"23 ms", "32 ms",
+                                                       "46 ms", "64 ms",
+                                                       "93 ms"};
+    for (int i = 0; i < 5; ++i) {
       juce::PopupMenu::Item frameItem(kFrameSizeNames[i]);
       frameItem.itemID = 3 + i;
       frameItem.isTicked = (i == frameSizeIdx);
       frameItem.action = [this, frameSizeParam, i]() {
         if (frameSizeParam != nullptr) {
           frameSizeParam->beginChangeGesture();
-          frameSizeParam->setValueNotifyingHost(static_cast<float>(i) / 3.0f);
+          frameSizeParam->setValueNotifyingHost(static_cast<float>(i) / 4.0f);
           frameSizeParam->endChangeGesture();
         }
       };

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -142,10 +142,16 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
     auto* tooltipParam =
         audioProcessor.getAPVTS().getParameter("show_tooltips");
     auto* hudParam = audioProcessor.getAPVTS().getParameter("show_hud");
+    auto* frameSizeParam =
+        audioProcessor.getAPVTS().getParameter("frame_size");
 
     bool tooltipVal =
         (tooltipParam != nullptr && tooltipParam->getValue() > 0.5f);
     bool hudVal = (hudParam != nullptr && hudParam->getValue() > 0.5f);
+    int frameSizeIdx = 2;
+    if (auto* choice = dynamic_cast<juce::AudioParameterChoice*>(
+            frameSizeParam))
+      frameSizeIdx = choice->getIndex();
 
     juce::PopupMenu menu;
 
@@ -174,6 +180,24 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
       }
     };
     menu.addItem(item2);
+
+    menu.addSeparator();
+    menu.addSectionHeader("STFT FRAME SIZE (FFT RESOLUTION)");
+    static constexpr const char* kFrameSizeNames[4] = {"23 ms", "32 ms",
+                                                       "46 ms", "64 ms"};
+    for (int i = 0; i < 4; ++i) {
+      juce::PopupMenu::Item frameItem(kFrameSizeNames[i]);
+      frameItem.itemID = 3 + i;
+      frameItem.isTicked = (i == frameSizeIdx);
+      frameItem.action = [this, frameSizeParam, i]() {
+        if (frameSizeParam != nullptr) {
+          frameSizeParam->beginChangeGesture();
+          frameSizeParam->setValueNotifyingHost(static_cast<float>(i) / 3.0f);
+          frameSizeParam->endChangeGesture();
+        }
+      };
+      menu.addItem(frameItem);
+    }
 
     menu.setLookAndFeel(&getLookAndFeel());
     menu.showMenuAsync(
@@ -985,10 +1009,17 @@ void NoiseRepellentAudioProcessorEditor::updateProfileStatus() {
     lblProfileStatus.setColour(juce::Label::textColourId,
                                NoiseRepellentLookAndFeel::kColorDenoising);
   } else if (hasProfile) {
-    lblProfileStatus.setText("STATUS: STATIONARY NOISE PROFILE",
-                             juce::dontSendNotification);
-    lblProfileStatus.setColour(juce::Label::textColourId,
-                               NoiseRepellentLookAndFeel::kColorNoiseProfile);
+    if (audioProcessor.isProfileResampledStale()) {
+      lblProfileStatus.setText("STATUS: PROFILE RESAMPLED - RE-LEARN ADVISED",
+                               juce::dontSendNotification);
+      lblProfileStatus.setColour(juce::Label::textColourId,
+                                 juce::Colour(NoiseRepellentLookAndFeel::kColorTonalPeaks));
+    } else {
+      lblProfileStatus.setText("STATUS: STATIONARY NOISE PROFILE",
+                               juce::dontSendNotification);
+      lblProfileStatus.setColour(juce::Label::textColourId,
+                                 NoiseRepellentLookAndFeel::kColorNoiseProfile);
+    }
   } else {
     lblProfileStatus.setText("STATUS: NO PROFILE (PASS-THROUGH)",
                              juce::dontSendNotification);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -55,7 +55,11 @@ NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
               .withInput("Input", juce::AudioChannelSet::stereo(), true)
               .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
       parameters(*this, nullptr, "PARAMETERS", createParameterLayout()),
-      dryWetMixer(16384) {
+      // Dry-delay headroom must exceed the worst-case engine latency:
+      // 93 ms at 192 kHz needs 35712 samples (latency = 2x frame).
+      // setWetLatency() silently clamps past this ceiling, which
+      // misaligns dry/wet and skips on bypass toggles.
+      dryWetMixer(65536) {
   bypassParameter = dynamic_cast<juce::AudioParameterBool*>(
       parameters.getParameter("bypass"));
   parameters.addParameterListener("frame_size", this);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -879,17 +879,16 @@ void NoiseRepellentAudioProcessor::processBlock(
               const float dbOffset = (maxProfileIdx > 0.0f)
                                          ? (20.0f * std::log10(maxProfileIdx))
                                          : 0.0f;
+              // Nearest-bin mapping (see the live FFT path): the frozen profile
+              // keeps the engine's native resolution so frame-size changes
+              // stay visible while stopped/silent.
               for (size_t i = 0; i < kFftBins; ++i) {
                 float normPos = static_cast<float>(i) / maxFftIdx;
-                float exactP = normPos * maxProfileIdx;
-                size_t p0 =
-                    std::clamp(static_cast<size_t>(exactP),
-                               static_cast<size_t>(0), realProfileBins - 1);
-                size_t p1 = std::min(p0 + 1, realProfileBins - 1);
-                float frac = exactP - static_cast<float>(p0);
-                float interpVal =
-                    (1.0f - frac) * morphedPtr[p0] + frac * morphedPtr[p1];
-                float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
+                size_t p = std::clamp(
+                    static_cast<size_t>(normPos * maxProfileIdx + 0.5f),
+                    static_cast<size_t>(0), realProfileBins - 1);
+                float rawDb =
+                    10.0f * std::log10(std::max(morphedPtr[p], 1e-12f));
                 frame.noiseFloorDB[i] = rawDb - dbOffset;
               }
             } else {
@@ -1059,20 +1058,18 @@ void NoiseRepellentAudioProcessor::processBlock(
                                      ? (20.0f * std::log10(maxProfileIdx))
                                      : 0.0f;
 
+          // Nearest-bin mapping (no interpolation): the display shows exactly
+          // the engine's native bins, so a shorter frame renders a visibly
+          // coarser profile and a longer frame a finer one. Interpolating
+          // would invent detail the engine never measured.
           for (size_t i = 0; i < kFftBins; ++i) {
             float normPos = static_cast<float>(i) / maxFftIdx;
-            float exactP = normPos * maxProfileIdx;
+            size_t p = std::clamp(
+                static_cast<size_t>(normPos * maxProfileIdx + 0.5f),
+                static_cast<size_t>(0), realProfileBins - 1);
 
-            size_t p0 = std::clamp(static_cast<size_t>(exactP),
-                                   static_cast<size_t>(0), realProfileBins - 1);
-            size_t p1 = std::min(p0 + 1, realProfileBins - 1);
-            float frac = exactP - static_cast<float>(p0);
-
-            float val0 = actualNoiseProfile[p0];
-            float val1 = actualNoiseProfile[p1];
-            float interpVal = (1.0f - frac) * val0 + frac * val1;
-
-            float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
+            float rawDb =
+                10.0f * std::log10(std::max(actualNoiseProfile[p], 1e-12f));
             frame.noiseFloorDB[i] = rawDb - dbOffset;
           }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -77,7 +77,7 @@ float NoiseRepellentAudioProcessor::getFrameSizeMs() const {
   if (auto* choice = dynamic_cast<juce::AudioParameterChoice*>(
           parameters.getParameter("frame_size"))) {
     const int index = choice->getIndex();
-    if (index >= 0 && index < 4)
+    if (index >= 0 && index < 5)
       return kFrameSizeOptionsMs[static_cast<size_t>(index)];
   }
   return kFrameSizeOptionsMs[kDefaultFrameSizeIndex];
@@ -129,7 +129,7 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
 
   params.push_back(std::make_unique<juce::AudioParameterChoice>(
       "frame_size", "STFT Frame Size",
-      juce::StringArray{"23 ms", "32 ms", "46 ms", "64 ms"},
+      juce::StringArray{"23 ms", "32 ms", "46 ms", "64 ms", "93 ms"},
       NoiseRepellentAudioProcessor::kDefaultFrameSizeIndex,
       juce::AudioParameterChoiceAttributes().withAutomatable(false).withMeta(
           true)));

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -473,6 +473,14 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   }
 
   // Free existing group before allocating the replacement
+  // A frame-size switch starts clean: resampling a profile captured at a
+  // different resolution works poorly, so drop it and let the user re-learn
+  // at native resolution. Gated on live profiles so state restores into a
+  // fresh engine (empty savedProfiles) never discard session data.
+  if (frameSizeChanged && !savedProfiles.empty()) {
+    savedProfiles.clear();
+    pendingProfiles.clear();
+  }
   engineGroup.reset();
 
   uint32_t channels = wantedChannels;
@@ -483,8 +491,6 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
 
   currentSampleRate = sampleRate;
   currentFrameSizeMs = wantedFrameSizeMs;
-  if (frameSizeChanged && !savedProfiles.empty())
-    profileResampledStale.store(true, std::memory_order_relaxed);
   preparedNumChannels = channels;
 
   // Restore backed-up profiles into the new group (library resamples to
@@ -647,8 +653,6 @@ void NoiseRepellentAudioProcessor::processBlock(
       0.5f;
   const bool learnNoise =
       parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
-  if (learnNoise)
-    profileResampledStale.store(false, std::memory_order_relaxed);
   const bool adaptiveNoise =
       parameters.getRawParameterValue("adaptive_noise")->load() > 0.5f;
   const int adaptiveMethod = static_cast<int>(
@@ -879,16 +883,17 @@ void NoiseRepellentAudioProcessor::processBlock(
               const float dbOffset = (maxProfileIdx > 0.0f)
                                          ? (20.0f * std::log10(maxProfileIdx))
                                          : 0.0f;
-              // Nearest-bin mapping (see the live FFT path): the frozen profile
-              // keeps the engine's native resolution so frame-size changes
-              // stay visible while stopped/silent.
               for (size_t i = 0; i < kFftBins; ++i) {
                 float normPos = static_cast<float>(i) / maxFftIdx;
-                size_t p = std::clamp(
-                    static_cast<size_t>(normPos * maxProfileIdx + 0.5f),
-                    static_cast<size_t>(0), realProfileBins - 1);
-                float rawDb =
-                    10.0f * std::log10(std::max(morphedPtr[p], 1e-12f));
+                float exactP = normPos * maxProfileIdx;
+                size_t p0 =
+                    std::clamp(static_cast<size_t>(exactP),
+                               static_cast<size_t>(0), realProfileBins - 1);
+                size_t p1 = std::min(p0 + 1, realProfileBins - 1);
+                float frac = exactP - static_cast<float>(p0);
+                float interpVal =
+                    (1.0f - frac) * morphedPtr[p0] + frac * morphedPtr[p1];
+                float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
                 frame.noiseFloorDB[i] = rawDb - dbOffset;
               }
             } else {
@@ -1058,18 +1063,20 @@ void NoiseRepellentAudioProcessor::processBlock(
                                      ? (20.0f * std::log10(maxProfileIdx))
                                      : 0.0f;
 
-          // Nearest-bin mapping (no interpolation): the display shows exactly
-          // the engine's native bins, so a shorter frame renders a visibly
-          // coarser profile and a longer frame a finer one. Interpolating
-          // would invent detail the engine never measured.
           for (size_t i = 0; i < kFftBins; ++i) {
             float normPos = static_cast<float>(i) / maxFftIdx;
-            size_t p = std::clamp(
-                static_cast<size_t>(normPos * maxProfileIdx + 0.5f),
-                static_cast<size_t>(0), realProfileBins - 1);
+            float exactP = normPos * maxProfileIdx;
 
-            float rawDb =
-                10.0f * std::log10(std::max(actualNoiseProfile[p], 1e-12f));
+            size_t p0 = std::clamp(static_cast<size_t>(exactP),
+                                   static_cast<size_t>(0), realProfileBins - 1);
+            size_t p1 = std::min(p0 + 1, realProfileBins - 1);
+            float frac = exactP - static_cast<float>(p0);
+
+            float val0 = actualNoiseProfile[p0];
+            float val1 = actualNoiseProfile[p1];
+            float interpVal = (1.0f - frac) * val0 + frac * val1;
+
+            float rawDb = 10.0f * std::log10(std::max(interpVal, 1e-12f));
             frame.noiseFloorDB[i] = rawDb - dbOffset;
           }
 
@@ -1137,7 +1144,6 @@ bool NoiseRepellentAudioProcessor::getNextSpectralFrame(SpectralFrame& frame) {
 void NoiseRepellentAudioProcessor::resetNoiseProfile() {
   specbleach_stereo_reset_profiles(engineGroup.get());
   pendingProfiles.clear();
-  profileResampledStale.store(false, std::memory_order_relaxed);
 }
 
 bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -112,11 +112,13 @@ void NoiseRepellentAudioProcessor::rebuildForFrameSizeChange() {
   ensureEnginesInitialized(currentSampleRate);
   updateLatencyReporting();
   // Fresh STFT history: clear visualization accumulators so the first frames
-  // after the switch don't mix pre/post-switch spectra.
+  // after the switch don't mix pre/post-switch spectra. The rebuilt
+  // pipeline is empty, so the silence streak restarts clean.
   fftAccumInput.fill(0.0f);
   fftAccumOutput.fill(0.0f);
   fftAccumTransient.fill(0.0f);
   fftAccumCount = 0;
+  silentBlocksStreak = 0;
   suspendProcessing(false);
   if (auto* editor = getActiveEditor())
     editor->repaint();
@@ -624,6 +626,9 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
   fftAccumOutput.fill(0.0f);
   fftAccumTransient.fill(0.0f);
   fftAccumCount = 0;
+  // Unknown pipeline state after (re)configuration: restart the silence
+  // streak so a fresh silence re-proves the flush before any sleep.
+  silentBlocksStreak = 0;
 }
 
 void NoiseRepellentAudioProcessor::releaseResources() {
@@ -639,25 +644,17 @@ bool NoiseRepellentAudioProcessor::isBusesLayoutSupported(
   return layouts.getMainOutputChannelSet() == layouts.getMainInputChannelSet();
 }
 
-void NoiseRepellentAudioProcessor::processBlock(
-    juce::AudioBuffer<float>& buffer, juce::MidiBuffer&) {
-  juce::ScopedNoDenormals noDenormals;
-  const int numSamples = buffer.getNumSamples();
-  const int numChannels = buffer.getNumChannels();
-
-  if (numSamples == 0 || numChannels == 0)
-    return;
-
-  const bool isBypassed =
-      parameters.getRawParameterValue("bypass")->load() > 0.5f;
+NoiseRepellentAudioProcessor::EngineParams
+NoiseRepellentAudioProcessor::buildEngineParams() {
+  EngineParams ep;
   const int algoMode = static_cast<int>(
       parameters.getRawParameterValue("algorithm_mode")->load());
-  const bool transientProtectionEnable =
+  ep.transientProtectionEnable =
       parameters.getRawParameterValue("transient_protection_enable")->load() >
       0.5f;
-  const bool learnNoise =
+  ep.learnNoise =
       parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
-  const bool adaptiveNoise =
+  ep.adaptiveNoise =
       parameters.getRawParameterValue("adaptive_noise")->load() > 0.5f;
   const int adaptiveMethod = static_cast<int>(
       parameters.getRawParameterValue("adaptive_method")->load());
@@ -695,10 +692,10 @@ void NoiseRepellentAudioProcessor::processBlock(
           ? profileOffset
           : parameters.getRawParameterValue("tonal_noise_profile_offset")
                 ->load();
-  const bool curveEnabled =
+  ep.curveEnabled =
       parameters.getRawParameterValue("reduction_curve_enabled")->load() > 0.5f;
 
-  if (curveEnabled) {
+  if (ep.curveEnabled) {
     if (curveNodesDirty.exchange(false)) {
       juce::SpinLock::ScopedTryLockType tryLock(curveLock);
       if (tryLock.isLocked()) {
@@ -724,30 +721,75 @@ void NoiseRepellentAudioProcessor::processBlock(
 
   // Single unified parameter block. The smoothing strategy is selected via
   // smoothing_mode: the library performs the seamless runtime switch
-  // internally (allocation-free crossfade, constant latency).
-  SpecbleachDenoiserParameters p{};
-  p.learn_noise = learnNoise ? SPECBLEACH_LEARN_ALL : SPECBLEACH_LEARN_OFF;
-  p.residual_listen = residualListen;
-  p.reduction_gain = reductionGain;
-  p.smoothing_factor = smoothingNorm;
-  p.smoothing_mode =
-      (algoMode == 1) ? SPECBLEACH_SMOOTHING_NLM_2D : SPECBLEACH_SMOOTHING_TEMPORAL;
-  p.whitening_factor = whiteningNorm;
-  p.adaptive_noise = adaptiveNoise;
-  p.noise_estimation_method =
+  // internally (allocation-free crossfade, constant latency per frame size).
+  ep.p.learn_noise =
+      ep.learnNoise ? SPECBLEACH_LEARN_ALL : SPECBLEACH_LEARN_OFF;
+  ep.p.residual_listen = residualListen;
+  ep.p.reduction_gain = reductionGain;
+  ep.p.smoothing_factor = smoothingNorm;
+  ep.p.smoothing_mode = (algoMode == 1) ? SPECBLEACH_SMOOTHING_NLM_2D
+                                        : SPECBLEACH_SMOOTHING_TEMPORAL;
+  ep.p.whitening_factor = whiteningNorm;
+  ep.p.adaptive_noise = ep.adaptiveNoise;
+  ep.p.noise_estimation_method =
       static_cast<SpecbleachNoiseEstimationMethod>(adaptiveMethod);
-  p.masking_depth = masking;
-  p.suppression_strength = 1.0f;
-  p.aggressiveness = aggressiveness;
-  p.tonal_reduction_gain = tonalReductionGain;
-  p.hpss_enable = transientProtectionEnable;
-  p.noise_profile_scale = profileScale;
-  p.reduction_curve_bias =
-      curveEnabled ? interpolatedCurveBias.data() : nullptr;
-  p.reduction_curve_enabled = curveEnabled;
-  p.reduction_curve_size =
-      curveEnabled ? static_cast<uint32_t>(interpolatedCurveBias.size()) : 0;
-  p.tonal_noise_profile_scale = tonalProfileScale;
+  ep.p.masking_depth = masking;
+  ep.p.suppression_strength = 1.0f;
+  ep.p.aggressiveness = aggressiveness;
+  ep.p.tonal_reduction_gain = tonalReductionGain;
+  ep.p.hpss_enable = ep.transientProtectionEnable;
+  ep.p.noise_profile_scale = profileScale;
+  ep.p.reduction_curve_bias =
+      ep.curveEnabled ? interpolatedCurveBias.data() : nullptr;
+  ep.p.reduction_curve_enabled = ep.curveEnabled;
+  ep.p.reduction_curve_size =
+      ep.curveEnabled ? static_cast<uint32_t>(interpolatedCurveBias.size())
+                      : 0;
+  ep.p.tonal_noise_profile_scale = tonalProfileScale;
+  return ep;
+}
+
+void NoiseRepellentAudioProcessor::runEngine(
+    juce::AudioBuffer<float>& buffer, const EngineParams& ep) {
+  if (engineGroup == nullptr)
+    return;
+  const int numChannels = buffer.getNumChannels();
+  // Process 1:1 up to the buffer width (mono hosts get a 1-engine group;
+  // layouts beyond stereo are rejected in isBusesLayoutSupported).
+  const uint32_t groupChannels = std::min<uint32_t>(
+      specbleach_stereo_get_channel_count(engineGroup.get()),
+      static_cast<uint32_t>(numChannels));
+  const float* inPtrs[2] = {nullptr, nullptr};
+  for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
+    inPtrs[ch] = buffer.getReadPointer(static_cast<int>(ch));
+
+  float* outPtrs[2] = {nullptr, nullptr};
+  for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
+    outPtrs[ch] = buffer.getWritePointer(static_cast<int>(ch));
+
+  // Push the latest parameter values ahead of processing, but only when
+  // they changed since the last push — steady-state blocks skip the
+  // setup-only library call (same-thread handoff, never concurrent).
+  loadParametersIfChanged(ep.p, ep.curveEnabled);
+  specbleach_stereo_process(engineGroup.get(),
+                            static_cast<uint32_t>(buffer.getNumSamples()),
+                            inPtrs, outPtrs);
+}
+
+void NoiseRepellentAudioProcessor::processBlock(
+    juce::AudioBuffer<float>& buffer, juce::MidiBuffer&) {
+  juce::ScopedNoDenormals noDenormals;
+  const int numSamples = buffer.getNumSamples();
+  const int numChannels = buffer.getNumChannels();
+
+  if (numSamples == 0 || numChannels == 0)
+    return;
+
+  const bool isBypassed =
+      parameters.getRawParameterValue("bypass")->load() > 0.5f;
+  const EngineParams ep = buildEngineParams();
+  const bool learnNoise = ep.learnNoise;
+  const bool adaptiveNoise = ep.adaptiveNoise;
 
   // Silence detection: when input is ~-100dB and not learning, skip heavy
   // STFT+denoise (was culprit for idle > denoising and no-playback CPU).
@@ -780,37 +822,39 @@ void NoiseRepellentAudioProcessor::processBlock(
   dryWetMixer.pushDrySamples(audioBlock);
 
   const bool hasProfile = hasNoiseProfile();
-  const bool canSkipDenoise =
-      isSilent && !hasProfile && !adaptiveNoise && !learnNoise;
+  // Sleep the engine on silence only after the streak outlasts the whole
+  // pipeline (reported latency plus gain-release tails): the pipeline
+  // holds over a full latency of future output, so an output-silence check
+  // cannot tell "empty" from "still primed". Bypass always runs — see below.
+  if (isSilent)
+    ++silentBlocksStreak;
+  else
+    silentBlocksStreak = 0;
+  const double tailMarginSamples =
+      (currentSampleRate > 0.0 ? currentSampleRate * 0.5 : 24000.0);
+  const double flushSamples =
+      static_cast<double>(currentLatency) + tailMarginSamples;
+  const bool pipelineFlushed =
+      static_cast<double>(silentBlocksStreak) *
+          static_cast<double>(std::max(numSamples, 1)) >
+      flushSamples;
+  const bool canSkipDenoise = isSilent && pipelineFlushed && !hasProfile &&
+                              !adaptiveNoise && !learnNoise;
 
-  if (isBypassed || canSkipDenoise) {
-    // Skip specbleach STFT and denoise when bypassed or when silent with
-    // no noise profile or adaptive estimation active.
-    if (canSkipDenoise) {
-      buffer.clear();
-    }
-  } else if (engineGroup != nullptr) {
-    // Process 1:1 up to the buffer width (mono hosts get a 1-engine group;
-    // layouts beyond stereo are rejected in isBusesLayoutSupported).
-    const uint32_t groupChannels = std::min<uint32_t>(
-        specbleach_stereo_get_channel_count(engineGroup.get()),
-        static_cast<uint32_t>(numChannels));
-    const float* inPtrs[2] = {nullptr, nullptr};
-    for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
-      inPtrs[ch] = buffer.getReadPointer(static_cast<int>(ch));
-
-    float* outPtrs[2] = {nullptr, nullptr};
-    for (uint32_t ch = 0; ch < groupChannels && ch < 2u; ++ch)
-      outPtrs[ch] = buffer.getWritePointer(static_cast<int>(ch));
-
-    // Push the latest parameter values ahead of processing, but only when
-    // they changed since the last push — steady-state blocks skip the
-    // setup-only library call (same-thread handoff, never concurrent).
-    loadParametersIfChanged(p, curveEnabled);
-    specbleach_stereo_process(
-        engineGroup.get(), static_cast<uint32_t>(numSamples), inPtrs, outPtrs);
-    // Latency is constant for both smoothing modes — no wet compensation
-    // padding and no host PDC handoff are ever needed.
+  if (canSkipDenoise && !isBypassed) {
+    // True idle: silence persisted past every tail, nothing learned or
+    // tracked. The engine sleeps; cleared output keeps the silence.
+    buffer.clear();
+  } else {
+    // The engine ALWAYS runs while bypassed. Skipping it would leave the
+    // raw current input in the buffer while the mixer's wet gain is still
+    // ~1 from before the toggle — the output would jump forward by a full
+    // engine latency and then sweep back over the crossfade (audible skip,
+    // scaling with frame size). With the engine running, both crossfade
+    // endpoints carry pipeline-delayed (t - latency) content and the
+    // toggle is seamless. Bonus: NLM/STFT history stays warm, so
+    // un-bypassing has no re-convergence glitch.
+    runEngine(buffer, ep);
   }
 
   // Query transient protection status and intensity (aggregated max across
@@ -821,8 +865,8 @@ void NoiseRepellentAudioProcessor::processBlock(
         specbleach_stereo_get_transient_intensity(engineGroup.get());
   transientActivity.store(reportedTransientIntensity,
                           std::memory_order_relaxed);
-  transientProtectionActive.store(transientProtectionEnable,
-                                  std::memory_order_relaxed);
+  transientProtectionActive.store(ep.transientProtectionEnable,
+                                   std::memory_order_relaxed);
 
   // Apply Soft Crossfade Bypass using JUCE DryWetMixer (with dry latency
   // compensation)
@@ -858,7 +902,7 @@ void NoiseRepellentAudioProcessor::processBlock(
                  ->load() > 0.5f);
         frame.transientIntensity = 0.0f;
         frame.isTransientProtected = false;
-        frame.isTransientProtectionActive = transientProtectionEnable;
+        frame.isTransientProtectionActive = ep.transientProtectionEnable;
         frame.tonalPeaksHz.clear();
         // Keep learned noise profile frozen while input/output fall — use
         // same active-profile logic as the normal FFT path so the line does
@@ -1052,7 +1096,7 @@ void NoiseRepellentAudioProcessor::processBlock(
         }
         frame.transientIntensity = maxWindowTransient;
         frame.isTransientProtected = (maxWindowTransient > 0.05f);
-        frame.isTransientProtectionActive = transientProtectionEnable;
+        frame.isTransientProtectionActive = ep.transientProtectionEnable;
         frame.tonalPeaksHz.clear();
 
         if (profileAvailable && actualNoiseProfile) {
@@ -1129,6 +1173,11 @@ void NoiseRepellentAudioProcessor::processBlockBypassed(
 
   juce::dsp::AudioBlock<float> audioBlock(buffer);
   dryWetMixer.pushDrySamples(audioBlock);
+  // Run the engine even though the wet path is muted: same alignment
+  // requirement as the internal bypass (see processBlock) — the buffer
+  // must hold pipeline-delayed content while the mixer ramps down, and
+  // the delay line stays warm for the resume boundary.
+  runEngine(buffer, buildEngineParams());
   dryWetMixer.setWetMixProportion(0.0f);
   dryWetMixer.mixWetSamples(audioBlock);
 }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -24,8 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 
-// STFT frame sent to libspecbleach (matches library examples/header docs).
-constexpr float kEngineFrameSizeMs = 46.0f;
 // Silence gate: amplitude floor ~-100 dB, i.e. the amplitude-domain twin of
 // libspecbleach's ESTIMATOR_SILENCE_THRESHOLD (1e-10 power).
 constexpr float kSilenceAmplitudeFloor = 1e-5f;
@@ -60,17 +58,64 @@ NoiseRepellentAudioProcessor::NoiseRepellentAudioProcessor()
       dryWetMixer(16384) {
   bypassParameter = dynamic_cast<juce::AudioParameterBool*>(
       parameters.getParameter("bypass"));
+  parameters.addParameterListener("frame_size", this);
   juce::ignoreUnused(specbleach_get_version_string());
   DBG(specbleach_get_version_string()); // banner is "libspecbleach X.Y.Z"
 }
 
 NoiseRepellentAudioProcessor::~NoiseRepellentAudioProcessor() {
+  parameters.removeParameterListener("frame_size", this);
   releaseResources();
 }
 
 juce::AudioProcessorParameter*
 NoiseRepellentAudioProcessor::getBypassParameter() const {
   return bypassParameter;
+}
+
+float NoiseRepellentAudioProcessor::getFrameSizeMs() const {
+  if (auto* choice = dynamic_cast<juce::AudioParameterChoice*>(
+          parameters.getParameter("frame_size"))) {
+    const int index = choice->getIndex();
+    if (index >= 0 && index < 4)
+      return kFrameSizeOptionsMs[static_cast<size_t>(index)];
+  }
+  return kFrameSizeOptionsMs[kDefaultFrameSizeIndex];
+}
+
+void NoiseRepellentAudioProcessor::parameterChanged(
+    const juce::String& parameterID, float /*newValue*/) {
+  if (parameterID != "frame_size")
+    return;
+  // APVTS listeners run on the message thread for non-automatable params
+  // touched from the Options menu; state restore happens before
+  // prepareToPlay so there is nothing live to rebuild yet.
+  if (juce::MessageManager::getInstance()->isThisTheMessageThread()) {
+    rebuildForFrameSizeChange();
+  } else {
+    juce::MessageManager::callAsync([this]() { rebuildForFrameSizeChange(); });
+  }
+}
+
+void NoiseRepellentAudioProcessor::rebuildForFrameSizeChange() {
+  if (currentSampleRate <= 0.0 || engineGroup == nullptr)
+    return; // not prepared yet — next prepareToPlay picks up the new value
+  // Auto-stop an in-progress Learn: a half-rolled mean must not migrate
+  // across resolutions.
+  if (auto* learn = parameters.getParameter("learn_noise"))
+    learn->setValueNotifyingHost(0.0f);
+  suspendProcessing(true);
+  ensureEnginesInitialized(currentSampleRate);
+  updateLatencyReporting();
+  // Fresh STFT history: clear visualization accumulators so the first frames
+  // after the switch don't mix pre/post-switch spectra.
+  fftAccumInput.fill(0.0f);
+  fftAccumOutput.fill(0.0f);
+  fftAccumTransient.fill(0.0f);
+  fftAccumCount = 0;
+  suspendProcessing(false);
+  if (auto* editor = getActiveEditor())
+    editor->repaint();
 }
 
 juce::AudioProcessorValueTreeState::ParameterLayout
@@ -81,6 +126,13 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
       "algorithm_mode", "Smoothing Quality",
       juce::StringArray{"Standard (Fast & Low CPU)", "Patch-Based (High Quality)"},
       0));
+
+  params.push_back(std::make_unique<juce::AudioParameterChoice>(
+      "frame_size", "STFT Frame Size",
+      juce::StringArray{"23 ms", "32 ms", "46 ms", "64 ms"},
+      NoiseRepellentAudioProcessor::kDefaultFrameSizeIndex,
+      juce::AudioParameterChoiceAttributes().withAutomatable(false).withMeta(
+          true)));
 
   params.push_back(std::make_unique<juce::AudioParameterBool>(
       "transient_protection_enable", "Transient Protection", false));
@@ -372,13 +424,18 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
       (engineGroup != nullptr)
           ? specbleach_stereo_get_channel_count(engineGroup.get())
           : 0;
+  const float wantedFrameSizeMs = getFrameSizeMs();
   const bool needNewEngines =
       (engineGroup == nullptr ||
        std::abs(currentSampleRate - sampleRate) > 0.001 ||
-       currentGroupChannels != wantedChannels);
+       currentGroupChannels != wantedChannels ||
+       std::abs(currentFrameSizeMs - wantedFrameSizeMs) > 0.001f);
 
   if (!needNewEngines)
     return;
+
+  const bool frameSizeChanged =
+      std::abs(currentFrameSizeMs - wantedFrameSizeMs) > 0.001f;
 
   struct SavedProfileData {
     int channel; // 0 = Left, 1 = Right
@@ -422,9 +479,12 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
 
   const uint32_t sampleRateUint = static_cast<uint32_t>(sampleRate);
   engineGroup = specbleach::make_stereo_group(sampleRateUint,
-                                                kEngineFrameSizeMs, channels);
+                                              wantedFrameSizeMs, channels);
 
   currentSampleRate = sampleRate;
+  currentFrameSizeMs = wantedFrameSizeMs;
+  if (frameSizeChanged && !savedProfiles.empty())
+    profileResampledStale.store(true, std::memory_order_relaxed);
   preparedNumChannels = channels;
 
   // Restore backed-up profiles into the new group (library resamples to
@@ -502,16 +562,26 @@ void NoiseRepellentAudioProcessor::ensureEnginesInitialized(double sampleRate) {
   }
 }
 
-void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
-                                                 int samplesPerBlock) {
-  ensureEnginesInitialized(sampleRate);
-
-  // Latency is constant for both smoothing modes (the library pads the
-  // temporal path to the NLM look-ahead), so it is set once here.
+void NoiseRepellentAudioProcessor::updateLatencyReporting() {
+  // Latency depends on the STFT frame size (frame + NLM look-ahead) but is
+  // constant across smoothing modes (temporal is padded to the NLM
+  // look-ahead), so hosts only need a re-report after a frame-size switch.
   const uint32_t reportedLatency =
       engineGroup ? specbleach_stereo_get_latency(engineGroup.get()) : 0;
   lastReportedLatency = reportedLatency;
   setLatencySamples(static_cast<int>(reportedLatency));
+  dryWetMixer.setWetLatency(static_cast<float>(reportedLatency));
+
+  currentLatency = reportedLatency;
+  visualizerDelayBuffer.assign(
+      std::max<size_t>(32768, static_cast<size_t>(reportedLatency) + 8192),
+      0.0f);
+  visualizerDelayWritePos = 0;
+}
+
+void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
+                                                 int samplesPerBlock) {
+  ensureEnginesInitialized(sampleRate);
 
   const int bufferCapacity = std::max(samplesPerBlock, 16384);
   preparedBlockSize = static_cast<uint32_t>(bufferCapacity);
@@ -525,13 +595,7 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
 
   dryWetMixer.prepare(spec);
   dryWetMixer.setMixingRule(juce::dsp::DryWetMixingRule::linear);
-  dryWetMixer.setWetLatency(static_cast<float>(reportedLatency));
-
-  currentLatency = reportedLatency;
-  visualizerDelayBuffer.assign(
-      std::max<size_t>(32768, static_cast<size_t>(reportedLatency) + 8192),
-      0.0f);
-  visualizerDelayWritePos = 0;
+  updateLatencyReporting();
 
   // Pre-allocate persistent buffers to prevent audio-thread allocations
   dryInputL.resize(static_cast<size_t>(bufferCapacity), 0.0f);
@@ -544,8 +608,6 @@ void NoiseRepellentAudioProcessor::prepareToPlay(double sampleRate,
 
   // NB: pendingProfiles is owned by ensureEnginesInitialized — retained
   // (narrow-group) entries must survive prepareToPlay for a later rebuild.
-  currentLatency = reportedLatency;
-  dryWetMixer.setWetLatency(static_cast<float>(reportedLatency));
 
   // Reset FFT accumulation
   fftAccumInput.fill(0.0f);
@@ -585,6 +647,8 @@ void NoiseRepellentAudioProcessor::processBlock(
       0.5f;
   const bool learnNoise =
       parameters.getRawParameterValue("learn_noise")->load() > 0.5f;
+  if (learnNoise)
+    profileResampledStale.store(false, std::memory_order_relaxed);
   const bool adaptiveNoise =
       parameters.getRawParameterValue("adaptive_noise")->load() > 0.5f;
   const int adaptiveMethod = static_cast<int>(
@@ -1076,6 +1140,7 @@ bool NoiseRepellentAudioProcessor::getNextSpectralFrame(SpectralFrame& frame) {
 void NoiseRepellentAudioProcessor::resetNoiseProfile() {
   specbleach_stereo_reset_profiles(engineGroup.get());
   pendingProfiles.clear();
+  profileResampledStale.store(false, std::memory_order_relaxed);
 }
 
 bool NoiseRepellentAudioProcessor::hasNoiseProfile() const {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -36,8 +36,8 @@ public:
 
   // Stepped STFT frame-size options (ms) exposed in the Options menu.
   // Index 2 (46 ms) is the legacy default.
-  static constexpr float kFrameSizeOptionsMs[4] = {23.0f, 32.0f, 46.0f,
-                                                  64.0f};
+  static constexpr float kFrameSizeOptionsMs[5] = {23.0f, 32.0f, 46.0f,
+                                                  64.0f, 93.0f};
   static constexpr int kDefaultFrameSizeIndex = 2;
   float getFrameSizeMs() const;
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -134,9 +134,6 @@ public:
 
   void resetNoiseProfile();
   bool hasNoiseProfile() const;
-  bool isProfileResampledStale() const {
-    return profileResampledStale.load(std::memory_order_relaxed);
-  }
 
   double getSampleRate() const {
     return currentSampleRate;
@@ -193,10 +190,6 @@ public:
   // "frame_size" APVTS choice; compared in ensureEnginesInitialized to detect
   // a rebuild request. Message thread only (written under suspendProcessing).
   float currentFrameSizeMs = kFrameSizeOptionsMs[kDefaultFrameSizeIndex];
-  // Set when a frame-size switch resampled a learned profile: the kept
-  // profile is valid but captured at a different resolution, so the GUI
-  // should recommend re-learning. Cleared on reset/learn.
-  std::atomic<bool> profileResampledStale{false};
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> transientProtectionActive{false};
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -153,6 +153,16 @@ public:
   void rebuildForFrameSizeChange();
   void parameterChanged(const juce::String& parameterID,
                         float newValue) override;
+  // Parameter snapshot for one engine run (built from APVTS per block).
+  struct EngineParams {
+    SpecbleachDenoiserParameters p{};
+    bool curveEnabled = false;
+    bool learnNoise = false;
+    bool adaptiveNoise = false;
+    bool transientProtectionEnable = false;
+  };
+  EngineParams buildEngineParams();
+  void runEngine(juce::AudioBuffer<float>& buffer, const EngineParams& ep);
   void interpolateCurve(uint32_t numBins);
   // Pushes p to the engine group only when it differs from the last pushed
   // block (same-thread, serialized with process calls — never concurrent).
@@ -186,6 +196,11 @@ public:
   // call — readers must tolerate "host hasn't informed us yet" (see the
   // sr <= 0 fallback in interpolateCurve).
   double currentSampleRate = 0.0;
+  // Consecutive silent input blocks. The engine may sleep on silence only
+  // after the streak outlasts the full pipeline (latency + gain-release
+  // tails) — sleeping earlier would chop decaying tails and swallow sparse
+  // transients mid-response. Audio thread only.
+  uint32_t silentBlocksStreak = 0;
   // Frame size (ms) the live engine group was built with. Mirrors the
   // "frame_size" APVTS choice; compared in ensureEnginesInitialized to detect
   // a rebuild request. Message thread only (written under suspendProcessing).

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -28,10 +28,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "specbleach_stereo.hpp" // self-guarding for C++; do NOT wrap in extern "C"
 #include "specbleach_version.h"
 
-class NoiseRepellentAudioProcessor : public juce::AudioProcessor {
+class NoiseRepellentAudioProcessor : public juce::AudioProcessor,
+                                        private juce::AudioProcessorValueTreeState::Listener {
 public:
   NoiseRepellentAudioProcessor();
   ~NoiseRepellentAudioProcessor() override;
+
+  // Stepped STFT frame-size options (ms) exposed in the Options menu.
+  // Index 2 (46 ms) is the legacy default.
+  static constexpr float kFrameSizeOptionsMs[4] = {23.0f, 32.0f, 46.0f,
+                                                  64.0f};
+  static constexpr int kDefaultFrameSizeIndex = 2;
+  float getFrameSizeMs() const;
 
   void prepareToPlay(double sampleRate, int samplesPerBlock) override;
   void releaseResources() override;
@@ -126,6 +134,9 @@ public:
 
   void resetNoiseProfile();
   bool hasNoiseProfile() const;
+  bool isProfileResampledStale() const {
+    return profileResampledStale.load(std::memory_order_relaxed);
+  }
 
   double getSampleRate() const {
     return currentSampleRate;
@@ -139,8 +150,12 @@ public:
     return transientProtectionActive.load(std::memory_order_relaxed);
   }
 
-private:
+ private:
   void ensureEnginesInitialized(double sampleRate);
+  void updateLatencyReporting();
+  void rebuildForFrameSizeChange();
+  void parameterChanged(const juce::String& parameterID,
+                        float newValue) override;
   void interpolateCurve(uint32_t numBins);
   // Pushes p to the engine group only when it differs from the last pushed
   // block (same-thread, serialized with process calls — never concurrent).
@@ -174,6 +189,14 @@ private:
   // call — readers must tolerate "host hasn't informed us yet" (see the
   // sr <= 0 fallback in interpolateCurve).
   double currentSampleRate = 0.0;
+  // Frame size (ms) the live engine group was built with. Mirrors the
+  // "frame_size" APVTS choice; compared in ensureEnginesInitialized to detect
+  // a rebuild request. Message thread only (written under suspendProcessing).
+  float currentFrameSizeMs = kFrameSizeOptionsMs[kDefaultFrameSizeIndex];
+  // Set when a frame-size switch resampled a learned profile: the kept
+  // profile is valid but captured at a different resolution, so the GUI
+  // should recommend re-learning. Cleared on reset/learn.
+  std::atomic<bool> profileResampledStale{false};
   std::atomic<float> transientActivity{0.0f};
   std::atomic<bool> transientProtectionActive{false};
 
@@ -220,7 +243,7 @@ private:
   std::vector<float> visualizerDelayBuffer;
   size_t visualizerDelayWritePos = 0;
   uint32_t currentLatency = 0;
-  uint32_t lastReportedLatency = 0; // constant for both smoothing modes
+  uint32_t lastReportedLatency = 0; // constant per frame size / smoothing mode
 
   juce::AudioParameterBool* bypassParameter = nullptr;
   juce::dsp::DryWetMixer<float> dryWetMixer;

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -186,6 +186,9 @@ public:
 
     beginTest("Transient Protection Dynamic Response");
     testTransientProtection();
+
+    beginTest("Frame-Size Switch Preserves Profile and Re-reports Latency");
+    testFrameSizeSwitch();
   }
 
 private:
@@ -699,6 +702,73 @@ private:
     float transientAct = proc.consumeTransientActivity();
     // Transient activity should be reported or preserved safely
     expect(!std::isnan(transientAct), "Transient activity must be a valid number");
+
+    proc.releaseResources();
+  }
+
+  void testFrameSizeSwitch() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+
+    NoiseRepellentAudioProcessor proc;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+
+    // Default must be the legacy 46 ms frame.
+    expectWithinAbsoluteError(proc.getFrameSizeMs(), 46.0f, 1e-6f,
+                              "Default frame size must be 46 ms");
+    const int latency46 = proc.getLatencySamples();
+    expect(latency46 > 0, "Default engine must report positive latency");
+
+    learnProfile(proc, sampleRate, blockSize, 20);
+    expect(proc.hasNoiseProfile(), "Profile must exist before the switch");
+
+    // Upscale 46 -> 64 ms (choice index 2 -> 3) on the message thread.
+    setParam(proc, "frame_size", 3.0f);
+    pumpMessageLoop(50);
+    expectWithinAbsoluteError(proc.getFrameSizeMs(), 64.0f, 1e-6f,
+                              "Frame size must switch to 64 ms");
+    expect(proc.getLatencySamples() > latency46,
+           "Larger frame must report larger latency");
+    expect(proc.hasNoiseProfile(),
+           "Learned profile must survive the switch via resampling");
+    expect(proc.isProfileResampledStale(),
+           "Resampled profile must be flagged stale until re-learn");
+
+    // Audio must keep flowing without NaNs after the rebuild.
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+    for (int b = 0; b < 10; ++b) {
+      generateNoiseBuffer(buffer, 0.05f, 5000 + b);
+      proc.processBlock(buffer, midi);
+      for (int ch = 0; ch < buffer.getNumChannels(); ++ch) {
+        const float* d = buffer.getReadPointer(ch);
+        for (int s = 0; s < buffer.getNumSamples(); ++s)
+          expect(!std::isnan(d[s]) && !std::isinf(d[s]),
+                 "Output must stay finite after frame-size switch");
+      }
+    }
+
+    // Downscale back to 46 ms: profile still present, latency restored.
+    setParam(proc, "frame_size", 2.0f);
+    pumpMessageLoop(50);
+    expect(proc.getLatencySamples() == latency46,
+           "Latency must return to the 46 ms value");
+    expect(proc.hasNoiseProfile(), "Profile must survive the switch back");
+
+    // Switch with no profile: plain rebuild, nothing flagged.
+    NoiseRepellentAudioProcessor fresh;
+    fresh.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+    setParam(fresh, "frame_size", 0.0f);
+    pumpMessageLoop(50);
+    expectWithinAbsoluteError(fresh.getFrameSizeMs(), 23.0f, 1e-6f,
+                              "Fresh instance must switch to 23 ms");
+    expect(!fresh.hasNoiseProfile(),
+           "Fresh instance must still have no profile");
+    expect(!fresh.isProfileResampledStale(),
+           "No profile means nothing to flag stale");
+    fresh.releaseResources();
 
     proc.releaseResources();
   }

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -762,6 +762,23 @@ private:
     expect(proc.hasNoiseProfile(),
            "Re-learn must capture a fresh profile after the switch");
 
+    // Largest step (93 ms, choice index 4): latency grows again within the
+    // DryWetMixer's headroom, audio stays finite, profile resets.
+    setParam(proc, "frame_size", 4.0f);
+    pumpMessageLoop(50);
+    expectWithinAbsoluteError(proc.getFrameSizeMs(), 93.0f, 1e-6f,
+                              "Frame size must switch to 93 ms");
+    expect(proc.getLatencySamples() > latency46,
+           "93 ms frame must report larger latency than 46 ms");
+    expect(proc.getLatencySamples() < 16384,
+           "93 ms latency must fit the DryWetMixer delay headroom");
+    expect(!proc.hasNoiseProfile(),
+           "Switch to 93 ms must reset the learned profile");
+    generateNoiseBuffer(buffer, 0.05f, 6000);
+    proc.processBlock(buffer, midi);
+    expect(!std::isnan(buffer.getSample(0, 0)),
+           "Output must stay finite at 93 ms");
+
     // Switch with no profile: plain rebuild, nothing flagged.
     NoiseRepellentAudioProcessor fresh;
     fresh.prepareToPlay(sampleRate, blockSize);

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -189,6 +189,9 @@ public:
 
     beginTest("Frame-Size Switch Preserves Profile and Re-reports Latency");
     testFrameSizeSwitch();
+
+    beginTest("Bypass Toggle Stays Time-Aligned (No Skip)");
+    testBypassToggleAlignment();
   }
 
 private:
@@ -790,6 +793,78 @@ private:
     expect(!fresh.hasNoiseProfile(),
            "Fresh instance must still have no profile");
     fresh.releaseResources();
+
+    proc.releaseResources();
+  }
+
+  void testBypassToggleAlignment() {
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 512;
+    constexpr int settleBlocks = 12; // > latency (4416) + margin
+
+    NoiseRepellentAudioProcessor proc;
+    proc.prepareToPlay(sampleRate, blockSize);
+    pumpMessageLoop(10);
+
+    // Unity reduction: the wet path passes signal through cleanly so peak
+    // positions purely reflect pipeline delay, not denoising.
+    setParam(proc, "reduction_amount", 0.0f);
+
+    const int latency = proc.getLatencySamples();
+    expect(latency > 0, "Engine must report positive latency");
+
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    juce::MidiBuffer midi;
+
+    // Fires one isolated impulse over a low (non-silent) noise floor and
+    // returns its stream offset of peak energy. The floor keeps the engine
+    // deterministically running (no silence-sleep involvement) while sitting
+    // far below the impulse and the detection threshold; history stays
+    // near-clean so the response is deterministic.
+    int seedCounter = 0;
+    auto fireImpulse = [&](std::vector<float>& stream) {
+      stream.clear();
+      stream.reserve(static_cast<size_t>(blockSize) * settleBlocks);
+      for (int b = 0; b < settleBlocks; ++b) {
+        generateNoiseBuffer(buffer, 0.0001f, 9000 + seedCounter++);
+        if (b == 0)
+          buffer.setSample(0, 0, buffer.getSample(0, 0) + 0.5f);
+        proc.processBlock(buffer, midi);
+        const float* d = buffer.getReadPointer(0);
+        stream.insert(stream.end(), d, d + blockSize);
+      }
+      size_t peakIdx = 0;
+      float peakVal = 0.0f;
+      for (size_t i = 0; i < stream.size(); ++i) {
+        if (std::abs(stream[i]) > peakVal) {
+          peakVal = std::abs(stream[i]);
+          peakIdx = i;
+        }
+      }
+      return std::pair<size_t, float>{peakIdx, peakVal};
+    };
+
+    auto expectPeakAtLatency = [&](const char* what) {
+      std::vector<float> stream;
+      const auto [peakIdx, peakVal] = fireImpulse(stream);
+      fprintf(stderr, "DBG %s: peak=%zu val=%.4f latency=%d\n", what, peakIdx,
+              peakVal, latency);
+      expect(peakVal > 0.1f,
+             juce::String(what) + ": impulse must come through");
+      expect(static_cast<int>(std::abs(static_cast<int>(peakIdx) - latency)) <=
+                 2,
+             juce::String(what) +
+                 ": impulse must land on the reported latency, not jump");
+    };
+
+    // Baseline: unbypassed wet path delay.
+    expectPeakAtLatency("Unbypassed");
+    // Engage: the old skip-the-engine code time-travelled and peaked at ~0.
+    setParam(proc, "bypass", 1.0f);
+    expectPeakAtLatency("Bypassed");
+    // Disengage: engine never stopped, so alignment holds by construction.
+    setParam(proc, "bypass", 0.0f);
+    expectPeakAtLatency("Un-bypassed");
 
     proc.releaseResources();
   }

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -770,7 +770,7 @@ private:
                               "Frame size must switch to 93 ms");
     expect(proc.getLatencySamples() > latency46,
            "93 ms frame must report larger latency than 46 ms");
-    expect(proc.getLatencySamples() < 16384,
+    expect(proc.getLatencySamples() < 65536,
            "93 ms latency must fit the DryWetMixer delay headroom");
     expect(!proc.hasNoiseProfile(),
            "Switch to 93 ms must reset the learned profile");

--- a/Source/Tests/test_integration.cpp
+++ b/Source/Tests/test_integration.cpp
@@ -724,16 +724,16 @@ private:
     expect(proc.hasNoiseProfile(), "Profile must exist before the switch");
 
     // Upscale 46 -> 64 ms (choice index 2 -> 3) on the message thread.
+    // Policy: the switch resets the profile (resampling across resolutions
+    // works poorly), so the user re-learns at native resolution.
     setParam(proc, "frame_size", 3.0f);
     pumpMessageLoop(50);
     expectWithinAbsoluteError(proc.getFrameSizeMs(), 64.0f, 1e-6f,
                               "Frame size must switch to 64 ms");
     expect(proc.getLatencySamples() > latency46,
            "Larger frame must report larger latency");
-    expect(proc.hasNoiseProfile(),
-           "Learned profile must survive the switch via resampling");
-    expect(proc.isProfileResampledStale(),
-           "Resampled profile must be flagged stale until re-learn");
+    expect(!proc.hasNoiseProfile(),
+           "Frame-size switch must reset the learned profile");
 
     // Audio must keep flowing without NaNs after the rebuild.
     juce::AudioBuffer<float> buffer(2, blockSize);
@@ -749,12 +749,18 @@ private:
       }
     }
 
-    // Downscale back to 46 ms: profile still present, latency restored.
+    // Downscale back to 46 ms: still no profile, latency restored.
     setParam(proc, "frame_size", 2.0f);
     pumpMessageLoop(50);
     expect(proc.getLatencySamples() == latency46,
            "Latency must return to the 46 ms value");
-    expect(proc.hasNoiseProfile(), "Profile must survive the switch back");
+    expect(!proc.hasNoiseProfile(),
+           "Profile must stay cleared after switching back");
+
+    // Re-learning at the new size works normally.
+    learnProfile(proc, sampleRate, blockSize, 20);
+    expect(proc.hasNoiseProfile(),
+           "Re-learn must capture a fresh profile after the switch");
 
     // Switch with no profile: plain rebuild, nothing flagged.
     NoiseRepellentAudioProcessor fresh;
@@ -766,8 +772,6 @@ private:
                               "Fresh instance must switch to 23 ms");
     expect(!fresh.hasNoiseProfile(),
            "Fresh instance must still have no profile");
-    expect(!fresh.isProfileResampledStale(),
-           "No profile means nothing to flag stale");
     fresh.releaseResources();
 
     proc.releaseResources();

--- a/Source/Tests/test_performance.cpp
+++ b/Source/Tests/test_performance.cpp
@@ -219,6 +219,17 @@ private:
       juce::AudioBuffer<float> buffer(2, blockSize);
       juce::MidiBuffer midi;
 
+      // Learn a profile first so the bypass run executes the identical
+      // engine workload as the active run (learning works while bypassed;
+      // only monitoring is muted).
+      setParam(proc, "learn_noise", 1.0f);
+      for (int i = 0; i < 50; ++i) {
+        buffer.makeCopyOf(noiseBlocks[i % numBlocks]);
+        proc.processBlock(buffer, midi);
+      }
+      setParam(proc, "learn_noise", 0.0f);
+      pumpMessageLoop(20);
+
       setParam(proc, "bypass", 1.0f);
       pumpMessageLoop(20);
 
@@ -243,13 +254,16 @@ private:
     expect(bypassDurationUs > 0, "Bypass duration must be greater than zero");
     expect(activeDurationUs > 0, "Active duration must be greater than zero");
 
-    const double speedupRatio =
+    // Bypass keeps the full pipeline running (time-alignment across the
+    // toggle), so its throughput must be comparable to active denoising —
+    // neither skipping the engine (much faster) nor duplicating work.
+    const double parityRatio =
         static_cast<double>(activeDurationUs) /
         static_cast<double>(std::max<int64_t>(1, bypassDurationUs));
 
-    expect(speedupRatio >= 2.5,
-           "Bypassed processing must be at least 2.5x faster than active "
-           "denoising");
+    expect(parityRatio >= 0.5 && parityRatio <= 2.0,
+           "Bypassed processing must run the same pipeline as active "
+           "denoising (comparable throughput, within 2x)");
   }
 };
 

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -30,6 +30,7 @@ This document defines the critical UX invariants and architectural contracts tha
 ## 7. Frame-Size Switching
 * **Clean Slate:** A frame-size switch discards the learned profile (resampling across resolutions works poorly) and the HUD falls back to `NO PROFILE (PASS-THROUGH)` until the user re-learns at native resolution. Session state restores are exempt — profiles saved in a session load into the fresh engine normally.
 * **Learn Safety:** An in-progress Learn is auto-stopped before the rebuild; a half-rolled mean must never migrate across resolutions.
+* **Large-Frame Character (expected):** 64/93 ms trades time resolution for frequency resolution — transients smear across the (frame-counted) NLM patch and gain envelopes step per hop, which reads as "robotic" on transient material. This is inherent DSP tradeoff, not a defect; the Options menu steers transient material to 23/32 ms. Frame-rate-independent time constants are tracked as future library work (libspecbleach#152).
 
 ## 6. Real-Time Safety & Performance Hierarchy
 * **Strict RT-Safety:** The audio thread (`processBlock`) must never perform dynamic memory allocations, take blocking locks/mutexes, or execute file/console I/O. Runtime smoothing mode changes are allocation-free inside the library.

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -28,6 +28,7 @@ This document defines the critical UX invariants and architectural contracts tha
 
 ## 7. Frame-Size Switching
 * **Profile Preservation:** A learned profile survives a frame-size switch via resampled restore and is flagged stale (`STATUS: PROFILE RESAMPLED - RE-LEARN ADVISED`) until the user re-learns or resets, since resampling cannot invent (upscale) or keep (downscale) native-bin detail.
+* **Native-Resolution Display:** The profile line renders the engine's native bins (nearest-bin mapped, no display smoothing), so a shorter frame looks visibly coarser and a longer frame finer. Input/output spectra stay on the fixed high-resolution analysis FFT — they are independent measurements, not engine internals.
 * **Learn Safety:** An in-progress Learn is auto-stopped before the rebuild; a half-rolled mean must never migrate across resolutions.
 
 ## 6. Real-Time Safety & Performance Hierarchy

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -27,8 +27,7 @@ This document defines the critical UX invariants and architectural contracts tha
 * **No Host Suspension For Mode Switches:** Mode switching must never trigger `suspendProcessing`, latency re-reports, or profile migration in the plugin. Frame-size switches are the exception: they suspend, rebuild, and re-report.
 
 ## 7. Frame-Size Switching
-* **Profile Preservation:** A learned profile survives a frame-size switch via resampled restore and is flagged stale (`STATUS: PROFILE RESAMPLED - RE-LEARN ADVISED`) until the user re-learns or resets, since resampling cannot invent (upscale) or keep (downscale) native-bin detail.
-* **Native-Resolution Display:** The profile line renders the engine's native bins (nearest-bin mapped, no display smoothing), so a shorter frame looks visibly coarser and a longer frame finer. Input/output spectra stay on the fixed high-resolution analysis FFT — they are independent measurements, not engine internals.
+* **Clean Slate:** A frame-size switch discards the learned profile (resampling across resolutions works poorly) and the HUD falls back to `NO PROFILE (PASS-THROUGH)` until the user re-learns at native resolution. Session state restores are exempt — profiles saved in a session load into the fresh engine normally.
 * **Learn Safety:** An in-progress Learn is auto-stopped before the rebuild; a half-rolled mean must never migrate across resolutions.
 
 ## 6. Real-Time Safety & Performance Hierarchy

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -23,7 +23,7 @@ This document defines the critical UX invariants and architectural contracts tha
 
 ## 5. Smoothing Mode Switching (Library-Owned)
 * **Instantaneous From Plugin Perspective:** Switching between 1D Spectral and 2D NLM is a plain parameter load. libspecbleach performs the transition internally (allocation-free crossfade); the plugin keeps a single engine instance and no switch machinery.
-* **Constant Latency Per Frame Size:** For a given STFT frame size, both smoothing modes share the same algorithmic latency (temporal is padded to the NLM look-ahead). Changing the frame size (Options menu: 23 / 32 / 46 / 64 ms) changes latency (roughly 2x the frame) and re-reports PDC via a suspended rebuild; it must never rebuild concurrently with `processBlock`.
+* **Constant Latency Per Frame Size:** For a given STFT frame size, both smoothing modes share the same algorithmic latency (temporal is padded to the NLM look-ahead). Changing the frame size (Options menu: 23 / 32 / 46 / 64 / 93 ms) changes latency (roughly 2x the frame) and re-reports PDC via a suspended rebuild; it must never rebuild concurrently with `processBlock`.
 * **No Host Suspension For Mode Switches:** Mode switching must never trigger `suspendProcessing`, latency re-reports, or profile migration in the plugin. Frame-size switches are the exception: they suspend, rebuild, and re-report.
 
 ## 7. Frame-Size Switching

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -20,6 +20,7 @@ This document defines the critical UX invariants and architectural contracts tha
 ## 4. Silence Segregation
 * **Input / Output Drop:** When the input signal drops below silence threshold (`< 1e-5` / ~-100 dB) and learning is inactive, input and output spectra drop to -120 dB.
 * **Profile Isolation:** The noise floor profile must *never* drop or clear on silence; it remains frozen and interactive.
+* **Flush Before Sleep:** The engine sleeps on silence only after it persists past the full pipeline (reported latency plus gain-release tails), so decaying tails ring out naturally and sparse transients are never swallowed mid-response.
 
 ## 5. Smoothing Mode Switching (Library-Owned)
 * **Instantaneous From Plugin Perspective:** Switching between 1D Spectral and 2D NLM is a plain parameter load. libspecbleach performs the transition internally (allocation-free crossfade); the plugin keeps a single engine instance and no switch machinery.
@@ -32,5 +33,6 @@ This document defines the critical UX invariants and architectural contracts tha
 
 ## 6. Real-Time Safety & Performance Hierarchy
 * **Strict RT-Safety:** The audio thread (`processBlock`) must never perform dynamic memory allocations, take blocking locks/mutexes, or execute file/console I/O. Runtime smoothing mode changes are allocation-free inside the library.
+* **Bypass Alignment:** The engine keeps running while bypassed (internal or host) so both ends of the mixer's crossfade carry pipeline-delayed content — toggling never time-travels by a full latency. The true-idle engine sleep applies only when unbypassed.
 * **CPU Hierarchy:**
-  $$\text{Bypass} < \text{Silent/Idle} < \text{Learn} < \text{Denoise 1D} < \text{Denoise 2D}$$
+  $$\text{Silent/Idle (unbypassed)} < \text{Bypass} \approx \text{Denoise 1D} < \text{Denoise 2D} \le \text{Learn}$$

--- a/docs/UX_INVARIANTS.md
+++ b/docs/UX_INVARIANTS.md
@@ -23,8 +23,12 @@ This document defines the critical UX invariants and architectural contracts tha
 
 ## 5. Smoothing Mode Switching (Library-Owned)
 * **Instantaneous From Plugin Perspective:** Switching between 1D Spectral and 2D NLM is a plain parameter load. libspecbleach performs the transition internally (allocation-free crossfade); the plugin keeps a single engine instance and no switch machinery.
-* **Constant Latency:** Both smoothing modes share the same algorithmic latency (temporal is padded to the NLM look-ahead), so `getLatencySamples()` and host PDC never change on a mode switch.
-* **No Host Suspension:** Mode switching must never trigger `suspendProcessing`, latency re-reports, or profile migration in the plugin.
+* **Constant Latency Per Frame Size:** For a given STFT frame size, both smoothing modes share the same algorithmic latency (temporal is padded to the NLM look-ahead). Changing the frame size (Options menu: 23 / 32 / 46 / 64 ms) changes latency (roughly 2x the frame) and re-reports PDC via a suspended rebuild; it must never rebuild concurrently with `processBlock`.
+* **No Host Suspension For Mode Switches:** Mode switching must never trigger `suspendProcessing`, latency re-reports, or profile migration in the plugin. Frame-size switches are the exception: they suspend, rebuild, and re-report.
+
+## 7. Frame-Size Switching
+* **Profile Preservation:** A learned profile survives a frame-size switch via resampled restore and is flagged stale (`STATUS: PROFILE RESAMPLED - RE-LEARN ADVISED`) until the user re-learns or resets, since resampling cannot invent (upscale) or keep (downscale) native-bin detail.
+* **Learn Safety:** An in-progress Learn is auto-stopped before the rebuild; a half-rolled mean must never migrate across resolutions.
 
 ## 6. Real-Time Safety & Performance Hierarchy
 * **Strict RT-Safety:** The audio thread (`processBlock`) must never perform dynamic memory allocations, take blocking locks/mutexes, or execute file/console I/O. Runtime smoothing mode changes are allocation-free inside the library.


### PR DESCRIPTION
Closes #201.

## Feature
Stepped frame-size control in the Options menu (23/32/46/64/93 ms, 46 ms default). Non-automatable meta APVTS Choice, so no automation lane, persisted in state, old sessions default to 46 ms, LV2 URI unchanged. Live rebuild via suspendProcessing with latency re-report (PDC), DryWetMixer wet latency and visualizer delay buffer. Frame switch resets the learned profile (resampling across resolutions works poorly); in-progress Learn auto-stops; session restores exempt. Each menu option carries when-to-use guidance with its latency cost (latency is always 2x frame, sample-rate independent).

## Bypass alignment fixes (found while testing)
- Engine keeps running while bypassed (internal + host): skipping it left raw current input in the buffer while mixer wet gain was still ~1, jumping output forward a full latency then sweeping back (skip scaling with frame size). Both crossfade endpoints now carry pipeline-delayed content; history stays warm so un-bypassing has no re-convergence glitch.
- DryWetMixer delay ceiling 16384 -> 65536 (93 ms at 96 kHz needs 17856; setWetLatency silently clamped past the ceiling).
- Silence-sleep now engages only after silence outlasts the full pipeline (was chopping tails / swallowing sparse transients).

## Tests/docs
- New test_integration cases: frame-size switch (profile reset, latency re-report, 93 ms headroom) and bypass-toggle impulse alignment (peaks land exactly on reported latency in both directions).
- UX_INVARIANTS updated (latency per frame size, clean-slate switches, bypass alignment, flush-before-sleep, large-frame character note).
- Full ctest 5/5 green. The one JUCE DelayLine assert in logs is pre-existing on master.