### PR TITLE
Fourth algorithm mode: Collaborative (BM3D)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ else()
             libspecbleach
             GIT_REPOSITORY https://github.com/lucianodato/libspecbleach.git
             # Pinned to the matching libspecbleach release (keep in sync).
-            GIT_TAG        v0.4.0
+            GIT_TAG        main
         )
         FetchContent_MakeAvailable(libspecbleach)
         set(SPECBLEACH_SRC "${libspecbleach_SOURCE_DIR}")

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -238,7 +238,8 @@ NoiseRepellentAudioProcessorEditor::NoiseRepellentAudioProcessorEditor(
 
   comboAlgoMode.addItemList(
       {"Standard (Fast & Low CPU)", "Patch-Based (High Quality)",
-       "Patch-Based + Refinement (Max Quality)"},
+       "Patch-Based + Refinement (Max Quality)",
+       "Collaborative (Max Quality)"},
       1);
   addAndMakeVisible(comboAlgoMode);
   comboAlgoMode.onChange = [this]() { updateLayout(); };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -171,7 +171,8 @@ NoiseRepellentAudioProcessor::createParameterLayout() {
       "algorithm_mode", "Smoothing Quality",
       juce::StringArray{"Standard (Fast & Low CPU)",
                         "Patch-Based (High Quality)",
-                        "Patch-Based + Refinement (Max Quality)"},
+                        "Patch-Based + Refinement (Max Quality)",
+                        "Collaborative (Max Quality)"},
       0));
 
   params.push_back(std::make_unique<juce::AudioParameterChoice>(
@@ -802,6 +803,7 @@ NoiseRepellentAudioProcessor::buildEngineParams() {
   ep.p.smoothing_factor = lowLatency ? smoothingNorm * 0.5f : smoothingNorm;
   ep.p.smoothing_mode =
       lowLatency ? SPECBLEACH_SMOOTHING_TEMPORAL
+                 : (algoMode == 3)   ? SPECBLEACH_SMOOTHING_BM3D
                  : (algoMode == 2)   ? SPECBLEACH_SMOOTHING_NLM_2D_DFTT
                  : (algoMode == 1) ? SPECBLEACH_SMOOTHING_NLM_2D
                                    : SPECBLEACH_SMOOTHING_TEMPORAL;

--- a/Source/Tests/test_ux_invariants.cpp
+++ b/Source/Tests/test_ux_invariants.cpp
@@ -621,7 +621,7 @@ private:
     processSilentBlocks(proc, buffer, midi, 12);
     const int latency = proc.getLatencySamples();
 
-    for (float mode : {1.0f, 2.0f, 0.0f}) {
+    for (float mode : {1.0f, 2.0f, 3.0f, 0.0f}) {
       setParam(proc, "algorithm_mode", mode);
       pumpMessageLoop(50);
       processSilentBlocks(proc, buffer, midi, 12);


### PR DESCRIPTION
- 4th smoothing choice 'Collaborative (Max Quality)' in processor + editor (replaces technical 'Block-Match 3D' label)
- algoMode 3 -> SPECBLEACH_SMOOTHING_BM3D mapping; ux-invariant mode loop covers {1,2,3,0}
- Depends on libspecbleach feat/bm3d-smoothing (sibling checkout; transient_protection_enable sync included there)

Verified: 5/5 ctest green (incl. test_ux_invariants).